### PR TITLE
👌 IMPROVE: use `autodoc2-docstring` directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ I've use a lot of their code, for the `astroid` static analysis, but I've made a
 - fixed `a | b` annotations inference
 - added analysis of `functools.singledispatch` and their registers
 - handling of `__all__`
-- the summary only got the first line, not first paragraph
+- docstrings (and summaries) are now parsed with the correct source/line, i.e. warnings point to the correct location in the source file
 - added `:canonical:` to `py` directives
 - Moved away from using jinja templates, to using python functions
   - IMO the templates were too complex and hard to read,

--- a/docs/apidocs/aiida/aiida.cmdline.rst
+++ b/docs/apidocs/aiida/aiida.cmdline.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-The command line interface of AiiDA.
+.. autodoc2-docstring:: aiida.cmdline
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -20,59 +22,113 @@ Classes
    :align: left
 
    * - :py:obj:`AbsolutePathParamType <aiida.cmdline.params.types.path.AbsolutePathParamType>`
-     - The ParamType for identifying absolute Paths (derived from click.Path).
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.path.AbsolutePathParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalculationParamType <aiida.cmdline.params.types.calculation.CalculationParamType>`
-     - The ParamType for identifying Calculation entities or its subclasses
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.calculation.CalculationParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`CodeParamType <aiida.cmdline.params.types.code.CodeParamType>`
-     - The ParamType for identifying Code entities or its subclasses
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.code.CodeParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`ComputerParamType <aiida.cmdline.params.types.computer.ComputerParamType>`
-     - The ParamType for identifying Computer entities or its subclasses
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ComputerParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`ConfigOptionParamType <aiida.cmdline.params.types.config.ConfigOptionParamType>`
-     - ParamType for configuration options.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.config.ConfigOptionParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`DataParamType <aiida.cmdline.params.types.data.DataParamType>`
-     - The ParamType for identifying Data entities or its subclasses
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.data.DataParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`DynamicEntryPointCommandGroup <aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup>`
-     - Subclass of :class:`click.Group` that loads subcommands dynamically from entry points.
+     - .. autodoc2-docstring:: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup
+          :renderer: rst
+          :summary:
    * - :py:obj:`EmailType <aiida.cmdline.params.types.strings.EmailType>`
-     - Parameter whose values have to correspond to a valid email address format.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EmailType
+          :renderer: rst
+          :summary:
    * - :py:obj:`EntryPointType <aiida.cmdline.params.types.strings.EntryPointType>`
-     - Parameter whose values have to be valid Python entry point strings.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EntryPointType
+          :renderer: rst
+          :summary:
    * - :py:obj:`FileOrUrl <aiida.cmdline.params.types.path.FileOrUrl>`
-     - Extension of click's File-type to include URLs.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.path.FileOrUrl
+          :renderer: rst
+          :summary:
    * - :py:obj:`GroupParamType <aiida.cmdline.params.types.group.GroupParamType>`
-     - The ParamType for identifying Group entities or its subclasses.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.group.GroupParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`HostnameType <aiida.cmdline.params.types.strings.HostnameType>`
-     - Parameter corresponding to a valid hostname (or empty) string.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.strings.HostnameType
+          :renderer: rst
+          :summary:
    * - :py:obj:`IdentifierParamType <aiida.cmdline.params.types.identifier.IdentifierParamType>`
-     - An extension of click.ParamType for a generic identifier parameter. In AiiDA, orm entities can often be identified by either their ID, UUID or optionally some LABEL identifier. This parameter type implements the convert method, which attempts to convert a value passed to the command for a parameter with this type, to an orm entity. The actual loading of the entity is delegated to the orm class loader. Subclasses of this parameter type should implement the `orm_class_loader` method to return the appropriate orm class loader, which should be a subclass of `aiida.orm.utils.loaders.OrmEntityLoader` for the corresponding orm class.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.identifier.IdentifierParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`LabelStringType <aiida.cmdline.params.types.strings.LabelStringType>`
-     - Parameter accepting valid label strings.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.strings.LabelStringType
+          :renderer: rst
+          :summary:
    * - :py:obj:`LazyChoice <aiida.cmdline.params.types.choice.LazyChoice>`
-     - This is a delegate of click's Choice ParamType that evaluates the set of choices lazily. This is useful if the choices set requires an import that is slow. Using the vanilla click.Choice will call this on import which will slow down verdi and its autocomplete. This type will generate the choices set lazily through the choices property
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice
+          :renderer: rst
+          :summary:
    * - :py:obj:`MpirunCommandParamType <aiida.cmdline.params.types.computer.MpirunCommandParamType>`
-     - Custom click param type for mpirun-command
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.computer.MpirunCommandParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`MultipleValueParamType <aiida.cmdline.params.types.multiple.MultipleValueParamType>`
-     - An extension of click.ParamType that can parse multiple values for a given ParamType
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.multiple.MultipleValueParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`NodeParamType <aiida.cmdline.params.types.node.NodeParamType>`
-     - The ParamType for identifying Node entities or its subclasses
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.node.NodeParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`NonEmptyStringParamType <aiida.cmdline.params.types.strings.NonEmptyStringParamType>`
-     - Parameter whose values have to be string and non-empty.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.strings.NonEmptyStringParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`PathOrUrl <aiida.cmdline.params.types.path.PathOrUrl>`
-     - Extension of click's Path-type to include URLs.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.path.PathOrUrl
+          :renderer: rst
+          :summary:
    * - :py:obj:`PluginParamType <aiida.cmdline.params.types.plugin.PluginParamType>`
-     - AiiDA Plugin name parameter type.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProcessParamType <aiida.cmdline.params.types.process.ProcessParamType>`
-     - The ParamType for identifying ProcessNode entities or its subclasses
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.process.ProcessParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProfileParamType <aiida.cmdline.params.types.profile.ProfileParamType>`
-     - The profile parameter type for click.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.profile.ProfileParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`ShebangParamType <aiida.cmdline.params.types.computer.ShebangParamType>`
-     - Custom click param type for shebang line
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ShebangParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`UserParamType <aiida.cmdline.params.types.user.UserParamType>`
-     - The user parameter type for click.   Can get or create a user.
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.user.UserParamType
+          :renderer: rst
+          :summary:
    * - :py:obj:`VerdiCommandGroup <aiida.cmdline.groups.verdi.VerdiCommandGroup>`
-     - Subclass of :class:`click.Group` for the ``verdi`` CLI.
+     - .. autodoc2-docstring:: aiida.cmdline.groups.verdi.VerdiCommandGroup
+          :renderer: rst
+          :summary:
    * - :py:obj:`WorkflowParamType <aiida.cmdline.params.types.workflow.WorkflowParamType>`
-     - The ParamType for identifying WorkflowNode entities or its subclasses
+     - .. autodoc2-docstring:: aiida.cmdline.params.types.workflow.WorkflowParamType
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -82,29 +138,53 @@ Functions
    :align: left
 
    * - :py:obj:`dbenv <aiida.cmdline.utils.decorators.dbenv>`
-     - Loads the dbenv for a specific region of code, does not unload afterwards
+     - .. autodoc2-docstring:: aiida.cmdline.utils.decorators.dbenv
+          :renderer: rst
+          :summary:
    * - :py:obj:`echo_critical <aiida.cmdline.utils.echo.echo_critical>`
-     - Log a critical error message to the cmdline logger and exit with ``exit_status``.
+     - .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_critical
+          :renderer: rst
+          :summary:
    * - :py:obj:`echo_dictionary <aiida.cmdline.utils.echo.echo_dictionary>`
-     - Log the given dictionary to stdout in the given format
+     - .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_dictionary
+          :renderer: rst
+          :summary:
    * - :py:obj:`echo_error <aiida.cmdline.utils.echo.echo_error>`
-     - Log an error message to the cmdline logger.
+     - .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_error
+          :renderer: rst
+          :summary:
    * - :py:obj:`echo_info <aiida.cmdline.utils.echo.echo_info>`
-     - Log an info message to the cmdline logger.
+     - .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_info
+          :renderer: rst
+          :summary:
    * - :py:obj:`echo_report <aiida.cmdline.utils.echo.echo_report>`
-     - Log an report message to the cmdline logger.
+     - .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_report
+          :renderer: rst
+          :summary:
    * - :py:obj:`echo_success <aiida.cmdline.utils.echo.echo_success>`
-     - Log a success message to the cmdline logger.
+     - .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_success
+          :renderer: rst
+          :summary:
    * - :py:obj:`echo_warning <aiida.cmdline.utils.echo.echo_warning>`
-     - Log a warning message to the cmdline logger.
+     - .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_warning
+          :renderer: rst
+          :summary:
    * - :py:obj:`format_call_graph <aiida.cmdline.utils.ascii_vis.format_call_graph>`
-     - Print a tree like the POSIX tree command for the calculation call graph
+     - .. autodoc2-docstring:: aiida.cmdline.utils.ascii_vis.format_call_graph
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_verbose <aiida.cmdline.utils.common.is_verbose>`
-     - Return whether the configured logging verbosity is considered verbose, i.e., equal or lower to ``INFO`` level.
+     - .. autodoc2-docstring:: aiida.cmdline.utils.common.is_verbose
+          :renderer: rst
+          :summary:
    * - :py:obj:`only_if_daemon_running <aiida.cmdline.utils.decorators.only_if_daemon_running>`
-     - Function decorator for CLI command to print critical error and exit automatically when daemon is not running.
+     - .. autodoc2-docstring:: aiida.cmdline.utils.decorators.only_if_daemon_running
+          :renderer: rst
+          :summary:
    * - :py:obj:`with_dbenv <aiida.cmdline.utils.decorators.with_dbenv>`
-     - Function decorator that will load the database environment for the currently loaded profile.
+     - .. autodoc2-docstring:: aiida.cmdline.utils.decorators.with_dbenv
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -114,976 +194,951 @@ API
 
    Bases: :py:obj:`click.Path`
 
-   The ParamType for identifying absolute Paths (derived from click.Path).
+   .. autodoc2-docstring:: aiida.cmdline.params.types.path.AbsolutePathParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.path.AbsolutePathParamType.name
       :value: 'AbsolutePath'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.path.AbsolutePathParamType.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.path.AbsolutePathParamType.convert
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.path.AbsolutePathParamType.convert
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.cmdline.params.types.path.AbsolutePathParamType.__repr__
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.path.AbsolutePathParamType.__repr__
+         :renderer: rst
 
 .. py:class:: CalculationParamType
    :canonical: aiida.cmdline.params.types.calculation.CalculationParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.identifier.IdentifierParamType`
 
-   The ParamType for identifying Calculation entities or its subclasses
+   .. autodoc2-docstring:: aiida.cmdline.params.types.calculation.CalculationParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.calculation.CalculationParamType.name
       :value: 'Calculation'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.calculation.CalculationParamType.name
+         :renderer: rst
+
    .. py:property:: orm_class_loader
       :canonical: aiida.cmdline.params.types.calculation.CalculationParamType.orm_class_loader
 
-      Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
-      to be used to load the entity for a given identifier
-
-      :return: the orm entity loader class for this ParamType
+      .. autodoc2-docstring:: aiida.cmdline.params.types.calculation.CalculationParamType.orm_class_loader
+         :renderer: rst
 
 .. py:class:: CodeParamType(sub_classes=None, entry_point=None)
    :canonical: aiida.cmdline.params.types.code.CodeParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.identifier.IdentifierParamType`
 
-   The ParamType for identifying Code entities or its subclasses
+   .. autodoc2-docstring:: aiida.cmdline.params.types.code.CodeParamType
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct the param type
-
-   :param sub_classes: specify a tuple of Code sub classes to narrow the query set
-   :param entry_point: specify an optional calculation entry point that the Code's input plugin should match
+   .. autodoc2-docstring:: aiida.cmdline.params.types.code.CodeParamType.__init__
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.code.CodeParamType.name
       :value: 'Code'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.code.CodeParamType.name
+         :renderer: rst
+
    .. py:property:: orm_class_loader
       :canonical: aiida.cmdline.params.types.code.CodeParamType.orm_class_loader
 
-      Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
-      to be used to load the entity for a given identifier
-
-      :return: the orm entity loader class for this ParamType
+      .. autodoc2-docstring:: aiida.cmdline.params.types.code.CodeParamType.orm_class_loader
+         :renderer: rst
 
    .. py:method:: shell_complete(ctx, param, incomplete)
       :canonical: aiida.cmdline.params.types.code.CodeParamType.shell_complete
 
-      Return possible completions based on an incomplete value.
-
-      :returns: list of tuples of valid entry points (matching incomplete) and a description
+      .. autodoc2-docstring:: aiida.cmdline.params.types.code.CodeParamType.shell_complete
+         :renderer: rst
 
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.code.CodeParamType.convert
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.code.CodeParamType.convert
+         :renderer: rst
 
 .. py:class:: ComputerParamType
    :canonical: aiida.cmdline.params.types.computer.ComputerParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.identifier.IdentifierParamType`
 
-   The ParamType for identifying Computer entities or its subclasses
+   .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ComputerParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.computer.ComputerParamType.name
       :value: 'Computer'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ComputerParamType.name
+         :renderer: rst
+
    .. py:property:: orm_class_loader
       :canonical: aiida.cmdline.params.types.computer.ComputerParamType.orm_class_loader
 
-      Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
-      to be used to load the entity for a given identifier
-
-      :return: the orm entity loader class for this ParamType
+      .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ComputerParamType.orm_class_loader
+         :renderer: rst
 
    .. py:method:: shell_complete(ctx, param, incomplete)
       :canonical: aiida.cmdline.params.types.computer.ComputerParamType.shell_complete
 
-      Return possible completions based on an incomplete value.
-
-      :returns: list of tuples of valid entry points (matching incomplete) and a description
+      .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ComputerParamType.shell_complete
+         :renderer: rst
 
 .. py:class:: ConfigOptionParamType
    :canonical: aiida.cmdline.params.types.config.ConfigOptionParamType
 
    Bases: :py:obj:`click.types.StringParamType`
 
-   ParamType for configuration options.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.config.ConfigOptionParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.config.ConfigOptionParamType.name
       :value: 'config option'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.config.ConfigOptionParamType.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.config.ConfigOptionParamType.convert
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.config.ConfigOptionParamType.convert
+         :renderer: rst
 
    .. py:method:: shell_complete(ctx, param, incomplete)
       :canonical: aiida.cmdline.params.types.config.ConfigOptionParamType.shell_complete
 
-      Return possible completions based on an incomplete value
-
-      :returns: list of tuples of valid entry points (matching incomplete) and a description
+      .. autodoc2-docstring:: aiida.cmdline.params.types.config.ConfigOptionParamType.shell_complete
+         :renderer: rst
 
 .. py:class:: DataParamType(sub_classes=None)
    :canonical: aiida.cmdline.params.types.data.DataParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.identifier.IdentifierParamType`
 
-   The ParamType for identifying Data entities or its subclasses
+   .. autodoc2-docstring:: aiida.cmdline.params.types.data.DataParamType
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct the parameter type, optionally specifying a tuple of entry points that reference classes
-   that should be a sub class of the base orm class of the orm class loader. The classes pointed to by
-   these entry points will be passed to the OrmEntityLoader when converting an identifier and they will
-   restrict the query set by demanding that the class of the corresponding entity matches these sub classes.
-
-   To prevent having to load the database environment at import time, the actual loading of the entry points
-   is deferred until the call to `convert` is made. This is to keep the command line autocompletion light
-   and responsive. The entry point strings will be validated, however, to see if the correspond to known
-   entry points.
-
-   :param sub_classes: a tuple of entry point strings that can narrow the set of orm classes that values
-       will be mapped upon. These classes have to be strict sub classes of the base orm class defined
-       by the orm class loader
+   .. autodoc2-docstring:: aiida.cmdline.params.types.data.DataParamType.__init__
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.data.DataParamType.name
       :value: 'Data'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.data.DataParamType.name
+         :renderer: rst
+
    .. py:property:: orm_class_loader
       :canonical: aiida.cmdline.params.types.data.DataParamType.orm_class_loader
 
-      Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
-      to be used to load the entity for a given identifier
-
-      :return: the orm entity loader class for this ParamType
+      .. autodoc2-docstring:: aiida.cmdline.params.types.data.DataParamType.orm_class_loader
+         :renderer: rst
 
 .. py:class:: DynamicEntryPointCommandGroup(command, entry_point_group: str, entry_point_name_filter='.*', **kwargs)
    :canonical: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup
 
    Bases: :py:obj:`aiida.cmdline.groups.verdi.VerdiCommandGroup`
 
-   Subclass of :class:`click.Group` that loads subcommands dynamically from entry points.
+   .. autodoc2-docstring:: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup
+      :renderer: rst
 
-   A command group using this class will automatically generate the sub commands from the entry points registered in
-   the given ``entry_point_group``. The entry points can be additionally filtered using a regex defined for the
-   ``entry_point_name_filter`` keyword. The actual command for each entry point is defined by ``command``, which should
-   take as a first argument the class that corresponds to the entry point. In addition, it should accept ``kwargs``
-   which will be the values for the options passed when the command is invoked. The help string of the command will be
-   provided by the docstring of the class registered at the respective entry point. Example usage:
+   .. rubric:: Initialization
 
-   .. code:: python
-
-       def create_instance(cls, **kwargs):
-           instance = cls(**kwargs)
-           instance.store()
-           echo.echo_success(f'Created {cls.__name__}<{instance.pk}>')
-
-       @click.group('create', cls=DynamicEntryPointCommandGroup, command=create_instance,)
-       def cmd_create():
-           pass
-
+   .. autodoc2-docstring:: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.__init__
+      :renderer: rst
 
    .. py:method:: list_commands(ctx) -> list[str]
       :canonical: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.list_commands
 
-      Return the sorted list of subcommands for this group.
-
-      :param ctx: The :class:`click.Context`.
+      .. autodoc2-docstring:: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.list_commands
+         :renderer: rst
 
    .. py:method:: get_command(ctx, cmd_name)
       :canonical: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.get_command
 
-      Return the command with the given name.
-
-      :param ctx: The :class:`click.Context`.
-      :param cmd_name: The name of the command.
-      :returns: The :class:`click.Command`.
+      .. autodoc2-docstring:: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.get_command
+         :renderer: rst
 
    .. py:method:: create_command(entry_point)
       :canonical: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.create_command
 
-      Create a subcommand for the given ``entry_point``.
+      .. autodoc2-docstring:: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.create_command
+         :renderer: rst
 
    .. py:method:: create_options(entry_point)
       :canonical: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.create_options
 
-      Create the option decorators for the command function for the given entry point.
-
-      :param entry_point: The entry point.
+      .. autodoc2-docstring:: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.create_options
+         :renderer: rst
 
    .. py:method:: list_options(entry_point)
       :canonical: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.list_options
 
-      Return the list of options that should be applied to the command for the given entry point.
-
-      :param entry_point: The entry point.
+      .. autodoc2-docstring:: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.list_options
+         :renderer: rst
 
    .. py:method:: create_option(name, spec)
       :canonical: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.create_option
       :staticmethod:
 
-      Create a click option from a name and a specification.
+      .. autodoc2-docstring:: aiida.cmdline.groups.dynamic.DynamicEntryPointCommandGroup.create_option
+         :renderer: rst
 
 .. py:class:: EmailType
    :canonical: aiida.cmdline.params.types.strings.EmailType
 
    Bases: :py:obj:`click.types.StringParamType`
 
-   Parameter whose values have to correspond to a valid email address format.
-
-   .. note:: For the moment, we do not require the domain suffix, i.e. 'aiida@localhost' is still valid.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EmailType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.strings.EmailType.name
       :value: 'email'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EmailType.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.strings.EmailType.convert
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EmailType.convert
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.cmdline.params.types.strings.EmailType.__repr__
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EmailType.__repr__
+         :renderer: rst
 
 .. py:class:: EntryPointType
    :canonical: aiida.cmdline.params.types.strings.EntryPointType
 
    Bases: :py:obj:`aiida.cmdline.params.types.strings.NonEmptyStringParamType`
 
-   Parameter whose values have to be valid Python entry point strings.
-
-   See https://packaging.python.org/en/latest/specifications/entry-points/
+   .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EntryPointType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.strings.EntryPointType.name
       :value: 'entrypoint'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EntryPointType.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.strings.EntryPointType.convert
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EntryPointType.convert
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.cmdline.params.types.strings.EntryPointType.__repr__
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.EntryPointType.__repr__
+         :renderer: rst
 
 .. py:class:: FileOrUrl(timeout_seconds=URL_TIMEOUT_SECONDS, **kwargs)
    :canonical: aiida.cmdline.params.types.path.FileOrUrl
 
    Bases: :py:obj:`click.File`
 
-   Extension of click's File-type to include URLs.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.path.FileOrUrl
+      :renderer: rst
 
-   Returns handle either to local file or to remote file fetched from URL.
+   .. rubric:: Initialization
 
-   :param int timeout_seconds: Maximum timeout accepted for URL response.
-       Must be an integer in the range [0;60].
+   .. autodoc2-docstring:: aiida.cmdline.params.types.path.FileOrUrl.__init__
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.path.FileOrUrl.name
       :value: 'FileOrUrl'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.path.FileOrUrl.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.path.FileOrUrl.convert
 
-      Return file handle.
+      .. autodoc2-docstring:: aiida.cmdline.params.types.path.FileOrUrl.convert
+         :renderer: rst
 
    .. py:method:: get_url(url, param, ctx)
       :canonical: aiida.cmdline.params.types.path.FileOrUrl.get_url
 
-      Retrieve file from URL.
+      .. autodoc2-docstring:: aiida.cmdline.params.types.path.FileOrUrl.get_url
+         :renderer: rst
 
 .. py:class:: GroupParamType(create_if_not_exist=False, sub_classes=('aiida.groups:core', ))
    :canonical: aiida.cmdline.params.types.group.GroupParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.identifier.IdentifierParamType`
 
-   The ParamType for identifying Group entities or its subclasses.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.group.GroupParamType
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct the parameter type.
-
-   The `sub_classes` argument can be used to narrow the set of subclasses of `Group` that should be matched. By
-   default all subclasses of `Group` will be matched, otherwise it is restricted to the subclasses that correspond
-   to the entry point names in the tuple of `sub_classes`.
-
-   To prevent having to load the database environment at import time, the actual loading of the entry points is
-   deferred until the call to `convert` is made. This is to keep the command line autocompletion light and
-   responsive. The entry point strings will be validated, however, to see if they correspond to known entry points.
-
-   :param create_if_not_exist: boolean, if True, will create the group if it does not yet exist. By default the
-       group created will be of class `Group`, unless another subclass is specified through `sub_classes`. Note
-       that in this case, only a single entry point name can be specified
-   :param sub_classes: a tuple of entry point strings from the `aiida.groups` entry point group.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.group.GroupParamType.__init__
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.group.GroupParamType.name
       :value: 'Group'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.group.GroupParamType.name
+         :renderer: rst
+
    .. py:property:: orm_class_loader
       :canonical: aiida.cmdline.params.types.group.GroupParamType.orm_class_loader
 
-      Return the orm entity loader class, which should be a subclass of `OrmEntityLoader`.
-
-      This class is supposed to be used to load the entity for a given identifier.
-
-      :return: the orm entity loader class for this `ParamType`
+      .. autodoc2-docstring:: aiida.cmdline.params.types.group.GroupParamType.orm_class_loader
+         :renderer: rst
 
    .. py:method:: shell_complete(ctx, param, incomplete)
       :canonical: aiida.cmdline.params.types.group.GroupParamType.shell_complete
 
-      Return possible completions based on an incomplete value.
-
-      :returns: list of tuples of valid entry points (matching incomplete) and a description
+      .. autodoc2-docstring:: aiida.cmdline.params.types.group.GroupParamType.shell_complete
+         :renderer: rst
 
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.group.GroupParamType.convert
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.group.GroupParamType.convert
+         :renderer: rst
 
 .. py:class:: HostnameType
    :canonical: aiida.cmdline.params.types.strings.HostnameType
 
    Bases: :py:obj:`click.types.StringParamType`
 
-   Parameter corresponding to a valid hostname (or empty) string.
-
-   Regex according to https://stackoverflow.com/a/3824105/1069467
+   .. autodoc2-docstring:: aiida.cmdline.params.types.strings.HostnameType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.strings.HostnameType.name
       :value: 'hostname'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.HostnameType.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.strings.HostnameType.convert
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.HostnameType.convert
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.cmdline.params.types.strings.HostnameType.__repr__
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.HostnameType.__repr__
+         :renderer: rst
 
 .. py:class:: IdentifierParamType(sub_classes=None)
    :canonical: aiida.cmdline.params.types.identifier.IdentifierParamType
 
    Bases: :py:obj:`click.ParamType`, :py:obj:`abc.ABC`
 
-   An extension of click.ParamType for a generic identifier parameter. In AiiDA, orm entities can often be
-   identified by either their ID, UUID or optionally some LABEL identifier. This parameter type implements
-   the convert method, which attempts to convert a value passed to the command for a parameter with this type,
-   to an orm entity. The actual loading of the entity is delegated to the orm class loader. Subclasses of this
-   parameter type should implement the `orm_class_loader` method to return the appropriate orm class loader,
-   which should be a subclass of `aiida.orm.utils.loaders.OrmEntityLoader` for the corresponding orm class.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.identifier.IdentifierParamType
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct the parameter type, optionally specifying a tuple of entry points that reference classes
-   that should be a sub class of the base orm class of the orm class loader. The classes pointed to by
-   these entry points will be passed to the OrmEntityLoader when converting an identifier and they will
-   restrict the query set by demanding that the class of the corresponding entity matches these sub classes.
-
-   To prevent having to load the database environment at import time, the actual loading of the entry points
-   is deferred until the call to `convert` is made. This is to keep the command line autocompletion light
-   and responsive. The entry point strings will be validated, however, to see if the correspond to known
-   entry points.
-
-   :param sub_classes: a tuple of entry point strings that can narrow the set of orm classes that values
-       will be mapped upon. These classes have to be strict sub classes of the base orm class defined
-       by the orm class loader
+   .. autodoc2-docstring:: aiida.cmdline.params.types.identifier.IdentifierParamType.__init__
+      :renderer: rst
 
    .. py:property:: orm_class_loader
       :canonical: aiida.cmdline.params.types.identifier.IdentifierParamType.orm_class_loader
       :abstractmethod:
 
-      Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
-      to be used to load the entity for a given identifier
-
-      :return: the orm entity loader class for this ParamType
+      .. autodoc2-docstring:: aiida.cmdline.params.types.identifier.IdentifierParamType.orm_class_loader
+         :renderer: rst
 
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.identifier.IdentifierParamType.convert
 
-      Attempt to convert the given value to an instance of the orm class using the orm class loader.
-
-      :return: the loaded orm entity
-      :raises click.BadParameter: if the value is ambiguous and leads to multiple entities
-      :raises click.BadParameter: if the value cannot be mapped onto any existing instance
-      :raises RuntimeError: if the defined orm class loader is not a subclass of the OrmEntityLoader class
+      .. autodoc2-docstring:: aiida.cmdline.params.types.identifier.IdentifierParamType.convert
+         :renderer: rst
 
 .. py:class:: LabelStringType
    :canonical: aiida.cmdline.params.types.strings.LabelStringType
 
    Bases: :py:obj:`aiida.cmdline.params.types.strings.NonEmptyStringParamType`
 
-   Parameter accepting valid label strings.
-
-   Non-empty string, made up of word characters (includes underscores [1]), dashes, and dots.
-
-   [1] See https://docs.python.org/3/library/re.html
+   .. autodoc2-docstring:: aiida.cmdline.params.types.strings.LabelStringType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.strings.LabelStringType.name
       :value: 'labelstring'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.LabelStringType.name
+         :renderer: rst
+
    .. py:attribute:: ALPHABET
       :canonical: aiida.cmdline.params.types.strings.LabelStringType.ALPHABET
       :value: '\\w\\.\\-'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.LabelStringType.ALPHABET
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.strings.LabelStringType.convert
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.LabelStringType.convert
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.cmdline.params.types.strings.LabelStringType.__repr__
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.LabelStringType.__repr__
+         :renderer: rst
 
 .. py:class:: LazyChoice(get_choices)
    :canonical: aiida.cmdline.params.types.choice.LazyChoice
 
    Bases: :py:obj:`click.ParamType`
 
-   This is a delegate of click's Choice ParamType that evaluates the set of choices
-   lazily. This is useful if the choices set requires an import that is slow. Using
-   the vanilla click.Choice will call this on import which will slow down verdi and
-   its autocomplete. This type will generate the choices set lazily through the
-   choices property
+   .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice.__init__
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.choice.LazyChoice.name
       :value: 'choice'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice.name
+         :renderer: rst
+
    .. py:property:: _click_choice
       :canonical: aiida.cmdline.params.types.choice.LazyChoice._click_choice
 
-      Get the internal click Choice object that we delegate functionality to.
-      Will construct it lazily if necessary.
-
-      :return: The click Choice
-      :rtype: :class:`click.Choice`
+      .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice._click_choice
+         :renderer: rst
 
    .. py:property:: choices
       :canonical: aiida.cmdline.params.types.choice.LazyChoice.choices
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice.choices
+         :renderer: rst
+
    .. py:method:: get_metavar(param)
       :canonical: aiida.cmdline.params.types.choice.LazyChoice.get_metavar
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice.get_metavar
+         :renderer: rst
 
    .. py:method:: get_missing_message(param)
       :canonical: aiida.cmdline.params.types.choice.LazyChoice.get_missing_message
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice.get_missing_message
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.choice.LazyChoice.convert
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice.convert
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.cmdline.params.types.choice.LazyChoice.__repr__
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.choice.LazyChoice.__repr__
+         :renderer: rst
 
 .. py:class:: MpirunCommandParamType
    :canonical: aiida.cmdline.params.types.computer.MpirunCommandParamType
 
    Bases: :py:obj:`click.types.StringParamType`
 
-   Custom click param type for mpirun-command
-
-   .. note:: requires also a scheduler to be provided, and the scheduler
-      must be called first!
-
-   Validate that the provided 'mpirun' command only contains replacement fields
-   (e.g. ``{tot_num_mpiprocs}``) that are known.
-
-   Return a list of arguments (by using 'value.strip().split(" ") on the input string)
+   .. autodoc2-docstring:: aiida.cmdline.params.types.computer.MpirunCommandParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.computer.MpirunCommandParamType.name
       :value: 'mpiruncommandstring'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.computer.MpirunCommandParamType.name
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.cmdline.params.types.computer.MpirunCommandParamType.__repr__
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.computer.MpirunCommandParamType.__repr__
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.computer.MpirunCommandParamType.convert
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.computer.MpirunCommandParamType.convert
+         :renderer: rst
 
 .. py:class:: MultipleValueParamType(param_type)
    :canonical: aiida.cmdline.params.types.multiple.MultipleValueParamType
 
    Bases: :py:obj:`click.ParamType`
 
-   An extension of click.ParamType that can parse multiple values for a given ParamType
+   .. autodoc2-docstring:: aiida.cmdline.params.types.multiple.MultipleValueParamType
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.cmdline.params.types.multiple.MultipleValueParamType.__init__
+      :renderer: rst
 
    .. py:method:: get_metavar(param)
       :canonical: aiida.cmdline.params.types.multiple.MultipleValueParamType.get_metavar
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.multiple.MultipleValueParamType.get_metavar
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.multiple.MultipleValueParamType.convert
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.multiple.MultipleValueParamType.convert
+         :renderer: rst
 
 .. py:class:: NodeParamType
    :canonical: aiida.cmdline.params.types.node.NodeParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.identifier.IdentifierParamType`
 
-   The ParamType for identifying Node entities or its subclasses
+   .. autodoc2-docstring:: aiida.cmdline.params.types.node.NodeParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.node.NodeParamType.name
       :value: 'Node'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.node.NodeParamType.name
+         :renderer: rst
+
    .. py:property:: orm_class_loader
       :canonical: aiida.cmdline.params.types.node.NodeParamType.orm_class_loader
 
-      Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
-      to be used to load the entity for a given identifier
-
-      :return: the orm entity loader class for this ParamType
+      .. autodoc2-docstring:: aiida.cmdline.params.types.node.NodeParamType.orm_class_loader
+         :renderer: rst
 
 .. py:class:: NonEmptyStringParamType
    :canonical: aiida.cmdline.params.types.strings.NonEmptyStringParamType
 
    Bases: :py:obj:`click.types.StringParamType`
 
-   Parameter whose values have to be string and non-empty.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.strings.NonEmptyStringParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.strings.NonEmptyStringParamType.name
       :value: 'nonemptystring'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.NonEmptyStringParamType.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.strings.NonEmptyStringParamType.convert
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.NonEmptyStringParamType.convert
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.cmdline.params.types.strings.NonEmptyStringParamType.__repr__
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.strings.NonEmptyStringParamType.__repr__
+         :renderer: rst
 
 .. py:class:: PathOrUrl(timeout_seconds=URL_TIMEOUT_SECONDS, **kwargs)
    :canonical: aiida.cmdline.params.types.path.PathOrUrl
 
    Bases: :py:obj:`click.Path`
 
-   Extension of click's Path-type to include URLs.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.path.PathOrUrl
+      :renderer: rst
 
-   A PathOrUrl can either be a `click.Path`-type or a URL.
+   .. rubric:: Initialization
 
-   :param int timeout_seconds: Maximum timeout accepted for URL response.
-       Must be an integer in the range [0;60].
+   .. autodoc2-docstring:: aiida.cmdline.params.types.path.PathOrUrl.__init__
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.path.PathOrUrl.name
       :value: 'PathOrUrl'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.path.PathOrUrl.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.path.PathOrUrl.convert
 
-      Overwrite `convert` Check first if `click.Path`-type, then check if URL.
+      .. autodoc2-docstring:: aiida.cmdline.params.types.path.PathOrUrl.convert
+         :renderer: rst
 
    .. py:method:: checks_url(url, param, ctx)
       :canonical: aiida.cmdline.params.types.path.PathOrUrl.checks_url
 
-      Check whether URL is reachable within timeout.
+      .. autodoc2-docstring:: aiida.cmdline.params.types.path.PathOrUrl.checks_url
+         :renderer: rst
 
 .. py:class:: PluginParamType(group=None, load=False, *args, **kwargs)
    :canonical: aiida.cmdline.params.types.plugin.PluginParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.strings.EntryPointType`
 
-   AiiDA Plugin name parameter type.
-
-   :param group: string or tuple of strings, where each is a valid entry point group. Adding the `aiida.`
-       prefix is optional. If it is not detected it will be prepended internally.
-   :param load: when set to True, convert will not return the entry point, but the loaded entry point
-
-   Usage::
-
-       click.option(... type=PluginParamType(group='aiida.calculations')
-
-   or::
-
-       click.option(... type=PluginParamType(group=('calculations', 'data'))
-
+   .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Validate that group is either a string or a tuple of valid entry point groups, or if it
-   is not specified use the tuple of all recognized entry point groups.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.__init__
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.name
       :value: 'plugin'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.name
+         :renderer: rst
+
    .. py:attribute:: _factory_mapping
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType._factory_mapping
       :value: None
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType._factory_mapping
+         :renderer: rst
+
    .. py:method:: _init_entry_points()
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType._init_entry_points
 
-      Populate entry point information that will be used later on.  This should only be called
-      once in the constructor after setting self.groups because the groups should not be changed
-      after instantiation
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType._init_entry_points
+         :renderer: rst
 
    .. py:property:: groups
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.groups
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.groups
+         :renderer: rst
+
    .. py:property:: has_potential_ambiguity
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.has_potential_ambiguity
 
-      Returns whether the set of supported entry point groups can lead to ambiguity when only an entry point name
-      is specified. This will happen if one ore more groups share an entry point with a common name
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.has_potential_ambiguity
+         :renderer: rst
 
    .. py:method:: get_valid_arguments()
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.get_valid_arguments
 
-      Return a list of all available plugins for the groups configured for this PluginParamType instance.
-      If the entry point names are not unique, because there are multiple groups that contain an entry
-      point that has an identical name, we need to prefix the names with the full group name
-
-      :returns: list of valid entry point strings
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.get_valid_arguments
+         :renderer: rst
 
    .. py:method:: get_possibilities(incomplete='')
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.get_possibilities
 
-      Return a list of plugins starting with incomplete
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.get_possibilities
+         :renderer: rst
 
    .. py:method:: shell_complete(ctx, param, incomplete)
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.shell_complete
 
-      Return possible completions based on an incomplete value
-
-      :returns: list of tuples of valid entry points (matching incomplete) and a description
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.shell_complete
+         :renderer: rst
 
    .. py:method:: get_missing_message(param)
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.get_missing_message
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.get_missing_message
+         :renderer: rst
+
    .. py:method:: get_entry_point_from_string(entry_point_string)
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.get_entry_point_from_string
 
-      Validate a given entry point string, which means that it should have a valid entry point string format
-      and that the entry point unambiguously corresponds to an entry point in the groups configured for this
-      instance of PluginParameterType.
-
-      :returns: the entry point if valid
-      :raises: ValueError if the entry point string is invalid
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.get_entry_point_from_string
+         :renderer: rst
 
    .. py:method:: validate_entry_point_group(group)
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.validate_entry_point_group
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.validate_entry_point_group
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.plugin.PluginParamType.convert
 
-      Convert the string value to an entry point instance, if the value can be successfully parsed
-      into an actual entry point. Will raise click.BadParameter if validation fails.
+      .. autodoc2-docstring:: aiida.cmdline.params.types.plugin.PluginParamType.convert
+         :renderer: rst
 
 .. py:class:: ProcessParamType
    :canonical: aiida.cmdline.params.types.process.ProcessParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.identifier.IdentifierParamType`
 
-   The ParamType for identifying ProcessNode entities or its subclasses
+   .. autodoc2-docstring:: aiida.cmdline.params.types.process.ProcessParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.process.ProcessParamType.name
       :value: 'Process'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.process.ProcessParamType.name
+         :renderer: rst
+
    .. py:property:: orm_class_loader
       :canonical: aiida.cmdline.params.types.process.ProcessParamType.orm_class_loader
 
-      Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
-      to be used to load the entity for a given identifier
-
-      :return: the orm entity loader class for this ParamType
+      .. autodoc2-docstring:: aiida.cmdline.params.types.process.ProcessParamType.orm_class_loader
+         :renderer: rst
 
 .. py:class:: ProfileParamType(*args, **kwargs)
    :canonical: aiida.cmdline.params.types.profile.ProfileParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.strings.LabelStringType`
 
-   The profile parameter type for click.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.profile.ProfileParamType
+      :renderer: rst
 
-   This parameter type requires the command that uses it to define the ``context_class`` class attribute to be the
-   :class:`aiida.cmdline.groups.verdi.VerdiContext` class, as that is responsible for creating the user defined object
-   ``obj`` on the context and loads the instance config.
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.cmdline.params.types.profile.ProfileParamType.__init__
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.profile.ProfileParamType.name
       :value: 'profile'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.profile.ProfileParamType.name
+         :renderer: rst
+
    .. py:method:: deconvert_default(value)
       :canonical: aiida.cmdline.params.types.profile.ProfileParamType.deconvert_default
       :staticmethod:
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.profile.ProfileParamType.deconvert_default
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.profile.ProfileParamType.convert
 
-      Attempt to match the given value to a valid profile.
+      .. autodoc2-docstring:: aiida.cmdline.params.types.profile.ProfileParamType.convert
+         :renderer: rst
 
    .. py:method:: shell_complete(ctx, param, incomplete)
       :canonical: aiida.cmdline.params.types.profile.ProfileParamType.shell_complete
 
-      Return possible completions based on an incomplete value
-
-      :returns: list of tuples of valid entry points (matching incomplete) and a description
+      .. autodoc2-docstring:: aiida.cmdline.params.types.profile.ProfileParamType.shell_complete
+         :renderer: rst
 
 .. py:class:: ShebangParamType
    :canonical: aiida.cmdline.params.types.computer.ShebangParamType
 
    Bases: :py:obj:`click.types.StringParamType`
 
-   Custom click param type for shebang line
+   .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ShebangParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.computer.ShebangParamType.name
       :value: 'shebangline'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ShebangParamType.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.computer.ShebangParamType.convert
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ShebangParamType.convert
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.cmdline.params.types.computer.ShebangParamType.__repr__
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.computer.ShebangParamType.__repr__
+         :renderer: rst
 
 .. py:class:: UserParamType(create=False)
    :canonical: aiida.cmdline.params.types.user.UserParamType
 
    Bases: :py:obj:`click.ParamType`
 
-   The user parameter type for click.   Can get or create a user.
+   .. autodoc2-docstring:: aiida.cmdline.params.types.user.UserParamType
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   :param create: If the user does not exist, create a new instance (unstored).
+   .. autodoc2-docstring:: aiida.cmdline.params.types.user.UserParamType.__init__
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.user.UserParamType.name
       :value: 'user'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.user.UserParamType.name
+         :renderer: rst
+
    .. py:method:: convert(value, param, ctx)
       :canonical: aiida.cmdline.params.types.user.UserParamType.convert
+
+      .. autodoc2-docstring:: aiida.cmdline.params.types.user.UserParamType.convert
+         :renderer: rst
 
    .. py:method:: shell_complete(ctx, param, incomplete)
       :canonical: aiida.cmdline.params.types.user.UserParamType.shell_complete
 
-      Return possible completions based on an incomplete value
-
-      :returns: list of tuples of valid entry points (matching incomplete) and a description
+      .. autodoc2-docstring:: aiida.cmdline.params.types.user.UserParamType.shell_complete
+         :renderer: rst
 
 .. py:class:: VerdiCommandGroup
    :canonical: aiida.cmdline.groups.verdi.VerdiCommandGroup
 
    Bases: :py:obj:`click.Group`
 
-   Subclass of :class:`click.Group` for the ``verdi`` CLI.
-
-   The class automatically adds the verbosity option to all commands in the interface. It also adds some functionality
-   to provide suggestions of commands in case the user provided command name does not exist.
+   .. autodoc2-docstring:: aiida.cmdline.groups.verdi.VerdiCommandGroup
+      :renderer: rst
 
    .. py:attribute:: context_class
       :canonical: aiida.cmdline.groups.verdi.VerdiCommandGroup.context_class
       :value: None
 
+      .. autodoc2-docstring:: aiida.cmdline.groups.verdi.VerdiCommandGroup.context_class
+         :renderer: rst
+
    .. py:method:: add_verbosity_option(cmd)
       :canonical: aiida.cmdline.groups.verdi.VerdiCommandGroup.add_verbosity_option
       :staticmethod:
 
-      Apply the ``verbosity`` option to the command, which is common to all ``verdi`` commands.
+      .. autodoc2-docstring:: aiida.cmdline.groups.verdi.VerdiCommandGroup.add_verbosity_option
+         :renderer: rst
 
    .. py:method:: fail_with_suggestions(ctx, cmd_name)
       :canonical: aiida.cmdline.groups.verdi.VerdiCommandGroup.fail_with_suggestions
 
-      Fail the command while trying to suggest commands to resemble the requested ``cmd_name``.
+      .. autodoc2-docstring:: aiida.cmdline.groups.verdi.VerdiCommandGroup.fail_with_suggestions
+         :renderer: rst
 
    .. py:method:: get_command(ctx, cmd_name)
       :canonical: aiida.cmdline.groups.verdi.VerdiCommandGroup.get_command
 
-      Return the command that corresponds to the requested ``cmd_name``.
-
-      This method is overridden from the base class in order to two functionalities:
-
-          * If the command is found, automatically add the verbosity option.
-          * If the command is not found, attempt to provide a list of suggestions with existing commands that resemble
-            the requested command name.
-
-      Note that if the command is not found and ``resilient_parsing`` is set to True on the context, then the latter
-      feature is disabled because most likely we are operating in tab-completion mode.
+      .. autodoc2-docstring:: aiida.cmdline.groups.verdi.VerdiCommandGroup.get_command
+         :renderer: rst
 
    .. py:method:: group(*args, **kwargs)
       :canonical: aiida.cmdline.groups.verdi.VerdiCommandGroup.group
 
-      Ensure that sub command groups use the same class but do not override an explicitly set value.
+      .. autodoc2-docstring:: aiida.cmdline.groups.verdi.VerdiCommandGroup.group
+         :renderer: rst
 
 .. py:class:: WorkflowParamType
    :canonical: aiida.cmdline.params.types.workflow.WorkflowParamType
 
    Bases: :py:obj:`aiida.cmdline.params.types.identifier.IdentifierParamType`
 
-   The ParamType for identifying WorkflowNode entities or its subclasses
+   .. autodoc2-docstring:: aiida.cmdline.params.types.workflow.WorkflowParamType
+      :renderer: rst
 
    .. py:attribute:: name
       :canonical: aiida.cmdline.params.types.workflow.WorkflowParamType.name
       :value: 'WorkflowNode'
 
+      .. autodoc2-docstring:: aiida.cmdline.params.types.workflow.WorkflowParamType.name
+         :renderer: rst
+
    .. py:property:: orm_class_loader
       :canonical: aiida.cmdline.params.types.workflow.WorkflowParamType.orm_class_loader
 
-      Return the orm entity loader class, which should be a subclass of OrmEntityLoader. This class is supposed
-      to be used to load the entity for a given identifier
-
-      :return: the orm entity loader class for this ParamType
+      .. autodoc2-docstring:: aiida.cmdline.params.types.workflow.WorkflowParamType.orm_class_loader
+         :renderer: rst
 
 .. py:function:: dbenv()
    :canonical: aiida.cmdline.utils.decorators.dbenv
 
-   Loads the dbenv for a specific region of code, does not unload afterwards
-
-   Only use when it makes it possible to avoid loading the dbenv for certain
-   code paths
-
-   Good Example::
-
-       # do this
-       @click.command()
-       @click.option('--with-db', is_flag=True)
-       def profile_info(with_db):
-           # read the config file
-           click.echo(profile_config)
-
-           # load the db only if necessary
-           if with_db:
-               with dbenv():
-                   # gather db statistics for the profile
-                   click.echo(db_statistics)
-
-   This will run very fast without the --with-db flag and slow only if database info is requested
-
-   Do not use if you will end up loading the dbenv anyway
-
-   Bad Example::
-
-       # don't do this
-       def my_function():
-           with dbenv():
-               # read from db
-
-           # do db unrelated stuff
+   .. autodoc2-docstring:: aiida.cmdline.utils.decorators.dbenv
+      :renderer: rst
 
 .. py:function:: echo_critical(message: str, bold: bool = False, nl: bool = True, err: bool = True, prefix: bool = True) -> None
    :canonical: aiida.cmdline.utils.echo.echo_critical
 
-   Log a critical error message to the cmdline logger and exit with ``exit_status``.
-
-   This should be used to print messages for errors that cannot be recovered from and so the script should be directly
-   terminated with a non-zero exit status to indicate that the command failed.
-
-   :param message: the message to log.
-   :param bold: whether to format the message in bold.
-   :param nl: whether to add a newline at the end of the message.
-   :param err: whether to log to stderr.
-   :param prefix: whether the message should be prefixed with a colored version of the log level.
+   .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_critical
+      :renderer: rst
 
 .. py:function:: echo_dictionary(dictionary, fmt='json+date', sort_keys=True)
    :canonical: aiida.cmdline.utils.echo.echo_dictionary
 
-   Log the given dictionary to stdout in the given format
-
-   :param dictionary: the dictionary
-   :param fmt: the format to use for printing
-   :param sort_keys: Whether to automatically sort keys
+   .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_dictionary
+      :renderer: rst
 
 .. py:function:: echo_error(message: str, bold: bool = False, nl: bool = True, err: bool = True, prefix: bool = True) -> None
    :canonical: aiida.cmdline.utils.echo.echo_error
 
-   Log an error message to the cmdline logger.
-
-   :param message: the message to log.
-   :param bold: whether to format the message in bold.
-   :param nl: whether to add a newline at the end of the message.
-   :param err: whether to log to stderr.
-   :param prefix: whether the message should be prefixed with a colored version of the log level.
+   .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_error
+      :renderer: rst
 
 .. py:function:: echo_info(message: str, bold: bool = False, nl: bool = True, err: bool = False, prefix: bool = True) -> None
    :canonical: aiida.cmdline.utils.echo.echo_info
 
-   Log an info message to the cmdline logger.
-
-   :param message: the message to log.
-   :param bold: whether to format the message in bold.
-   :param nl: whether to add a newline at the end of the message.
-   :param err: whether to log to stderr.
-   :param prefix: whether the message should be prefixed with a colored version of the log level.
+   .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_info
+      :renderer: rst
 
 .. py:function:: echo_report(message: str, bold: bool = False, nl: bool = True, err: bool = False, prefix: bool = True) -> None
    :canonical: aiida.cmdline.utils.echo.echo_report
 
-   Log an report message to the cmdline logger.
-
-   :param message: the message to log.
-   :param bold: whether to format the message in bold.
-   :param nl: whether to add a newline at the end of the message.
-   :param err: whether to log to stderr.
-   :param prefix: whether the message should be prefixed with a colored version of the log level.
+   .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_report
+      :renderer: rst
 
 .. py:function:: echo_success(message: str, bold: bool = False, nl: bool = True, err: bool = False, prefix: bool = True) -> None
    :canonical: aiida.cmdline.utils.echo.echo_success
 
-   Log a success message to the cmdline logger.
-
-   .. note:: The message will be logged at the ``REPORT`` level and always with the ``Success:`` prefix.
-
-   :param message: the message to log.
-   :param bold: whether to format the message in bold.
-   :param nl: whether to add a newline at the end of the message.
-   :param err: whether to log to stderr.
-   :param prefix: whether the message should be prefixed with a colored version of the log level.
+   .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_success
+      :renderer: rst
 
 .. py:function:: echo_warning(message: str, bold: bool = False, nl: bool = True, err: bool = False, prefix: bool = True) -> None
    :canonical: aiida.cmdline.utils.echo.echo_warning
 
-   Log a warning message to the cmdline logger.
-
-   :param message: the message to log.
-   :param bold: whether to format the message in bold.
-   :param nl: whether to add a newline at the end of the message.
-   :param err: whether to log to stderr.
-   :param prefix: whether the message should be prefixed with a colored version of the log level.
+   .. autodoc2-docstring:: aiida.cmdline.utils.echo.echo_warning
+      :renderer: rst
 
 .. py:function:: format_call_graph(calc_node, max_depth: int = None, info_fn=calc_info)
    :canonical: aiida.cmdline.utils.ascii_vis.format_call_graph
 
-   Print a tree like the POSIX tree command for the calculation call graph
-
-   :param calc_node: The calculation node
-   :param max_depth: Maximum depth of the call graph to print
-   :param info_fn: An optional function that takes the node and returns a string
-       of information to be displayed for each node.
+   .. autodoc2-docstring:: aiida.cmdline.utils.ascii_vis.format_call_graph
+      :renderer: rst
 
 .. py:function:: is_verbose()
    :canonical: aiida.cmdline.utils.common.is_verbose
 
-   Return whether the configured logging verbosity is considered verbose, i.e., equal or lower to ``INFO`` level.
-
-   .. note:: This checks the effective logging level that is set on the ``CMDLINE_LOGGER``. This means that it will
-       consider the logging level set on the parent ``AIIDA_LOGGER`` if not explicitly set on itself. The level of the
-       main logger can be manipulated from the command line through the ``VERBOSITY`` option that is available for all
-       commands.
-
+   .. autodoc2-docstring:: aiida.cmdline.utils.common.is_verbose
+      :renderer: rst
 
 .. py:function:: only_if_daemon_running(echo_function=echo.echo_critical, message=None)
    :canonical: aiida.cmdline.utils.decorators.only_if_daemon_running
 
-   Function decorator for CLI command to print critical error and exit automatically when daemon is not running.
-
-   The error printing and exit behavior can be controlled with the decorator keyword arguments. The default message
-   that is printed can be overridden as well as the echo function that is to be used. By default it uses the
-   `aiida.cmdline.utils.echo.echo_critical` function which automatically aborts the command. The function can be
-   substituted by for example `aiida.cmdline.utils.echo.echo_warning` to instead print just a warning and continue.
-
-   Example::
-
-       @only_if_daemon_running(echo_function=echo.echo_warning, message='beware that the daemon is not running')
-       def create_node():
-           pass
-
-   :param echo_function: echo function to issue the message, should be from `aiida.cmdline.utils.echo`
-   :param message: optional message to override the default message
+   .. autodoc2-docstring:: aiida.cmdline.utils.decorators.only_if_daemon_running
+      :renderer: rst
 
 .. py:function:: with_dbenv()
    :canonical: aiida.cmdline.utils.decorators.with_dbenv
 
-   Function decorator that will load the database environment for the currently loaded profile.
-
-   .. note:: if no profile has been loaded yet, the default profile will be loaded first.
-
-   Example::
-
-       @with_dbenv()
-       def create_node():
-           from aiida.orm import Int  # note the local import
-           node = Int(1).store()
+   .. autodoc2-docstring:: aiida.cmdline.utils.decorators.with_dbenv
+      :renderer: rst

--- a/docs/apidocs/aiida/aiida.common.rst
+++ b/docs/apidocs/aiida/aiida.common.rst
@@ -7,9 +7,9 @@
 Description
 -----------
 
-Common data structures, utility classes and functions
-
-.. note:: Modules in this sub package have to run without a loaded database environment
+.. autodoc2-docstring:: aiida.common
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -22,27 +22,49 @@ Classes
    :align: left
 
    * - :py:obj:`AttributeDict <aiida.common.extendeddicts.AttributeDict>`
-     - This class internally stores values in a dictionary, but exposes the keys also as attributes, i.e. asking for attrdict.key will return the value of attrdict['key'] and so on.
+     - .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcInfo <aiida.common.datastructures.CalcInfo>`
-     - This object will store the data returned by the calculation plugin and to be passed to the ExecManager.
+     - .. autodoc2-docstring:: aiida.common.datastructures.CalcInfo
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcJobState <aiida.common.datastructures.CalcJobState>`
-     - The sub state of a CalcJobNode while its Process is in an active state (i.e. Running or Waiting).
+     - .. autodoc2-docstring:: aiida.common.datastructures.CalcJobState
+          :renderer: rst
+          :summary:
    * - :py:obj:`CodeInfo <aiida.common.datastructures.CodeInfo>`
-     - This attribute-dictionary contains the information needed to execute a code. Possible attributes are:
+     - .. autodoc2-docstring:: aiida.common.datastructures.CodeInfo
+          :renderer: rst
+          :summary:
    * - :py:obj:`CodeRunMode <aiida.common.datastructures.CodeRunMode>`
-     - Enum to indicate the way the codes of a calculation should be run.
+     - .. autodoc2-docstring:: aiida.common.datastructures.CodeRunMode
+          :renderer: rst
+          :summary:
    * - :py:obj:`DefaultFieldsAttributeDict <aiida.common.extendeddicts.DefaultFieldsAttributeDict>`
-     - A dictionary with access to the keys as attributes, and with an internal value storing the 'default' keys to be distinguished from extra fields.
+     - .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict
+          :renderer: rst
+          :summary:
    * - :py:obj:`FixedFieldsAttributeDict <aiida.common.extendeddicts.FixedFieldsAttributeDict>`
-     - A dictionary with access to the keys as attributes, and with filtering of valid attributes. This is only the base class, without valid attributes; use a derived class to do the actual work. E.g.
+     - .. autodoc2-docstring:: aiida.common.extendeddicts.FixedFieldsAttributeDict
+          :renderer: rst
+          :summary:
    * - :py:obj:`GraphTraversalRules <aiida.common.links.GraphTraversalRules>`
-     - Graph traversal rules when deleting or exporting nodes.
+     - .. autodoc2-docstring:: aiida.common.links.GraphTraversalRules
+          :renderer: rst
+          :summary:
    * - :py:obj:`LinkType <aiida.common.links.LinkType>`
-     - A simple enum of allowed link types.
+     - .. autodoc2-docstring:: aiida.common.links.LinkType
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProgressReporterAbstract <aiida.common.progress_reporter.ProgressReporterAbstract>`
-     - An abstract class for incrementing a progress reporter.
+     - .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract
+          :renderer: rst
+          :summary:
    * - :py:obj:`StashMode <aiida.common.datastructures.StashMode>`
-     - Mode to use when stashing files from the working directory of a completed calculation job for safekeeping.
+     - .. autodoc2-docstring:: aiida.common.datastructures.StashMode
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -52,17 +74,29 @@ Functions
    :align: left
 
    * - :py:obj:`create_callback <aiida.common.progress_reporter.create_callback>`
-     - Create a callback function to update the progress reporter.
+     - .. autodoc2-docstring:: aiida.common.progress_reporter.create_callback
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_progress_reporter <aiida.common.progress_reporter.get_progress_reporter>`
-     - Return the progress reporter
+     - .. autodoc2-docstring:: aiida.common.progress_reporter.get_progress_reporter
+          :renderer: rst
+          :summary:
    * - :py:obj:`override_log_level <aiida.common.log.override_log_level>`
-     - Temporarily adjust the log-level of logger.
+     - .. autodoc2-docstring:: aiida.common.log.override_log_level
+          :renderer: rst
+          :summary:
    * - :py:obj:`set_progress_bar_tqdm <aiida.common.progress_reporter.set_progress_bar_tqdm>`
-     - Set a `tqdm <https://github.com/tqdm/tqdm>`__ implementation of the progress reporter interface.
+     - .. autodoc2-docstring:: aiida.common.progress_reporter.set_progress_bar_tqdm
+          :renderer: rst
+          :summary:
    * - :py:obj:`set_progress_reporter <aiida.common.progress_reporter.set_progress_reporter>`
-     - Set the progress reporter implementation
+     - .. autodoc2-docstring:: aiida.common.progress_reporter.set_progress_reporter
+          :renderer: rst
+          :summary:
    * - :py:obj:`validate_link_label <aiida.common.links.validate_link_label>`
-     - Validate the given link label.
+     - .. autodoc2-docstring:: aiida.common.links.validate_link_label
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -72,11 +106,17 @@ Data
    :align: left
 
    * - :py:obj:`AIIDA_LOGGER <aiida.common.log.AIIDA_LOGGER>`
-     - 
+     - .. autodoc2-docstring:: aiida.common.log.AIIDA_LOGGER
+          :renderer: rst
+          :summary:
    * - :py:obj:`GraphTraversalRule <aiida.common.links.GraphTraversalRule>`
-     - A namedtuple that defines a graph traversal rule.
+     - .. autodoc2-docstring:: aiida.common.links.GraphTraversalRule
+          :renderer: rst
+          :summary:
    * - :py:obj:`TQDM_BAR_FORMAT <aiida.common.progress_reporter.TQDM_BAR_FORMAT>`
-     - 
+     - .. autodoc2-docstring:: aiida.common.progress_reporter.TQDM_BAR_FORMAT
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -85,1101 +125,1037 @@ API
    :canonical: aiida.common.log.AIIDA_LOGGER
    :value: None
 
+   .. autodoc2-docstring:: aiida.common.log.AIIDA_LOGGER
+      :renderer: rst
+
 .. py:exception:: AiidaException()
    :canonical: aiida.common.exceptions.AiidaException
 
    Bases: :py:obj:`Exception`
 
-   Base class for all AiiDA exceptions.
-
-   Each module will have its own subclass, inherited from this
-   (e.g. ExecManagerException, TransportException, ...)
+   .. autodoc2-docstring:: aiida.common.exceptions.AiidaException
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.AiidaException.__init__
+      :renderer: rst
 
 .. py:class:: AttributeDict(dictionary=None)
    :canonical: aiida.common.extendeddicts.AttributeDict
 
    Bases: :py:obj:`dict`
 
-   This class internally stores values in a dictionary, but exposes
-   the keys also as attributes, i.e. asking for attrdict.key
-   will return the value of attrdict['key'] and so on.
-
-   Raises an AttributeError if the key does not exist, when called as an attribute,
-   while the usual KeyError if the key does not exist and the dictionary syntax is
-   used.
+   .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict.__init__
+      :renderer: rst
 
    .. py:method:: __repr__()
       :canonical: aiida.common.extendeddicts.AttributeDict.__repr__
 
-      Representation of the object.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict.__repr__
+         :renderer: rst
 
    .. py:method:: __getattr__(attr)
       :canonical: aiida.common.extendeddicts.AttributeDict.__getattr__
 
-      Read a key as an attribute.
-
-      :raises AttributeError: if the attribute does not correspond to an existing key.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict.__getattr__
+         :renderer: rst
 
    .. py:method:: __setattr__(attr, value)
       :canonical: aiida.common.extendeddicts.AttributeDict.__setattr__
 
-      Set a key as an attribute.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict.__setattr__
+         :renderer: rst
 
    .. py:method:: __delattr__(attr)
       :canonical: aiida.common.extendeddicts.AttributeDict.__delattr__
 
-      Delete a key as an attribute.
-
-      :raises AttributeError: if the attribute does not correspond to an existing key.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict.__delattr__
+         :renderer: rst
 
    .. py:method:: __deepcopy__(memo=None)
       :canonical: aiida.common.extendeddicts.AttributeDict.__deepcopy__
 
-      Deep copy.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict.__deepcopy__
+         :renderer: rst
 
    .. py:method:: __getstate__()
       :canonical: aiida.common.extendeddicts.AttributeDict.__getstate__
 
-      Needed for pickling this class.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict.__getstate__
+         :renderer: rst
 
    .. py:method:: __setstate__(dictionary)
       :canonical: aiida.common.extendeddicts.AttributeDict.__setstate__
 
-      Needed for pickling this class.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict.__setstate__
+         :renderer: rst
 
    .. py:method:: __dir__()
       :canonical: aiida.common.extendeddicts.AttributeDict.__dir__
 
-      Default dir() implementation.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.AttributeDict.__dir__
+         :renderer: rst
 
 .. py:class:: CalcInfo(dictionary=None)
    :canonical: aiida.common.datastructures.CalcInfo
 
    Bases: :py:obj:`aiida.common.extendeddicts.DefaultFieldsAttributeDict`
 
-   This object will store the data returned by the calculation plugin and to be
-   passed to the ExecManager.
-
-   In the following descriptions all paths have to be considered relative
-
-   * retrieve_list: a list of strings or tuples that indicate files that are to be retrieved from the remote after the
-       calculation has finished and stored in the ``retrieved_folder`` output node of type ``FolderData``. If the entry
-       in the list is just a string, it is assumed to be the filepath on the remote and it will be copied to the base
-       directory of the retrieved folder, where the name corresponds to the basename of the remote relative path. This
-       means that any remote folder hierarchy is ignored entirely.
-
-       Remote folder hierarchy can be (partially) maintained by using a tuple instead, with the following format
-
-           (source, target, depth)
-
-       The ``source`` and ``target`` elements are relative filepaths in the remote and retrieved folder. The contents
-       of ``source`` (whether it is a file or folder) are copied in its entirety to the ``target`` subdirectory in the
-       retrieved folder. If no subdirectory should be created, ``'.'`` should be specified for ``target``.
-
-       The ``source`` filepaths support glob patterns ``*`` in case the exact name of the files that are to be
-       retrieved are not know a priori.
-
-       The ``depth`` element can be used to control what level of nesting of the source folder hierarchy should be
-       maintained. If ``depth`` equals ``0`` or ``1`` (they are equivalent), only the basename of the ``source``
-       filepath is kept. For each additional level, another subdirectory of the remote hierarchy is kept. For example:
-
-           ('path/sub/file.txt', '.', 2)
-
-       will retrieve the ``file.txt`` and store it under the path:
-
-           sub/file.txt
-
-   * retrieve_temporary_list: a list of strings or tuples that indicate files that will be retrieved
-       and stored temporarily in a FolderData, that will be available only during the parsing call.
-       The format of the list is the same as that of 'retrieve_list'
-
-   * local_copy_list: a list of tuples with format ('node_uuid', 'filename', relativedestpath')
-   * remote_copy_list: a list of tuples with format ('remotemachinename', 'remoteabspath', 'relativedestpath')
-   * remote_symlink_list: a list of tuples with format ('remotemachinename', 'remoteabspath', 'relativedestpath')
-   * provenance_exclude_list: a sequence of relative paths of files in the sandbox folder of a `CalcJob` instance that
-       should not be stored permanantly in the repository folder of the corresponding `CalcJobNode` that will be
-       created, but should only be copied to the remote working directory on the target computer. This is useful for
-       input files that should be copied to the working directory but should not be copied as well to the repository
-       either, for example, because they contain proprietary information or because they are big and their content is
-       already indirectly present in the repository through one of the data nodes passed as input to the calculation.
-   * codes_info: a list of dictionaries used to pass the info of the execution of a code
-   * codes_run_mode: the mode of execution in which the codes will be run (`CodeRunMode.SERIAL` by default,
-       but can also be `CodeRunMode.PARALLEL`)
-   * skip_submit: a flag that, when set to True, orders the engine to skip the submit/update steps (so no code will
-       run, it will only upload the files and then retrieve/parse).
+   .. autodoc2-docstring:: aiida.common.datastructures.CalcInfo
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.common.datastructures.CalcInfo.__init__
+      :renderer: rst
 
    .. py:attribute:: _default_fields
       :canonical: aiida.common.datastructures.CalcInfo._default_fields
       :value: ('job_environment', 'email', 'email_on_started', 'email_on_terminated', 'uuid', 'prepend_text', 'app...
+
+      .. autodoc2-docstring:: aiida.common.datastructures.CalcInfo._default_fields
+         :renderer: rst
 
 .. py:class:: CalcJobState
    :canonical: aiida.common.datastructures.CalcJobState
 
    Bases: :py:obj:`enum.Enum`
 
-   The sub state of a CalcJobNode while its Process is in an active state (i.e. Running or Waiting).
+   .. autodoc2-docstring:: aiida.common.datastructures.CalcJobState
+      :renderer: rst
 
    .. py:attribute:: UPLOADING
       :canonical: aiida.common.datastructures.CalcJobState.UPLOADING
       :value: 'uploading'
 
+      .. autodoc2-docstring:: aiida.common.datastructures.CalcJobState.UPLOADING
+         :renderer: rst
+
    .. py:attribute:: SUBMITTING
       :canonical: aiida.common.datastructures.CalcJobState.SUBMITTING
       :value: 'submitting'
+
+      .. autodoc2-docstring:: aiida.common.datastructures.CalcJobState.SUBMITTING
+         :renderer: rst
 
    .. py:attribute:: WITHSCHEDULER
       :canonical: aiida.common.datastructures.CalcJobState.WITHSCHEDULER
       :value: 'withscheduler'
 
+      .. autodoc2-docstring:: aiida.common.datastructures.CalcJobState.WITHSCHEDULER
+         :renderer: rst
+
    .. py:attribute:: STASHING
       :canonical: aiida.common.datastructures.CalcJobState.STASHING
       :value: 'stashing'
+
+      .. autodoc2-docstring:: aiida.common.datastructures.CalcJobState.STASHING
+         :renderer: rst
 
    .. py:attribute:: RETRIEVING
       :canonical: aiida.common.datastructures.CalcJobState.RETRIEVING
       :value: 'retrieving'
 
+      .. autodoc2-docstring:: aiida.common.datastructures.CalcJobState.RETRIEVING
+         :renderer: rst
+
    .. py:attribute:: PARSING
       :canonical: aiida.common.datastructures.CalcJobState.PARSING
       :value: 'parsing'
+
+      .. autodoc2-docstring:: aiida.common.datastructures.CalcJobState.PARSING
+         :renderer: rst
 
 .. py:exception:: ClosedStorage()
    :canonical: aiida.common.exceptions.ClosedStorage
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when trying to access data from a closed storage backend.
+   .. autodoc2-docstring:: aiida.common.exceptions.ClosedStorage
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.ClosedStorage.__init__
+      :renderer: rst
 
 .. py:class:: CodeInfo(dictionary=None)
    :canonical: aiida.common.datastructures.CodeInfo
 
    Bases: :py:obj:`aiida.common.extendeddicts.DefaultFieldsAttributeDict`
 
-   This attribute-dictionary contains the information needed to execute a code.
-   Possible attributes are:
-
-   * ``cmdline_params``: a list of strings, containing parameters to be written on
-     the command line right after the call to the code, as for example::
-
-       code.x cmdline_params[0] cmdline_params[1] ... < stdin > stdout
-
-   * ``stdin_name``: (optional) the name of the standard input file. Note, it is
-     only possible to use the stdin with the syntax::
-
-       code.x < stdin_name
-
-     If no stdin_name is specified, the string "< stdin_name" will not be
-     passed to the code.
-     Note: it is not possible to substitute/remove the '<' if stdin_name is specified;
-     if that is needed, avoid stdin_name and use instead the cmdline_params to
-     specify a suitable syntax.
-   * ``stdout_name``: (optional) the name of the standard output file. Note, it is
-     only possible to pass output to stdout_name with the syntax::
-
-       code.x ... > stdout_name
-
-     If no stdout_name is specified, the string "> stdout_name" will not be
-     passed to the code.
-     Note: it is not possible to substitute/remove the '>' if stdout_name is specified;
-     if that is needed, avoid stdout_name and use instead the cmdline_params to
-     specify a suitable syntax.
-   * ``stderr_name``: (optional) a string, the name of the error file of the code.
-   * ``join_files``: (optional) if True, redirects the error to the output file.
-     If join_files=True, the code will be called as::
-
-       code.x ... > stdout_name 2>&1
-
-     otherwise, if join_files=False and stderr is passed::
-
-       code.x ... > stdout_name 2> stderr_name
-
-   * ``withmpi``: if True, executes the code with mpirun (or another MPI installed
-     on the remote computer)
-   * ``code_uuid``: the uuid of the code associated to the CodeInfo
+   .. autodoc2-docstring:: aiida.common.datastructures.CodeInfo
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.common.datastructures.CodeInfo.__init__
+      :renderer: rst
 
    .. py:attribute:: _default_fields
       :canonical: aiida.common.datastructures.CodeInfo._default_fields
       :value: ('cmdline_params', 'stdin_name', 'stdout_name', 'stderr_name', 'join_files', 'withmpi', 'code_uuid')
+
+      .. autodoc2-docstring:: aiida.common.datastructures.CodeInfo._default_fields
+         :renderer: rst
 
 .. py:class:: CodeRunMode()
    :canonical: aiida.common.datastructures.CodeRunMode
 
    Bases: :py:obj:`enum.IntEnum`
 
-   Enum to indicate the way the codes of a calculation should be run.
-
-   For PARALLEL, the codes for a given calculation will be run in parallel by running them in the background::
-
-       code1.x &
-       code2.x &
-
-   For the SERIAL option, codes will be executed sequentially by running for example the following::
-
-       code1.x
-       code2.x
+   .. autodoc2-docstring:: aiida.common.datastructures.CodeRunMode
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.datastructures.CodeRunMode.__init__
+      :renderer: rst
 
    .. py:attribute:: SERIAL
       :canonical: aiida.common.datastructures.CodeRunMode.SERIAL
       :value: 0
 
+      .. autodoc2-docstring:: aiida.common.datastructures.CodeRunMode.SERIAL
+         :renderer: rst
+
    .. py:attribute:: PARALLEL
       :canonical: aiida.common.datastructures.CodeRunMode.PARALLEL
       :value: 1
+
+      .. autodoc2-docstring:: aiida.common.datastructures.CodeRunMode.PARALLEL
+         :renderer: rst
 
 .. py:exception:: ConfigurationError()
    :canonical: aiida.common.exceptions.ConfigurationError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Error raised when there is a configuration error in AiiDA.
+   .. autodoc2-docstring:: aiida.common.exceptions.ConfigurationError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.ConfigurationError.__init__
+      :renderer: rst
 
 .. py:exception:: ConfigurationVersionError()
    :canonical: aiida.common.exceptions.ConfigurationVersionError
 
    Bases: :py:obj:`aiida.common.exceptions.ConfigurationError`
 
-   Configuration error raised when the configuration file version is not
-   compatible with the current version.
+   .. autodoc2-docstring:: aiida.common.exceptions.ConfigurationVersionError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.ConfigurationVersionError.__init__
+      :renderer: rst
 
 .. py:exception:: ContentNotExistent()
    :canonical: aiida.common.exceptions.ContentNotExistent
 
    Bases: :py:obj:`aiida.common.exceptions.NotExistent`
 
-   Raised when trying to access an attribute, a key or a file in the result
-   nodes that is not present
+   .. autodoc2-docstring:: aiida.common.exceptions.ContentNotExistent
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.ContentNotExistent.__init__
+      :renderer: rst
 
 .. py:exception:: CorruptStorage()
    :canonical: aiida.common.exceptions.CorruptStorage
 
    Bases: :py:obj:`aiida.common.exceptions.ConfigurationError`
 
-   Raised when the storage is not found to be internally consistent on validation.
+   .. autodoc2-docstring:: aiida.common.exceptions.CorruptStorage
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.CorruptStorage.__init__
+      :renderer: rst
 
 .. py:exception:: DbContentError()
    :canonical: aiida.common.exceptions.DbContentError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when the content of the DB is not valid.
-   This should never happen if the user does not play directly
-   with the DB.
+   .. autodoc2-docstring:: aiida.common.exceptions.DbContentError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.DbContentError.__init__
+      :renderer: rst
 
 .. py:class:: DefaultFieldsAttributeDict(dictionary=None)
    :canonical: aiida.common.extendeddicts.DefaultFieldsAttributeDict
 
    Bases: :py:obj:`aiida.common.extendeddicts.AttributeDict`
 
-   A dictionary with access to the keys as attributes, and with an
-   internal value storing the 'default' keys to be distinguished
-   from extra fields.
-
-   Extra methods defaultkeys() and extrakeys() divide the set returned by
-   keys() in default keys (i.e. those defined at definition time)
-   and other keys.
-   There is also a method get_default_fields() to return the internal list.
-
-   Moreover, for undefined default keys, it returns None instead of raising a
-   KeyError/AttributeError exception.
-
-   Remember to define the _default_fields in a subclass!
-   E.g.::
-
-       class TestExample(DefaultFieldsAttributeDict):
-           _default_fields = ('a','b','c')
-
-   When the validate() method is called, it calls in turn all validate_KEY
-   methods, where KEY is one of the default keys.
-   If the method is not present, the field is considered to be always valid.
-   Each validate_KEY method should accept a single argument 'value' that will
-   contain the value to be checked.
-
-   It raises a ValidationError if any of the validate_KEY
-   function raises an exception, otherwise it simply returns.
-   NOTE: the `validate_*` functions are called also for unset fields, so if the
-   field can be empty on validation, you have to start your validation
-   function with something similar to::
-
-       if value is None:
-           return
-
-   .. todo::
-       Decide behavior if I set to None a field.
-       Current behavior, if
-       ``a`` is an instance and 'def_field' one of the default fields, that is
-       undefined, we get:
-
-       * ``a.get('def_field')``: None
-       * ``a.get('def_field','whatever')``: 'whatever'
-       * Note that ``a.defaultkeys()`` does NOT contain 'def_field'
-
-       if we do ``a.def_field = None``, then the behavior becomes
-
-       * ``a.get('def_field')``: None
-       * ``a.get('def_field','whatever')``: None
-       * Note that ``a.defaultkeys()`` DOES contain 'def_field'
-
-       See if we want that setting a default field to None means deleting it.
+   .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict.__init__
+      :renderer: rst
 
    .. py:attribute:: _default_fields
       :canonical: aiida.common.extendeddicts.DefaultFieldsAttributeDict._default_fields
       :value: None
 
+      .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict._default_fields
+         :renderer: rst
+
    .. py:method:: validate()
       :canonical: aiida.common.extendeddicts.DefaultFieldsAttributeDict.validate
 
-      Validate the keys, if any ``validate_*`` method is available.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict.validate
+         :renderer: rst
 
    .. py:method:: __setattr__(attr, value)
       :canonical: aiida.common.extendeddicts.DefaultFieldsAttributeDict.__setattr__
 
-      Overridden to allow direct access to fields with underscore.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict.__setattr__
+         :renderer: rst
 
    .. py:method:: __getitem__(key)
       :canonical: aiida.common.extendeddicts.DefaultFieldsAttributeDict.__getitem__
 
-      Return None instead of raising an exception if the key does not exist
-      but is in the list of default fields.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict.__getitem__
+         :renderer: rst
 
    .. py:method:: get_default_fields()
       :canonical: aiida.common.extendeddicts.DefaultFieldsAttributeDict.get_default_fields
       :classmethod:
 
-      Return the list of default fields, either defined in the instance or not.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict.get_default_fields
+         :renderer: rst
 
    .. py:method:: defaultkeys()
       :canonical: aiida.common.extendeddicts.DefaultFieldsAttributeDict.defaultkeys
 
-      Return the default keys defined in the instance.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict.defaultkeys
+         :renderer: rst
 
    .. py:method:: extrakeys()
       :canonical: aiida.common.extendeddicts.DefaultFieldsAttributeDict.extrakeys
 
-      Return the extra keys defined in the instance.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.DefaultFieldsAttributeDict.extrakeys
+         :renderer: rst
 
 .. py:exception:: EntryPointError()
    :canonical: aiida.common.exceptions.EntryPointError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when an entry point cannot be uniquely resolved and imported.
+   .. autodoc2-docstring:: aiida.common.exceptions.EntryPointError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.EntryPointError.__init__
+      :renderer: rst
 
 .. py:exception:: FailedError()
    :canonical: aiida.common.exceptions.FailedError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when accessing a calculation that is in the FAILED status
+   .. autodoc2-docstring:: aiida.common.exceptions.FailedError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.FailedError.__init__
+      :renderer: rst
 
 .. py:exception:: FeatureDisabled()
    :canonical: aiida.common.exceptions.FeatureDisabled
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when a feature is requested, but the user has chosen to disable
-   it (e.g., for submissions on disabled computers).
+   .. autodoc2-docstring:: aiida.common.exceptions.FeatureDisabled
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.FeatureDisabled.__init__
+      :renderer: rst
 
 .. py:exception:: FeatureNotAvailable()
    :canonical: aiida.common.exceptions.FeatureNotAvailable
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when a feature is requested from a plugin, that is not available.
+   .. autodoc2-docstring:: aiida.common.exceptions.FeatureNotAvailable
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.FeatureNotAvailable.__init__
+      :renderer: rst
 
 .. py:class:: FixedFieldsAttributeDict(init=None)
    :canonical: aiida.common.extendeddicts.FixedFieldsAttributeDict
 
    Bases: :py:obj:`aiida.common.extendeddicts.AttributeDict`
 
-   A dictionary with access to the keys as attributes, and with filtering
-   of valid attributes.
-   This is only the base class, without valid attributes;
-   use a derived class to do the actual work.
-   E.g.::
-
-       class TestExample(FixedFieldsAttributeDict):
-           _valid_fields = ('a','b','c')
+   .. autodoc2-docstring:: aiida.common.extendeddicts.FixedFieldsAttributeDict
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.common.extendeddicts.FixedFieldsAttributeDict.__init__
+      :renderer: rst
 
    .. py:attribute:: _valid_fields
       :canonical: aiida.common.extendeddicts.FixedFieldsAttributeDict._valid_fields
       :value: None
 
+      .. autodoc2-docstring:: aiida.common.extendeddicts.FixedFieldsAttributeDict._valid_fields
+         :renderer: rst
+
    .. py:method:: __setitem__(item, value)
       :canonical: aiida.common.extendeddicts.FixedFieldsAttributeDict.__setitem__
 
-      Set a key as an attribute.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.FixedFieldsAttributeDict.__setitem__
+         :renderer: rst
 
    .. py:method:: __setattr__(attr, value)
       :canonical: aiida.common.extendeddicts.FixedFieldsAttributeDict.__setattr__
 
-      Overridden to allow direct access to fields with underscore.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.FixedFieldsAttributeDict.__setattr__
+         :renderer: rst
 
    .. py:method:: get_valid_fields()
       :canonical: aiida.common.extendeddicts.FixedFieldsAttributeDict.get_valid_fields
       :classmethod:
 
-      Return the list of valid fields.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.FixedFieldsAttributeDict.get_valid_fields
+         :renderer: rst
 
    .. py:method:: __dir__()
       :canonical: aiida.common.extendeddicts.FixedFieldsAttributeDict.__dir__
 
-      Default dir() implementation.
+      .. autodoc2-docstring:: aiida.common.extendeddicts.FixedFieldsAttributeDict.__dir__
+         :renderer: rst
 
 .. py:data:: GraphTraversalRule
    :canonical: aiida.common.links.GraphTraversalRule
    :value: None
 
-   A namedtuple that defines a graph traversal rule.
-
-   When starting from a certain sub set of nodes, the graph traversal rules specify which links should be followed to
-   add adjacent nodes to finally arrive at a set of nodes that represent a valid and consistent sub graph.
-
-   :param link_type: the `LinkType` that the rule applies to
-   :param direction: whether the link type should be followed backwards or forwards
-   :param toggleable: boolean to indicate whether the rule can be changed from the default value. If this is `False` it
-       means the default value can never be changed as it will result in an inconsistent graph.
-   :param default: boolean, the default value of the rule, if `True` means that the link type for the given direction
-       should be followed.
+   .. autodoc2-docstring:: aiida.common.links.GraphTraversalRule
+      :renderer: rst
 
 .. py:class:: GraphTraversalRules
    :canonical: aiida.common.links.GraphTraversalRules
 
    Bases: :py:obj:`enum.Enum`
 
-   Graph traversal rules when deleting or exporting nodes.
+   .. autodoc2-docstring:: aiida.common.links.GraphTraversalRules
+      :renderer: rst
 
    .. py:attribute:: DEFAULT
       :canonical: aiida.common.links.GraphTraversalRules.DEFAULT
       :value: None
 
+      .. autodoc2-docstring:: aiida.common.links.GraphTraversalRules.DEFAULT
+         :renderer: rst
+
    .. py:attribute:: DELETE
       :canonical: aiida.common.links.GraphTraversalRules.DELETE
       :value: None
 
+      .. autodoc2-docstring:: aiida.common.links.GraphTraversalRules.DELETE
+         :renderer: rst
+
    .. py:attribute:: EXPORT
       :canonical: aiida.common.links.GraphTraversalRules.EXPORT
       :value: None
+
+      .. autodoc2-docstring:: aiida.common.links.GraphTraversalRules.EXPORT
+         :renderer: rst
 
 .. py:exception:: HashingError()
    :canonical: aiida.common.exceptions.HashingError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when an attempt to hash an object fails via a known failure mode
+   .. autodoc2-docstring:: aiida.common.exceptions.HashingError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.HashingError.__init__
+      :renderer: rst
 
 .. py:exception:: IncompatibleStorageSchema()
    :canonical: aiida.common.exceptions.IncompatibleStorageSchema
 
    Bases: :py:obj:`aiida.common.exceptions.IncompatibleDatabaseSchema`
 
-   Raised when the storage schema is incompatible with that of the code.
+   .. autodoc2-docstring:: aiida.common.exceptions.IncompatibleStorageSchema
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.IncompatibleStorageSchema.__init__
+      :renderer: rst
 
 .. py:exception:: InputValidationError()
    :canonical: aiida.common.exceptions.InputValidationError
 
    Bases: :py:obj:`aiida.common.exceptions.ValidationError`
 
-   The input data for a calculation did not validate (e.g., missing
-   required input data, wrong data, ...)
+   .. autodoc2-docstring:: aiida.common.exceptions.InputValidationError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.InputValidationError.__init__
+      :renderer: rst
 
 .. py:exception:: IntegrityError()
    :canonical: aiida.common.exceptions.IntegrityError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when there is an underlying data integrity error.  This can be database related
-   or a general data integrity error.  This can happen if, e.g., a foreign key check fails.
-   See PEP 249 for details.
+   .. autodoc2-docstring:: aiida.common.exceptions.IntegrityError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.IntegrityError.__init__
+      :renderer: rst
 
 .. py:exception:: InternalError()
    :canonical: aiida.common.exceptions.InternalError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Error raised when there is an internal error of AiiDA.
+   .. autodoc2-docstring:: aiida.common.exceptions.InternalError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.InternalError.__init__
+      :renderer: rst
 
 .. py:exception:: InvalidEntryPointTypeError()
    :canonical: aiida.common.exceptions.InvalidEntryPointTypeError
 
    Bases: :py:obj:`aiida.common.exceptions.EntryPointError`
 
-   Raised when a loaded entry point has a type that is not supported by the corresponding entry point group.
+   .. autodoc2-docstring:: aiida.common.exceptions.InvalidEntryPointTypeError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.InvalidEntryPointTypeError.__init__
+      :renderer: rst
 
 .. py:exception:: InvalidOperation()
    :canonical: aiida.common.exceptions.InvalidOperation
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   The allowed operation is not valid (e.g., when trying to add a non-internal attribute
-   before saving the entry), or deleting an entry that is protected (e.g.,
-   because it is referenced by foreign keys)
+   .. autodoc2-docstring:: aiida.common.exceptions.InvalidOperation
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.InvalidOperation.__init__
+      :renderer: rst
 
 .. py:exception:: LicensingException()
    :canonical: aiida.common.exceptions.LicensingException
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when requirements for data licensing are not met.
+   .. autodoc2-docstring:: aiida.common.exceptions.LicensingException
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.LicensingException.__init__
+      :renderer: rst
 
 .. py:class:: LinkType
    :canonical: aiida.common.links.LinkType
 
    Bases: :py:obj:`enum.Enum`
 
-   A simple enum of allowed link types.
+   .. autodoc2-docstring:: aiida.common.links.LinkType
+      :renderer: rst
 
    .. py:attribute:: CREATE
       :canonical: aiida.common.links.LinkType.CREATE
       :value: 'create'
 
+      .. autodoc2-docstring:: aiida.common.links.LinkType.CREATE
+         :renderer: rst
+
    .. py:attribute:: RETURN
       :canonical: aiida.common.links.LinkType.RETURN
       :value: 'return'
+
+      .. autodoc2-docstring:: aiida.common.links.LinkType.RETURN
+         :renderer: rst
 
    .. py:attribute:: INPUT_CALC
       :canonical: aiida.common.links.LinkType.INPUT_CALC
       :value: 'input_calc'
 
+      .. autodoc2-docstring:: aiida.common.links.LinkType.INPUT_CALC
+         :renderer: rst
+
    .. py:attribute:: INPUT_WORK
       :canonical: aiida.common.links.LinkType.INPUT_WORK
       :value: 'input_work'
+
+      .. autodoc2-docstring:: aiida.common.links.LinkType.INPUT_WORK
+         :renderer: rst
 
    .. py:attribute:: CALL_CALC
       :canonical: aiida.common.links.LinkType.CALL_CALC
       :value: 'call_calc'
 
+      .. autodoc2-docstring:: aiida.common.links.LinkType.CALL_CALC
+         :renderer: rst
+
    .. py:attribute:: CALL_WORK
       :canonical: aiida.common.links.LinkType.CALL_WORK
       :value: 'call_work'
+
+      .. autodoc2-docstring:: aiida.common.links.LinkType.CALL_WORK
+         :renderer: rst
 
 .. py:exception:: LoadingEntryPointError()
    :canonical: aiida.common.exceptions.LoadingEntryPointError
 
    Bases: :py:obj:`aiida.common.exceptions.EntryPointError`
 
-   Raised when the resource corresponding to requested entry point cannot be imported.
+   .. autodoc2-docstring:: aiida.common.exceptions.LoadingEntryPointError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.LoadingEntryPointError.__init__
+      :renderer: rst
 
 .. py:exception:: LockedProfileError()
    :canonical: aiida.common.exceptions.LockedProfileError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised if attempting to access a locked profile
+   .. autodoc2-docstring:: aiida.common.exceptions.LockedProfileError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.LockedProfileError.__init__
+      :renderer: rst
 
 .. py:exception:: LockingProfileError()
    :canonical: aiida.common.exceptions.LockingProfileError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised if the profile can`t be locked
+   .. autodoc2-docstring:: aiida.common.exceptions.LockingProfileError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.LockingProfileError.__init__
+      :renderer: rst
 
 .. py:exception:: MissingConfigurationError()
    :canonical: aiida.common.exceptions.MissingConfigurationError
 
    Bases: :py:obj:`aiida.common.exceptions.ConfigurationError`
 
-   Configuration error raised when the configuration file is missing.
+   .. autodoc2-docstring:: aiida.common.exceptions.MissingConfigurationError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.MissingConfigurationError.__init__
+      :renderer: rst
 
 .. py:exception:: MissingEntryPointError()
    :canonical: aiida.common.exceptions.MissingEntryPointError
 
    Bases: :py:obj:`aiida.common.exceptions.EntryPointError`
 
-   Raised when the requested entry point is not registered with the entry point manager.
+   .. autodoc2-docstring:: aiida.common.exceptions.MissingEntryPointError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.MissingEntryPointError.__init__
+      :renderer: rst
 
 .. py:exception:: ModificationNotAllowed()
    :canonical: aiida.common.exceptions.ModificationNotAllowed
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when the user tries to modify a field, object, property, ... that should not
-   be modified.
+   .. autodoc2-docstring:: aiida.common.exceptions.ModificationNotAllowed
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.ModificationNotAllowed.__init__
+      :renderer: rst
 
 .. py:exception:: MultipleEntryPointError()
    :canonical: aiida.common.exceptions.MultipleEntryPointError
 
    Bases: :py:obj:`aiida.common.exceptions.EntryPointError`
 
-   Raised when the requested entry point cannot uniquely be resolved by the entry point manager.
+   .. autodoc2-docstring:: aiida.common.exceptions.MultipleEntryPointError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.MultipleEntryPointError.__init__
+      :renderer: rst
 
 .. py:exception:: MultipleObjectsError()
    :canonical: aiida.common.exceptions.MultipleObjectsError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when more than one entity is found in the DB, but only one was
-   expected.
+   .. autodoc2-docstring:: aiida.common.exceptions.MultipleObjectsError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.MultipleObjectsError.__init__
+      :renderer: rst
 
 .. py:exception:: NotExistent()
    :canonical: aiida.common.exceptions.NotExistent
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when the required entity does not exist.
+   .. autodoc2-docstring:: aiida.common.exceptions.NotExistent
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.NotExistent.__init__
+      :renderer: rst
 
 .. py:exception:: NotExistentAttributeError()
    :canonical: aiida.common.exceptions.NotExistentAttributeError
 
    Bases: :py:obj:`AttributeError`, :py:obj:`aiida.common.exceptions.NotExistent`
 
-   Raised when the required entity does not exist, when fetched as an attribute.
+   .. autodoc2-docstring:: aiida.common.exceptions.NotExistentAttributeError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.NotExistentAttributeError.__init__
+      :renderer: rst
 
 .. py:exception:: NotExistentKeyError()
    :canonical: aiida.common.exceptions.NotExistentKeyError
 
    Bases: :py:obj:`KeyError`, :py:obj:`aiida.common.exceptions.NotExistent`
 
-   Raised when the required entity does not exist, when fetched as a dictionary key.
+   .. autodoc2-docstring:: aiida.common.exceptions.NotExistentKeyError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.NotExistentKeyError.__init__
+      :renderer: rst
 
 .. py:exception:: OutputParsingError()
    :canonical: aiida.common.exceptions.OutputParsingError
 
    Bases: :py:obj:`aiida.common.exceptions.ParsingError`
 
-   Can be raised by a Parser when it fails to parse the output generated by a `CalcJob` process.
+   .. autodoc2-docstring:: aiida.common.exceptions.OutputParsingError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.OutputParsingError.__init__
+      :renderer: rst
 
 .. py:exception:: ParsingError()
    :canonical: aiida.common.exceptions.ParsingError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Generic error raised when there is a parsing error
+   .. autodoc2-docstring:: aiida.common.exceptions.ParsingError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.ParsingError.__init__
+      :renderer: rst
 
 .. py:exception:: PluginInternalError()
    :canonical: aiida.common.exceptions.PluginInternalError
 
    Bases: :py:obj:`aiida.common.exceptions.InternalError`
 
-   Error raised when there is an internal error which is due to a plugin
-   and not to the AiiDA infrastructure.
+   .. autodoc2-docstring:: aiida.common.exceptions.PluginInternalError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.PluginInternalError.__init__
+      :renderer: rst
 
 .. py:exception:: ProfileConfigurationError()
    :canonical: aiida.common.exceptions.ProfileConfigurationError
 
    Bases: :py:obj:`aiida.common.exceptions.ConfigurationError`
 
-   Configuration error raised when a wrong/inexistent profile is requested.
+   .. autodoc2-docstring:: aiida.common.exceptions.ProfileConfigurationError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.ProfileConfigurationError.__init__
+      :renderer: rst
 
 .. py:class:: ProgressReporterAbstract(*, total: int, desc: typing.Optional[str] = None, **kwargs: typing.Any)
    :canonical: aiida.common.progress_reporter.ProgressReporterAbstract
 
-   An abstract class for incrementing a progress reporter.
-
-   This class provides the base interface for any `ProgressReporter` class.
-
-   Example Usage::
-
-       with ProgressReporter(total=10, desc="A process:") as progress:
-           for i in range(10):
-               progress.set_description_str(f"A process: {i}")
-               progress.update()
-
+   .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialise the progress reporting contextmanager.
-
-   :param total: The number of expected iterations.
-   :param desc: A description of the process
-
+   .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract.__init__
+      :renderer: rst
 
    .. py:property:: total
       :canonical: aiida.common.progress_reporter.ProgressReporterAbstract.total
       :type: int
 
-      Return the total iterations expected.
+      .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract.total
+         :renderer: rst
 
    .. py:property:: desc
       :canonical: aiida.common.progress_reporter.ProgressReporterAbstract.desc
       :type: typing.Optional[str]
 
-      Return the description of the process.
+      .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract.desc
+         :renderer: rst
 
    .. py:property:: n
       :canonical: aiida.common.progress_reporter.ProgressReporterAbstract.n
       :type: int
 
-      Return the current iteration.
+      .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract.n
+         :renderer: rst
 
    .. py:method:: __enter__() -> aiida.common.progress_reporter.ProgressReporterAbstract
       :canonical: aiida.common.progress_reporter.ProgressReporterAbstract.__enter__
 
-      Enter the contextmanager.
+      .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract.__enter__
+         :renderer: rst
 
    .. py:method:: __exit__(exctype: typing.Optional[typing.Type[BaseException]], excinst: typing.Optional[BaseException], exctb: typing.Optional[types.TracebackType])
       :canonical: aiida.common.progress_reporter.ProgressReporterAbstract.__exit__
 
-      Exit the contextmanager.
+      .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract.__exit__
+         :renderer: rst
 
    .. py:method:: set_description_str(text: typing.Optional[str] = None, refresh: bool = True)
       :canonical: aiida.common.progress_reporter.ProgressReporterAbstract.set_description_str
 
-      Set the text shown by the progress reporter.
-
-      :param text: The text to show
-      :param refresh: Force refresh of the progress reporter
-
+      .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract.set_description_str
+         :renderer: rst
 
    .. py:method:: update(n: int = 1)
       :canonical: aiida.common.progress_reporter.ProgressReporterAbstract.update
 
-      Update the progress counter.
-
-      :param n: Increment to add to the internal counter of iterations
-
+      .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract.update
+         :renderer: rst
 
    .. py:method:: reset(total: typing.Optional[int] = None)
       :canonical: aiida.common.progress_reporter.ProgressReporterAbstract.reset
 
-      Resets current iterations to 0.
-
-      :param total: If not None, update number of expected iterations.
-
+      .. autodoc2-docstring:: aiida.common.progress_reporter.ProgressReporterAbstract.reset
+         :renderer: rst
 
 .. py:exception:: RemoteOperationError()
    :canonical: aiida.common.exceptions.RemoteOperationError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when an error in a remote operation occurs, as in a failed kill()
-   of a scheduler job.
+   .. autodoc2-docstring:: aiida.common.exceptions.RemoteOperationError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.RemoteOperationError.__init__
+      :renderer: rst
 
 .. py:class:: StashMode
    :canonical: aiida.common.datastructures.StashMode
 
    Bases: :py:obj:`enum.Enum`
 
-   Mode to use when stashing files from the working directory of a completed calculation job for safekeeping.
+   .. autodoc2-docstring:: aiida.common.datastructures.StashMode
+      :renderer: rst
 
    .. py:attribute:: COPY
       :canonical: aiida.common.datastructures.StashMode.COPY
       :value: 'copy'
+
+      .. autodoc2-docstring:: aiida.common.datastructures.StashMode.COPY
+         :renderer: rst
 
 .. py:exception:: StorageMigrationError()
    :canonical: aiida.common.exceptions.StorageMigrationError
 
    Bases: :py:obj:`aiida.common.exceptions.DatabaseMigrationError`
 
-   Raised if a critical error is encountered during a storage migration.
+   .. autodoc2-docstring:: aiida.common.exceptions.StorageMigrationError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.StorageMigrationError.__init__
+      :renderer: rst
 
 .. py:exception:: StoringNotAllowed()
    :canonical: aiida.common.exceptions.StoringNotAllowed
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when the user tries to store an unstorable node (e.g. a base Node class)
+   .. autodoc2-docstring:: aiida.common.exceptions.StoringNotAllowed
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.StoringNotAllowed.__init__
+      :renderer: rst
 
 .. py:data:: TQDM_BAR_FORMAT
    :canonical: aiida.common.progress_reporter.TQDM_BAR_FORMAT
    :value: '{desc:40.40}{percentage:6.1f}%|{bar}| {n_fmt}/{total_fmt}'
+
+   .. autodoc2-docstring:: aiida.common.progress_reporter.TQDM_BAR_FORMAT
+      :renderer: rst
 
 .. py:exception:: TestsNotAllowedError()
    :canonical: aiida.common.exceptions.TestsNotAllowedError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when tests are required to be run/loaded, but we are not in a testing environment.
-
-   This is to prevent data loss.
+   .. autodoc2-docstring:: aiida.common.exceptions.TestsNotAllowedError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.TestsNotAllowedError.__init__
+      :renderer: rst
 
 .. py:exception:: TransportTaskException()
    :canonical: aiida.common.exceptions.TransportTaskException
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when a TransportTask, an task to be completed by the engine that requires transport, fails
+   .. autodoc2-docstring:: aiida.common.exceptions.TransportTaskException
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.TransportTaskException.__init__
+      :renderer: rst
 
 .. py:exception:: UniquenessError()
    :canonical: aiida.common.exceptions.UniquenessError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when the user tries to violate a uniqueness constraint (on the
-   DB, for instance).
+   .. autodoc2-docstring:: aiida.common.exceptions.UniquenessError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.UniquenessError.__init__
+      :renderer: rst
 
 .. py:exception:: UnsupportedSpeciesError()
    :canonical: aiida.common.exceptions.UnsupportedSpeciesError
 
    Bases: :py:obj:`ValueError`
 
-   Raised when StructureData operations are fed species that are not supported by AiiDA such as Deuterium
+   .. autodoc2-docstring:: aiida.common.exceptions.UnsupportedSpeciesError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.UnsupportedSpeciesError.__init__
+      :renderer: rst
 
 .. py:exception:: ValidationError()
    :canonical: aiida.common.exceptions.ValidationError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Error raised when there is an error during the validation phase
-   of a property.
+   .. autodoc2-docstring:: aiida.common.exceptions.ValidationError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.common.exceptions.ValidationError.__init__
+      :renderer: rst
 
 .. py:function:: create_callback(progress_reporter: aiida.common.progress_reporter.ProgressReporterAbstract) -> typing.Callable[[str, typing.Any], None]
    :canonical: aiida.common.progress_reporter.create_callback
 
-   Create a callback function to update the progress reporter.
-
-   :returns: a callback to report on the process, ``callback(action, value)``,
-       with the following callback signatures:
-
-       - ``callback('init', {'total': <int>, 'description': <str>})``,
-           to reset the progress with a new total iterations and description
-       - ``callback('update', <int>)``,
-           to update the progress by a certain number of iterations
-
+   .. autodoc2-docstring:: aiida.common.progress_reporter.create_callback
+      :renderer: rst
 
 .. py:function:: get_progress_reporter() -> typing.Type[aiida.common.progress_reporter.ProgressReporterAbstract]
    :canonical: aiida.common.progress_reporter.get_progress_reporter
 
-   Return the progress reporter
-
-   Example Usage::
-
-       with get_progress_reporter()(total=10, desc="A process:") as progress:
-           for i in range(10):
-               progress.set_description_str(f"A process: {i}")
-               progress.update()
-
+   .. autodoc2-docstring:: aiida.common.progress_reporter.get_progress_reporter
+      :renderer: rst
 
 .. py:function:: override_log_level(level=logging.CRITICAL)
    :canonical: aiida.common.log.override_log_level
 
-   Temporarily adjust the log-level of logger.
+   .. autodoc2-docstring:: aiida.common.log.override_log_level
+      :renderer: rst
 
 .. py:function:: set_progress_bar_tqdm(bar_format: typing.Optional[str] = TQDM_BAR_FORMAT, leave: typing.Optional[bool] = False, **kwargs: typing.Any)
    :canonical: aiida.common.progress_reporter.set_progress_bar_tqdm
 
-   Set a `tqdm <https://github.com/tqdm/tqdm>`__ implementation of the progress reporter interface.
-
-   See :func:`~aiida.common.progress_reporter.set_progress_reporter` for details.
-
-   :param bar_format: Specify a custom bar string format.
-   :param leave: If True, keeps all traces of the progressbar upon termination of iteration.
-           If `None`, will leave only if `position` is `0`.
-   :param kwargs: pass to the tqdm init
-
+   .. autodoc2-docstring:: aiida.common.progress_reporter.set_progress_bar_tqdm
+      :renderer: rst
 
 .. py:function:: set_progress_reporter(reporter: typing.Optional[typing.Type[aiida.common.progress_reporter.ProgressReporterAbstract]] = None, **kwargs: typing.Any)
    :canonical: aiida.common.progress_reporter.set_progress_reporter
 
-   Set the progress reporter implementation
-
-   :param reporter: A progress reporter for a process.  If None, reset to ``ProgressReporterNull``.
-
-   :param kwargs: If present, set a partial function with these kwargs
-
-   The reporter should be a context manager that implements the
-   :func:`~aiida.common.progress_reporter.ProgressReporterAbstract` interface.
-
-   Example Usage::
-
-       set_progress_reporter(ProgressReporterNull)
-       with get_progress_reporter()(total=10, desc="A process:") as progress:
-           for i in range(10):
-               progress.set_description_str(f"A process: {i}")
-               progress.update()
-
+   .. autodoc2-docstring:: aiida.common.progress_reporter.set_progress_reporter
+      :renderer: rst
 
 .. py:function:: validate_link_label(link_label)
    :canonical: aiida.common.links.validate_link_label
 
-   Validate the given link label.
-
-   Valid link labels adhere to the following restrictions:
-
-       * Has to be a valid python identifier
-       * Can only contain alphanumeric characters and underscores
-       * Can not start or end with an underscore
-
-   :raises TypeError: if the link label is not a string type
-   :raises ValueError: if the link label is invalid
+   .. autodoc2-docstring:: aiida.common.links.validate_link_label
+      :renderer: rst

--- a/docs/apidocs/aiida/aiida.engine.rst
+++ b/docs/apidocs/aiida/aiida.engine.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Module with all the internals that make up the engine of `aiida-core`.
+.. autodoc2-docstring:: aiida.engine
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -20,63 +22,121 @@ Classes
    :align: left
 
    * - :py:obj:`AiiDAPersister <aiida.engine.persistence.AiiDAPersister>`
-     - Persister to take saved process instance states and persisting them to the database.
+     - .. autodoc2-docstring:: aiida.engine.persistence.AiiDAPersister
+          :renderer: rst
+          :summary:
    * - :py:obj:`Awaitable <aiida.engine.processes.workchains.awaitable.Awaitable>`
-     - An attribute dictionary that represents an action that a Process could be waiting for to finish.
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.Awaitable
+          :renderer: rst
+          :summary:
    * - :py:obj:`AwaitableAction <aiida.engine.processes.workchains.awaitable.AwaitableAction>`
-     - Enum that describes the action to be taken for a given awaitable.
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.AwaitableAction
+          :renderer: rst
+          :summary:
    * - :py:obj:`AwaitableTarget <aiida.engine.processes.workchains.awaitable.AwaitableTarget>`
-     - Enum that describes the class of the target a given awaitable.
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.AwaitableTarget
+          :renderer: rst
+          :summary:
    * - :py:obj:`BaseRestartWorkChain <aiida.engine.processes.workchains.restart.BaseRestartWorkChain>`
-     - Base restart work chain.
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcJob <aiida.engine.processes.calcjobs.calcjob.CalcJob>`
-     - Implementation of the CalcJob process.
+     - .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcJobImporter <aiida.engine.processes.calcjobs.importer.CalcJobImporter>`
-     - An abstract class, to define an importer for computations completed outside of AiiDA.
+     - .. autodoc2-docstring:: aiida.engine.processes.calcjobs.importer.CalcJobImporter
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcJobOutputPort <aiida.engine.processes.ports.CalcJobOutputPort>`
-     - Sub class of plumpy.OutputPort which adds the `_pass_to_parser` attribute.
+     - .. autodoc2-docstring:: aiida.engine.processes.ports.CalcJobOutputPort
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcJobProcessSpec <aiida.engine.processes.process_spec.CalcJobProcessSpec>`
-     - Process spec intended for the `CalcJob` process class.
+     - .. autodoc2-docstring:: aiida.engine.processes.process_spec.CalcJobProcessSpec
+          :renderer: rst
+          :summary:
    * - :py:obj:`DaemonClient <aiida.engine.daemon.client.DaemonClient>`
-     - Client to interact with the daemon.
+     - .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient
+          :renderer: rst
+          :summary:
    * - :py:obj:`ExitCode <aiida.engine.processes.exit_code.ExitCode>`
-     - A simple data class to define an exit code for a :class:`~aiida.engine.processes.process.Process`.
+     - .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCode
+          :renderer: rst
+          :summary:
    * - :py:obj:`ExitCodesNamespace <aiida.engine.processes.exit_code.ExitCodesNamespace>`
-     - A namespace of `ExitCode` instances that can be accessed through getattr as well as getitem.
+     - .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCodesNamespace
+          :renderer: rst
+          :summary:
    * - :py:obj:`FunctionProcess <aiida.engine.processes.functions.FunctionProcess>`
-     - Function process class used for turning functions into a Process
+     - .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess
+          :renderer: rst
+          :summary:
    * - :py:obj:`InputPort <aiida.engine.processes.ports.InputPort>`
-     - Sub class of plumpy.InputPort which mixes in the WithSerialize and WithNonDb mixins to support automatic value serialization to database storable types and support non database storable input types as well.
+     - .. autodoc2-docstring:: aiida.engine.processes.ports.InputPort
+          :renderer: rst
+          :summary:
    * - :py:obj:`InterruptableFuture <aiida.engine.utils.InterruptableFuture>`
-     - A future that can be interrupted by calling `interrupt`.
+     - .. autodoc2-docstring:: aiida.engine.utils.InterruptableFuture
+          :renderer: rst
+          :summary:
    * - :py:obj:`JobManager <aiida.engine.processes.calcjobs.manager.JobManager>`
-     - A manager for :py:class:`~aiida.engine.processes.calcjobs.calcjob.CalcJob` submitted to ``Computer`` instances.
+     - .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobManager
+          :renderer: rst
+          :summary:
    * - :py:obj:`JobsList <aiida.engine.processes.calcjobs.manager.JobsList>`
-     - Manager of calculation jobs submitted with a specific ``AuthInfo``, i.e. computer configured for a specific user.
+     - .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList
+          :renderer: rst
+          :summary:
    * - :py:obj:`ObjectLoader <aiida.engine.persistence.ObjectLoader>`
-     - Custom object loader for `aiida-core`.
+     - .. autodoc2-docstring:: aiida.engine.persistence.ObjectLoader
+          :renderer: rst
+          :summary:
    * - :py:obj:`PortNamespace <aiida.engine.processes.ports.PortNamespace>`
-     - Sub class of plumpy.PortNamespace which implements the serialize method to support automatic recursive serialization of a given mapping onto the ports of the PortNamespace.
+     - .. autodoc2-docstring:: aiida.engine.processes.ports.PortNamespace
+          :renderer: rst
+          :summary:
    * - :py:obj:`Process <aiida.engine.processes.process.Process>`
-     - This class represents an AiiDA process which can be executed and will have full provenance saved in the database.
+     - .. autodoc2-docstring:: aiida.engine.processes.process.Process
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProcessBuilder <aiida.engine.processes.builder.ProcessBuilder>`
-     - A process builder that helps setting up the inputs for creating a new process.
+     - .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilder
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProcessBuilderNamespace <aiida.engine.processes.builder.ProcessBuilderNamespace>`
-     - Input namespace for the `ProcessBuilder`.
+     - .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProcessFuture <aiida.engine.processes.futures.ProcessFuture>`
-     - Future that waits for a process to complete using both polling and listening for broadcast events if possible.
+     - .. autodoc2-docstring:: aiida.engine.processes.futures.ProcessFuture
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProcessHandlerReport <aiida.engine.processes.workchains.utils.ProcessHandlerReport>`
-     - A namedtuple to define a process handler report for a :class:`aiida.engine.BaseRestartWorkChain`.
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.utils.ProcessHandlerReport
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProcessSpec <aiida.engine.processes.process_spec.ProcessSpec>`
-     - Default process spec for process classes defined in `aiida-core`.
+     - .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec
+          :renderer: rst
+          :summary:
    * - :py:obj:`Runner <aiida.engine.runners.Runner>`
-     - Class that can launch processes by running in the current interpreter or by submitting them to the daemon.
+     - .. autodoc2-docstring:: aiida.engine.runners.Runner
+          :renderer: rst
+          :summary:
    * - :py:obj:`WithNonDb <aiida.engine.processes.ports.WithNonDb>`
-     - A mixin that adds support to a port to flag that it should not be stored in the database using the non_db=True flag.
+     - .. autodoc2-docstring:: aiida.engine.processes.ports.WithNonDb
+          :renderer: rst
+          :summary:
    * - :py:obj:`WithSerialize <aiida.engine.processes.ports.WithSerialize>`
-     - A mixin that adds support for a serialization function which is automatically applied on inputs that are not AiiDA data types.
+     - .. autodoc2-docstring:: aiida.engine.processes.ports.WithSerialize
+          :renderer: rst
+          :summary:
    * - :py:obj:`WorkChain <aiida.engine.processes.workchains.workchain.WorkChain>`
-     - The `WorkChain` class is the principle component to implement workflows in AiiDA.
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -86,31 +146,57 @@ Functions
    :align: left
 
    * - :py:obj:`append_ <aiida.engine.processes.workchains.context.append_>`
-     - Convenience function that will construct an Awaitable for a given class instance with the context action set to APPEND. When the awaitable target is completed it will be appended to a list in the context for a key that is to be defined later
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.context.append_
+          :renderer: rst
+          :summary:
    * - :py:obj:`assign_ <aiida.engine.processes.workchains.context.assign_>`
-     - Convenience function that will construct an Awaitable for a given class instance with the context action set to ASSIGN. When the awaitable target is completed it will be assigned to the context for a key that is to be defined later
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.context.assign_
+          :renderer: rst
+          :summary:
    * - :py:obj:`calcfunction <aiida.engine.processes.functions.calcfunction>`
-     - A decorator to turn a standard python function into a calcfunction. Example usage:
+     - .. autodoc2-docstring:: aiida.engine.processes.functions.calcfunction
+          :renderer: rst
+          :summary:
    * - :py:obj:`construct_awaitable <aiida.engine.processes.workchains.awaitable.construct_awaitable>`
-     - Construct an instance of the Awaitable class that will contain the information related to the action to be taken with respect to the context once the awaitable object is completed.
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.construct_awaitable
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_object_loader <aiida.engine.persistence.get_object_loader>`
-     - Return the global AiiDA object loader.
+     - .. autodoc2-docstring:: aiida.engine.persistence.get_object_loader
+          :renderer: rst
+          :summary:
    * - :py:obj:`interruptable_task <aiida.engine.utils.interruptable_task>`
-     - Turn the given coroutine into an interruptable task by turning it into an InterruptableFuture and returning it.
+     - .. autodoc2-docstring:: aiida.engine.utils.interruptable_task
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_process_function <aiida.engine.utils.is_process_function>`
-     - Return whether the given function is a process function
+     - .. autodoc2-docstring:: aiida.engine.utils.is_process_function
+          :renderer: rst
+          :summary:
    * - :py:obj:`process_handler <aiida.engine.processes.workchains.utils.process_handler>`
-     - Decorator to register a :class:`~aiida.engine.BaseRestartWorkChain` instance method as a process handler.
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.utils.process_handler
+          :renderer: rst
+          :summary:
    * - :py:obj:`run <aiida.engine.launch.run>`
-     - Run the process with the supplied inputs in a local runner that will block until the process is completed.
+     - .. autodoc2-docstring:: aiida.engine.launch.run
+          :renderer: rst
+          :summary:
    * - :py:obj:`run_get_node <aiida.engine.launch.run_get_node>`
-     - Run the process with the supplied inputs in a local runner that will block until the process is completed.
+     - .. autodoc2-docstring:: aiida.engine.launch.run_get_node
+          :renderer: rst
+          :summary:
    * - :py:obj:`run_get_pk <aiida.engine.launch.run_get_pk>`
-     - Run the process with the supplied inputs in a local runner that will block until the process is completed.
+     - .. autodoc2-docstring:: aiida.engine.launch.run_get_pk
+          :renderer: rst
+          :summary:
    * - :py:obj:`submit <aiida.engine.launch.submit>`
-     - Submit the process with the supplied inputs to the daemon immediately returning control to the interpreter.
+     - .. autodoc2-docstring:: aiida.engine.launch.submit
+          :renderer: rst
+          :summary:
    * - :py:obj:`workfunction <aiida.engine.processes.functions.workfunction>`
-     - A decorator to turn a standard python function into a workfunction. Example usage:
+     - .. autodoc2-docstring:: aiida.engine.processes.functions.workfunction
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -120,11 +206,17 @@ Data
    :align: left
 
    * - :py:obj:`OutputPort <aiida.engine.processes.ports.OutputPort>`
-     - 
+     - .. autodoc2-docstring:: aiida.engine.processes.ports.OutputPort
+          :renderer: rst
+          :summary:
    * - :py:obj:`PORT_NAMESPACE_SEPARATOR <aiida.engine.processes.ports.PORT_NAMESPACE_SEPARATOR>`
-     - 
+     - .. autodoc2-docstring:: aiida.engine.processes.ports.PORT_NAMESPACE_SEPARATOR
+          :renderer: rst
+          :summary:
    * - :py:obj:`ToContext <aiida.engine.processes.workchains.context.ToContext>`
-     - 
+     - .. autodoc2-docstring:: aiida.engine.processes.workchains.context.ToContext
+          :renderer: rst
+          :summary:
 
 External
 ~~~~~~~~
@@ -134,13 +226,21 @@ External
    :align: left
 
    * - :py:obj:`ProcessState <plumpy.process_states.ProcessState>`
-     - 
+     - .. autodoc2-docstring:: plumpy.process_states.ProcessState
+          :renderer: rst
+          :summary:
    * - :py:obj:`if_ <plumpy.workchains.if_>`
-     - 
+     - .. autodoc2-docstring:: plumpy.workchains.if_
+          :renderer: rst
+          :summary:
    * - :py:obj:`return_ <plumpy.workchains.return_>`
-     - 
+     - .. autodoc2-docstring:: plumpy.workchains.return_
+          :renderer: rst
+          :summary:
    * - :py:obj:`while_ <plumpy.workchains.while_>`
-     - 
+     - .. autodoc2-docstring:: plumpy.workchains.while_
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -150,2609 +250,2175 @@ API
 
    Bases: :py:obj:`plumpy.persistence.Persister`
 
-   Persister to take saved process instance states and persisting them to the database.
+   .. autodoc2-docstring:: aiida.engine.persistence.AiiDAPersister
+      :renderer: rst
 
    .. py:method:: save_checkpoint(process: aiida.engine.processes.process.Process, tag: typing.Optional[str] = None)
       :canonical: aiida.engine.persistence.AiiDAPersister.save_checkpoint
 
-      Persist a Process instance.
-
-      :param process: :class:`aiida.engine.Process`
-      :param tag: optional checkpoint identifier to allow distinguishing multiple checkpoints for the same process
-      :raises: :class:`PersistenceError` Raised if there was a problem saving the checkpoint
+      .. autodoc2-docstring:: aiida.engine.persistence.AiiDAPersister.save_checkpoint
+         :renderer: rst
 
    .. py:method:: load_checkpoint(pid: typing.Hashable, tag: typing.Optional[str] = None) -> plumpy.persistence.Bundle
       :canonical: aiida.engine.persistence.AiiDAPersister.load_checkpoint
 
-      Load a process from a persisted checkpoint by its process id.
-
-      :param pid: the process id of the :class:`plumpy.Process`
-      :param tag: optional checkpoint identifier to allow retrieving a specific sub checkpoint
-      :return: a bundle with the process state
-      :rtype: :class:`plumpy.Bundle`
-      :raises: :class:`PersistenceError` Raised if there was a problem loading the checkpoint
+      .. autodoc2-docstring:: aiida.engine.persistence.AiiDAPersister.load_checkpoint
+         :renderer: rst
 
    .. py:method:: get_checkpoints()
       :canonical: aiida.engine.persistence.AiiDAPersister.get_checkpoints
 
-      Return a list of all the current persisted process checkpoints
-
-      :return: list of PersistedCheckpoint tuples with element containing the process id and optional checkpoint tag.
+      .. autodoc2-docstring:: aiida.engine.persistence.AiiDAPersister.get_checkpoints
+         :renderer: rst
 
    .. py:method:: get_process_checkpoints(pid: typing.Hashable)
       :canonical: aiida.engine.persistence.AiiDAPersister.get_process_checkpoints
 
-      Return a list of all the current persisted process checkpoints for the specified process.
-
-      :param pid: the process pid
-      :return: list of PersistedCheckpoint tuples with element containing the process id and optional checkpoint tag.
+      .. autodoc2-docstring:: aiida.engine.persistence.AiiDAPersister.get_process_checkpoints
+         :renderer: rst
 
    .. py:method:: delete_checkpoint(pid: typing.Hashable, tag: typing.Optional[str] = None) -> None
       :canonical: aiida.engine.persistence.AiiDAPersister.delete_checkpoint
 
-      Delete a persisted process checkpoint, where no error will be raised if the checkpoint does not exist.
-
-      :param pid: the process id of the :class:`plumpy.Process`
-      :param tag: optional checkpoint identifier to allow retrieving a specific sub checkpoint
+      .. autodoc2-docstring:: aiida.engine.persistence.AiiDAPersister.delete_checkpoint
+         :renderer: rst
 
    .. py:method:: delete_process_checkpoints(pid: typing.Hashable)
       :canonical: aiida.engine.persistence.AiiDAPersister.delete_process_checkpoints
 
-      Delete all persisted checkpoints related to the given process id.
-
-      :param pid: the process id of the :class:`aiida.engine.processes.process.Process`
+      .. autodoc2-docstring:: aiida.engine.persistence.AiiDAPersister.delete_process_checkpoints
+         :renderer: rst
 
 .. py:class:: Awaitable
    :canonical: aiida.engine.processes.workchains.awaitable.Awaitable
 
    Bases: :py:obj:`plumpy.utils.AttributesDict`
 
-   An attribute dictionary that represents an action that a Process could be waiting for to finish.
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.Awaitable
+      :renderer: rst
 
 .. py:class:: AwaitableAction
    :canonical: aiida.engine.processes.workchains.awaitable.AwaitableAction
 
    Bases: :py:obj:`enum.Enum`
 
-   Enum that describes the action to be taken for a given awaitable.
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.AwaitableAction
+      :renderer: rst
 
    .. py:attribute:: ASSIGN
       :canonical: aiida.engine.processes.workchains.awaitable.AwaitableAction.ASSIGN
       :value: 'assign'
 
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.AwaitableAction.ASSIGN
+         :renderer: rst
+
    .. py:attribute:: APPEND
       :canonical: aiida.engine.processes.workchains.awaitable.AwaitableAction.APPEND
       :value: 'append'
+
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.AwaitableAction.APPEND
+         :renderer: rst
 
 .. py:class:: AwaitableTarget
    :canonical: aiida.engine.processes.workchains.awaitable.AwaitableTarget
 
    Bases: :py:obj:`enum.Enum`
 
-   Enum that describes the class of the target a given awaitable.
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.AwaitableTarget
+      :renderer: rst
 
    .. py:attribute:: PROCESS
       :canonical: aiida.engine.processes.workchains.awaitable.AwaitableTarget.PROCESS
       :value: 'process'
+
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.AwaitableTarget.PROCESS
+         :renderer: rst
 
 .. py:class:: BaseRestartWorkChain(*args, **kwargs)
    :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain
 
    Bases: :py:obj:`aiida.engine.processes.workchains.workchain.WorkChain`
 
-   Base restart work chain.
-
-   This work chain serves as the starting point for more complex work chains that will be designed to run a sub process
-   that might need multiple restarts to come to a successful end. These restarts may be necessary because a single
-   process run is not sufficient to achieve a fully converged result, or certain errors maybe encountered which
-   are recoverable.
-
-   This work chain implements the most basic functionality to achieve this goal. It will launch the sub process,
-   restarting until it is completed successfully or the maximum number of iterations is reached. After completion of
-   the sub process it will be inspected, and a list of process handlers are called successively. These process handlers
-   are defined as class methods that are decorated with :meth:`~aiida.engine.process_handler`.
-
-   The idea is to sub class this work chain and leverage the generic error handling that is implemented in the few
-   outline methods. The minimally required outline would look something like the following::
-
-       cls.setup
-       while_(cls.should_run_process)(
-           cls.run_process,
-           cls.inspect_process,
-       )
-
-   Each of these methods can of course be overriden but they should be general enough to fit most process cycles. The
-   `run_process` method will take the inputs for the process from the context under the key `inputs`. The user should,
-   therefore, make sure that before the `run_process` method is called, that the to be used inputs are stored under
-   `self.ctx.inputs`. One can update the inputs based on the results from a prior process by calling an outline method
-   just before the `run_process` step, for example::
-
-       cls.setup
-       while_(cls.should_run_process)(
-           cls.prepare_inputs,
-           cls.run_process,
-           cls.inspect_process,
-       )
-
-   Where in the `prepare_calculation` method, the inputs dictionary at `self.ctx.inputs` is updated before the next
-   process will be run with those inputs.
-
-   The `_process_class` attribute should be set to the `Process` class that should be run in the loop.
-   Finally, to define handlers that will be called during the `inspect_process` simply define a class method with the
-   signature `(self, node)` and decorate it with the `process_handler` decorator, for example::
-
-       @process_handler
-       def handle_problem(self, node):
-           if some_problem:
-               self.ctx.inputs = improved_inputs
-               return ProcessHandlerReport()
-
-   The `process_handler` and `ProcessHandlerReport` support various arguments to control the flow of the logic of the
-   `inspect_process`. Refer to their respective documentation for details.
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct the instance.
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.__init__
+      :renderer: rst
 
    .. py:attribute:: _process_class
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain._process_class
       :type: typing.Optional[typing.Type[aiida.engine.processes.Process]]
       :value: None
 
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain._process_class
+         :renderer: rst
+
    .. py:attribute:: _considered_handlers_extra
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain._considered_handlers_extra
       :value: 'considered_handlers'
+
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain._considered_handlers_extra
+         :renderer: rst
 
    .. py:property:: process_class
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.process_class
       :type: typing.Type[aiida.engine.processes.process.Process]
 
-      Return the process class to run in the loop.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.process_class
+         :renderer: rst
 
    .. py:method:: define(spec: aiida.engine.processes.ProcessSpec) -> None
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.define
       :classmethod:
 
-      Define the process specification.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.define
+         :renderer: rst
 
    .. py:method:: setup() -> None
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.setup
 
-      Initialize context variables that are used during the logical flow of the `BaseRestartWorkChain`.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.setup
+         :renderer: rst
 
    .. py:method:: should_run_process() -> bool
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.should_run_process
 
-      Return whether a new process should be run.
-
-      This is the case as long as the last process has not finished successfully and the maximum number of restarts
-      has not yet been exceeded.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.should_run_process
+         :renderer: rst
 
    .. py:method:: run_process() -> aiida.engine.processes.workchains.context.ToContext
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.run_process
 
-      Run the next process, taking the input dictionary from the context at `self.ctx.inputs`.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.run_process
+         :renderer: rst
 
    .. py:method:: inspect_process() -> typing.Optional[aiida.engine.processes.ExitCode]
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.inspect_process
 
-      Analyse the results of the previous process and call the handlers when necessary.
-
-      If the process is excepted or killed, the work chain will abort. Otherwise any attached handlers will be called
-      in order of their specified priority. If the process was failed and no handler returns a report indicating that
-      the error was handled, it is considered an unhandled process failure and the process is relaunched. If this
-      happens twice in a row, the work chain is aborted. In the case that at least one handler returned a report the
-      following matrix determines the logic that is followed:
-
-          Process  Handler    Handler     Action
-          result   report?    exit code
-          -----------------------------------------
-          Success      yes        == 0     Restart
-          Success      yes        != 0     Abort
-          Failed       yes        == 0     Restart
-          Failed       yes        != 0     Abort
-
-      If no handler returned a report and the process finished successfully, the work chain's work is considered done
-      and it will move on to the next step that directly follows the `while` conditional, if there is one defined in
-      the outline.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.inspect_process
+         :renderer: rst
 
    .. py:method:: get_outputs(node) -> typing.Mapping[str, aiida.orm.Node]
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.get_outputs
 
-      Return a mapping of the outputs that should be attached as outputs to the work chain.
-
-      By default this method returns the outputs of the last completed calculation job. This method can be overridden
-      if the implementation wants to update those outputs before attaching them. Make sure that if the content of an
-      output node is modified that this is done through a calcfunction in order to not lose the provenance.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.get_outputs
+         :renderer: rst
 
    .. py:method:: results() -> typing.Optional[aiida.engine.processes.ExitCode]
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.results
 
-      Attach the outputs specified in the output specification from the last completed process.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.results
+         :renderer: rst
 
    .. py:method:: is_process_handler(process_handler_name: typing.Union[str, types.FunctionType]) -> bool
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.is_process_handler
       :classmethod:
 
-      Return whether the given method name corresponds to a process handler of this class.
-
-      :param process_handler_name: string name of the instance method
-      :return: boolean, True if corresponds to process handler, False otherwise
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.is_process_handler
+         :renderer: rst
 
    .. py:method:: get_process_handlers() -> typing.List[types.FunctionType]
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.get_process_handlers
       :classmethod:
 
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.get_process_handlers
+         :renderer: rst
+
    .. py:method:: get_process_handlers_by_priority() -> typing.List[typing.Tuple[int, types.FunctionType]]
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.get_process_handlers_by_priority
 
-      Return list of process handlers where overrides from ``inputs.handler_overrides`` are taken into account.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.get_process_handlers_by_priority
+         :renderer: rst
 
    .. py:method:: on_terminated()
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.on_terminated
 
-      Clean the working directories of all child calculation jobs if `clean_workdir=True` in the inputs.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain.on_terminated
+         :renderer: rst
 
    .. py:method:: _wrap_bare_dict_inputs(port_namespace: aiida.engine.processes.PortNamespace, inputs: typing.Dict[str, typing.Any]) -> aiida.common.AttributeDict
       :canonical: aiida.engine.processes.workchains.restart.BaseRestartWorkChain._wrap_bare_dict_inputs
 
-      Wrap bare dictionaries in `inputs` in a `Dict` node if dictated by the corresponding inputs portnamespace.
-
-      :param port_namespace: a `PortNamespace`
-      :param inputs: a dictionary of inputs intended for submission of the process
-      :return: an attribute dictionary with all bare dictionaries wrapped in `Dict` if dictated by the port namespace
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.restart.BaseRestartWorkChain._wrap_bare_dict_inputs
+         :renderer: rst
 
 .. py:class:: CalcJob(*args, **kwargs)
    :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob
 
    Bases: :py:obj:`aiida.engine.processes.process.Process`
 
-   Implementation of the CalcJob process.
+   .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a CalcJob instance.
-
-   Construct the instance only if it is a sub class of `CalcJob`, otherwise raise `InvalidOperation`.
-
-   See documentation of :class:`aiida.engine.Process`.
+   .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.__init__
+      :renderer: rst
 
    .. py:attribute:: _node_class
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob._node_class
       :value: None
 
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob._node_class
+         :renderer: rst
+
    .. py:attribute:: _spec_class
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob._spec_class
       :value: None
+
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob._spec_class
+         :renderer: rst
 
    .. py:attribute:: link_label_retrieved
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.link_label_retrieved
       :type: str
       :value: 'retrieved'
 
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.link_label_retrieved
+         :renderer: rst
+
    .. py:method:: define(spec: aiida.engine.processes.process_spec.CalcJobProcessSpec) -> None
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.define
       :classmethod:
 
-      Define the process specification, including its inputs, outputs and known exit codes.
-
-      Ports are added to the `metadata` input namespace (inherited from the base Process),
-      and a `code` input Port, a `remote_folder` output Port and retrieved folder output Port
-      are added.
-
-      :param spec: the calculation job process spec to define.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.define
+         :renderer: rst
 
    .. py:method:: spec_options()
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.spec_options
 
-      Return the metadata options port namespace of the process specification of this process.
-
-      :return: options dictionary
-      :rtype: dict
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.spec_options
+         :renderer: rst
 
    .. py:method:: get_importer(entry_point_name: str | None = None) -> aiida.engine.processes.calcjobs.importer.CalcJobImporter
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.get_importer
       :classmethod:
 
-      Load the `CalcJobImporter` associated with this `CalcJob` if it exists.
-
-      By default an importer with the same entry point as the ``CalcJob`` will be loaded, however, this can be
-      overridden using the ``entry_point_name`` argument.
-
-      :param entry_point_name: optional entry point name of a ``CalcJobImporter`` to override the default.
-      :return: the loaded ``CalcJobImporter``.
-      :raises: if no importer class could be loaded.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.get_importer
+         :renderer: rst
 
    .. py:property:: options
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.options
       :type: aiida.common.AttributeDict
 
-      Return the options of the metadata that were specified when this process instance was launched.
-
-      :return: options dictionary
-
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.options
+         :renderer: rst
 
    .. py:method:: get_state_classes() -> typing.Dict[typing.Hashable, typing.Type[plumpy.process_states.State]]
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.get_state_classes
       :classmethod:
 
-      A mapping of the State constants to the corresponding state class.
-
-      Overrides the waiting state with the Calcjob specific version.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.get_state_classes
+         :renderer: rst
 
    .. py:property:: node
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.node
       :type: aiida.orm.CalcJobNode
 
-      Return the ProcessNode used by this process to represent itself in the database.
-
-      :return: instance of sub class of ProcessNode
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.node
+         :renderer: rst
 
    .. py:method:: on_terminated() -> None
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.on_terminated
 
-      Cleanup the node by deleting the calulation job state.
-
-      .. note:: This has to be done before calling the super because that will seal the node after we cannot change it
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.on_terminated
+         :renderer: rst
 
    .. py:method:: run() -> typing.Union[plumpy.process_states.Stop, int, plumpy.process_states.Wait]
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.run
 
-      Run the calculation job.
-
-      This means invoking the `presubmit` and storing the temporary folder in the node's repository. Then we move the
-      process in the `Wait` state, waiting for the `UPLOAD` transport task to be started.
-
-      :returns: the `Stop` command if a dry run, int if the process has an exit status,
-          `Wait` command if the calcjob is to be uploaded
-
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.run
+         :renderer: rst
 
    .. py:method:: prepare_for_submission(folder: aiida.common.folders.Folder) -> aiida.common.datastructures.CalcInfo
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.prepare_for_submission
       :abstractmethod:
 
-      Prepare the calculation for submission.
-
-      Convert the input nodes into the corresponding input files in the format that the code will expect. In addition,
-      define and return a `CalcInfo` instance, which is a simple data structure that contains  information for the
-      engine, for example, on what files to copy to the remote machine, what files to retrieve once it has completed,
-      specific scheduler settings and more.
-
-      :param folder: a temporary folder on the local file system.
-      :returns: the `CalcInfo` instance
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.prepare_for_submission
+         :renderer: rst
 
    .. py:method:: _setup_metadata(metadata: dict) -> None
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob._setup_metadata
 
-      Store the metadata on the ProcessNode.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob._setup_metadata
+         :renderer: rst
 
    .. py:method:: _setup_inputs() -> None
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob._setup_inputs
 
-      Create the links between the input nodes and the ProcessNode that represents this process.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob._setup_inputs
+         :renderer: rst
 
    .. py:method:: _perform_dry_run()
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob._perform_dry_run
 
-      Perform a dry run.
-
-      Instead of performing the normal sequence of steps, just the `presubmit` is called, which will call the method
-      `prepare_for_submission` of the plugin to generate the input files based on the inputs. Then the upload action
-      is called, but using a normal local transport that will copy the files to a local sandbox folder. The generated
-      input script and the absolute path to the sandbox folder are stored in the `dry_run_info` attribute of the node
-      of this process.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob._perform_dry_run
+         :renderer: rst
 
    .. py:method:: _perform_import()
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob._perform_import
 
-      Perform the import of an already completed calculation.
-
-      The inputs contained a `RemoteData` under the key `remote_folder` signalling that this is not supposed to be run
-      as a normal calculation job, but rather the results are already computed outside of AiiDA and merely need to be
-      imported.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob._perform_import
+         :renderer: rst
 
    .. py:method:: parse(retrieved_temporary_folder: typing.Optional[str] = None, existing_exit_code: aiida.engine.processes.exit_code.ExitCode | None = None) -> aiida.engine.processes.exit_code.ExitCode
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.parse
 
-      Parse a retrieved job calculation.
-
-      This is called once it's finished waiting for the calculation to be finished and the data has been retrieved.
-
-      :param retrieved_temporary_folder: The path to the temporary folder
-
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.parse
+         :renderer: rst
 
    .. py:method:: terminate(exit_code: aiida.engine.processes.exit_code.ExitCode) -> aiida.engine.processes.exit_code.ExitCode
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.terminate
       :staticmethod:
 
-      Terminate the process immediately and return the given exit code.
-
-      This method is called by :meth:`aiida.engine.processes.calcjobs.tasks.Waiting.execute` if a monitor triggered
-      the job to be terminated and specified the parsing to be skipped. It will construct the running state and tell
-      this method to be run, which returns the given exit code which will cause the process to be terminated.
-
-      :param exit_code: The exit code to return.
-      :returns: The provided exit code.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.terminate
+         :renderer: rst
 
    .. py:method:: parse_scheduler_output(retrieved: aiida.orm.Node) -> typing.Optional[aiida.engine.processes.exit_code.ExitCode]
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.parse_scheduler_output
 
-      Parse the output of the scheduler if that functionality has been implemented for the plugin.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.parse_scheduler_output
+         :renderer: rst
 
    .. py:method:: parse_retrieved_output(retrieved_temporary_folder: typing.Optional[str] = None) -> typing.Optional[aiida.engine.processes.exit_code.ExitCode]
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.parse_retrieved_output
 
-      Parse the retrieved data by calling the parser plugin if it was defined in the inputs.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.parse_retrieved_output
+         :renderer: rst
 
    .. py:method:: presubmit(folder: aiida.common.folders.Folder) -> aiida.common.datastructures.CalcInfo
       :canonical: aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit
 
-      Prepares the calculation folder with all inputs, ready to be copied to the cluster.
-
-      :param folder: a SandboxFolder that can be used to write calculation input files and the scheduling script.
-
-      :return calcinfo: the CalcInfo object containing the information needed by the daemon to handle operations.
-
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit
+         :renderer: rst
 
 .. py:class:: CalcJobImporter
    :canonical: aiida.engine.processes.calcjobs.importer.CalcJobImporter
 
    Bases: :py:obj:`abc.ABC`
 
-   An abstract class, to define an importer for computations completed outside of AiiDA.
-
-   This class is used to import the results of a calculation that was completed outside of AiiDA.
-   The importer is responsible for parsing the output files of the calculation and creating the
-   corresponding AiiDA nodes.
+   .. autodoc2-docstring:: aiida.engine.processes.calcjobs.importer.CalcJobImporter
+      :renderer: rst
 
    .. py:method:: parse_remote_data(remote_data: aiida.orm.RemoteData, **kwargs) -> typing.Dict[str, typing.Union[aiida.orm.Node, typing.Dict]]
       :canonical: aiida.engine.processes.calcjobs.importer.CalcJobImporter.parse_remote_data
       :abstractmethod:
       :staticmethod:
 
-      Parse the input nodes from the files in the provided ``RemoteData``.
-
-      :param remote_data: the remote data node containing the raw input files.
-      :param kwargs: additional keyword arguments to control the parsing process.
-      :returns: a dictionary with the parsed inputs nodes that match the input spec of the associated ``CalcJob``.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.importer.CalcJobImporter.parse_remote_data
+         :renderer: rst
 
 .. py:class:: CalcJobOutputPort(*args, **kwargs)
    :canonical: aiida.engine.processes.ports.CalcJobOutputPort
 
    Bases: :py:obj:`plumpy.ports.OutputPort`
 
-   Sub class of plumpy.OutputPort which adds the `_pass_to_parser` attribute.
+   .. autodoc2-docstring:: aiida.engine.processes.ports.CalcJobOutputPort
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.engine.processes.ports.CalcJobOutputPort.__init__
+      :renderer: rst
 
    .. py:property:: pass_to_parser
       :canonical: aiida.engine.processes.ports.CalcJobOutputPort.pass_to_parser
       :type: bool
+
+      .. autodoc2-docstring:: aiida.engine.processes.ports.CalcJobOutputPort.pass_to_parser
+         :renderer: rst
 
 .. py:class:: CalcJobProcessSpec()
    :canonical: aiida.engine.processes.process_spec.CalcJobProcessSpec
 
    Bases: :py:obj:`aiida.engine.processes.process_spec.ProcessSpec`
 
-   Process spec intended for the `CalcJob` process class.
+   .. autodoc2-docstring:: aiida.engine.processes.process_spec.CalcJobProcessSpec
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.engine.processes.process_spec.CalcJobProcessSpec.__init__
+      :renderer: rst
 
    .. py:attribute:: OUTPUT_PORT_TYPE
       :canonical: aiida.engine.processes.process_spec.CalcJobProcessSpec.OUTPUT_PORT_TYPE
       :value: None
 
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.CalcJobProcessSpec.OUTPUT_PORT_TYPE
+         :renderer: rst
+
    .. py:property:: default_output_node
       :canonical: aiida.engine.processes.process_spec.CalcJobProcessSpec.default_output_node
       :type: typing.Optional[str]
 
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.CalcJobProcessSpec.default_output_node
+         :renderer: rst
+
 .. py:class:: DaemonClient(profile: aiida.manage.configuration.profile.Profile)
    :canonical: aiida.engine.daemon.client.DaemonClient
 
-   Client to interact with the daemon.
+   .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct an instance for a given profile.
-
-   :param profile: The profile instance.
+   .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.__init__
+      :renderer: rst
 
    .. py:attribute:: DAEMON_ERROR_NOT_RUNNING
       :canonical: aiida.engine.daemon.client.DaemonClient.DAEMON_ERROR_NOT_RUNNING
       :value: 'daemon-error-not-running'
 
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.DAEMON_ERROR_NOT_RUNNING
+         :renderer: rst
+
    .. py:attribute:: DAEMON_ERROR_TIMEOUT
       :canonical: aiida.engine.daemon.client.DaemonClient.DAEMON_ERROR_TIMEOUT
       :value: 'daemon-error-timeout'
+
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.DAEMON_ERROR_TIMEOUT
+         :renderer: rst
 
    .. py:attribute:: _DAEMON_NAME
       :canonical: aiida.engine.daemon.client.DaemonClient._DAEMON_NAME
       :value: 'aiida-{name}'
 
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient._DAEMON_NAME
+         :renderer: rst
+
    .. py:attribute:: _ENDPOINT_PROTOCOL
       :canonical: aiida.engine.daemon.client.DaemonClient._ENDPOINT_PROTOCOL
       :value: None
+
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient._ENDPOINT_PROTOCOL
+         :renderer: rst
 
    .. py:property:: profile
       :canonical: aiida.engine.daemon.client.DaemonClient.profile
       :type: aiida.manage.configuration.profile.Profile
 
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.profile
+         :renderer: rst
+
    .. py:property:: daemon_name
       :canonical: aiida.engine.daemon.client.DaemonClient.daemon_name
       :type: str
 
-      Get the daemon name which is tied to the profile name.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.daemon_name
+         :renderer: rst
 
    .. py:property:: _verdi_bin
       :canonical: aiida.engine.daemon.client.DaemonClient._verdi_bin
       :type: str
 
-      Return the absolute path to the ``verdi`` binary.
-
-      :raises ConfigurationError: If the path to ``verdi`` could not be found
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient._verdi_bin
+         :renderer: rst
 
    .. py:method:: cmd_start_daemon(number_workers: int = 1, foreground: bool = False) -> list[str]
       :canonical: aiida.engine.daemon.client.DaemonClient.cmd_start_daemon
 
-      Return the command to start the daemon.
-
-      :param number_workers: Number of daemon workers to start.
-      :param foreground: Whether to launch the subprocess in the background or not.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.cmd_start_daemon
+         :renderer: rst
 
    .. py:property:: cmd_start_daemon_worker
       :canonical: aiida.engine.daemon.client.DaemonClient.cmd_start_daemon_worker
       :type: list[str]
 
-      Return the command to start a daemon worker process.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.cmd_start_daemon_worker
+         :renderer: rst
 
    .. py:property:: loglevel
       :canonical: aiida.engine.daemon.client.DaemonClient.loglevel
       :type: str
 
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.loglevel
+         :renderer: rst
+
    .. py:property:: virtualenv
       :canonical: aiida.engine.daemon.client.DaemonClient.virtualenv
       :type: str | None
+
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.virtualenv
+         :renderer: rst
 
    .. py:property:: circus_log_file
       :canonical: aiida.engine.daemon.client.DaemonClient.circus_log_file
       :type: str
 
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.circus_log_file
+         :renderer: rst
+
    .. py:property:: circus_pid_file
       :canonical: aiida.engine.daemon.client.DaemonClient.circus_pid_file
       :type: str
+
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.circus_pid_file
+         :renderer: rst
 
    .. py:property:: circus_port_file
       :canonical: aiida.engine.daemon.client.DaemonClient.circus_port_file
       :type: str
 
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.circus_port_file
+         :renderer: rst
+
    .. py:property:: circus_socket_file
       :canonical: aiida.engine.daemon.client.DaemonClient.circus_socket_file
       :type: str
+
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.circus_socket_file
+         :renderer: rst
 
    .. py:property:: circus_socket_endpoints
       :canonical: aiida.engine.daemon.client.DaemonClient.circus_socket_endpoints
       :type: dict[str, str]
 
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.circus_socket_endpoints
+         :renderer: rst
+
    .. py:property:: daemon_log_file
       :canonical: aiida.engine.daemon.client.DaemonClient.daemon_log_file
       :type: str
+
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.daemon_log_file
+         :renderer: rst
 
    .. py:property:: daemon_pid_file
       :canonical: aiida.engine.daemon.client.DaemonClient.daemon_pid_file
       :type: str
 
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.daemon_pid_file
+         :renderer: rst
+
    .. py:method:: get_circus_port() -> int
       :canonical: aiida.engine.daemon.client.DaemonClient.get_circus_port
 
-      Retrieve the port for the circus controller, which should be written to the circus port file.
-
-      If the daemon is running, the port file should exist and contain the port to which the controller is connected.
-      If it cannot be read, a RuntimeError will be thrown. If the daemon is not running, an available port will be
-      requested from the operating system, written to the port file and returned.
-
-      :return: The port for the circus controller.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_circus_port
+         :renderer: rst
 
    .. py:method:: get_env() -> dict[str, str]
       :canonical: aiida.engine.daemon.client.DaemonClient.get_env
       :staticmethod:
 
-      Return the environment for this current process.
-
-      This method is used to pass variables from the environment of the current process to a subprocess that is
-      spawned when the daemon or a daemon worker is started.
-
-      It replicates the ``PATH``, ``PYTHONPATH` and the ``AIIDA_PATH`` environment variables. The ``PYTHONPATH``
-      variable ensures that all Python modules that can be imported by the parent process, are also importable by
-      the subprocess. The ``AIIDA_PATH`` variable ensures that the subprocess will use the same AiiDA configuration
-      directory as used by the current process.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_env
+         :renderer: rst
 
    .. py:method:: get_circus_socket_directory() -> str
       :canonical: aiida.engine.daemon.client.DaemonClient.get_circus_socket_directory
 
-      Retrieve the absolute path of the directory where the circus sockets are stored.
-
-      If the daemon is running, the sockets file should exist and contain the absolute path of the directory that
-      contains the sockets of the circus endpoints. If it cannot be read, a ``RuntimeError`` will be thrown. If the
-      daemon is not running, a temporary directory will be created and its path will be written to the sockets file
-      and returned.
-
-      .. note:: A temporary folder needs to be used for the sockets because UNIX limits the filepath length to
-          107 bytes. Placing the socket files in the AiiDA config folder might seem like the more logical choice
-          but that folder can be placed in an arbitrarily nested directory, the socket filename will exceed the
-          limit. The solution is therefore to always store them in the temporary directory of the operation system
-          whose base path is typically short enough as to not exceed the limit
-
-      :return: The absolute path of directory to write the sockets to.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_circus_socket_directory
+         :renderer: rst
 
    .. py:method:: get_daemon_pid() -> int | None
       :canonical: aiida.engine.daemon.client.DaemonClient.get_daemon_pid
 
-      Get the daemon pid which should be written in the daemon pid file specific to the profile.
-
-      :return: The pid of the circus daemon process or None if not found.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_daemon_pid
+         :renderer: rst
 
    .. py:property:: is_daemon_running
       :canonical: aiida.engine.daemon.client.DaemonClient.is_daemon_running
       :type: bool
 
-      Return whether the daemon is running, which is determined by seeing if the daemon pid file is present.
-
-      :return: True if daemon is running, False otherwise.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.is_daemon_running
+         :renderer: rst
 
    .. py:method:: delete_circus_socket_directory() -> None
       :canonical: aiida.engine.daemon.client.DaemonClient.delete_circus_socket_directory
 
-      Attempt to delete the directory used to store the circus endpoint sockets.
-
-      Will not raise if the directory does not exist.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.delete_circus_socket_directory
+         :renderer: rst
 
    .. py:method:: get_available_port()
       :canonical: aiida.engine.daemon.client.DaemonClient.get_available_port
       :classmethod:
 
-      Get an available port from the operating system.
-
-      :return: A currently available port.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_available_port
+         :renderer: rst
 
    .. py:method:: get_controller_endpoint()
       :canonical: aiida.engine.daemon.client.DaemonClient.get_controller_endpoint
 
-      Get the endpoint string for the circus controller.
-
-      For the IPC protocol a profile specific socket will be used, whereas for the TCP protocol an available port will
-      be found and saved in the profile specific port file.
-
-      :return: The endpoint string.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_controller_endpoint
+         :renderer: rst
 
    .. py:method:: get_pubsub_endpoint()
       :canonical: aiida.engine.daemon.client.DaemonClient.get_pubsub_endpoint
 
-      Get the endpoint string for the circus pubsub endpoint.
-
-      For the IPC protocol a profile specific socket will be used, whereas for the TCP protocol any available port
-      will be used.
-
-      :return: The endpoint string.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_pubsub_endpoint
+         :renderer: rst
 
    .. py:method:: get_stats_endpoint()
       :canonical: aiida.engine.daemon.client.DaemonClient.get_stats_endpoint
 
-      Get the endpoint string for the circus stats endpoint.
-
-      For the IPC protocol a profile specific socket will be used, whereas for the TCP protocol any available port
-      will be used.
-
-      :return: The endpoint string.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_stats_endpoint
+         :renderer: rst
 
    .. py:method:: get_ipc_endpoint(endpoint)
       :canonical: aiida.engine.daemon.client.DaemonClient.get_ipc_endpoint
 
-      Get the ipc endpoint string for a circus daemon endpoint for a given socket.
-
-      :param endpoint: The circus endpoint for which to return a socket.
-      :return: The ipc endpoint string.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_ipc_endpoint
+         :renderer: rst
 
    .. py:method:: get_tcp_endpoint(port=None)
       :canonical: aiida.engine.daemon.client.DaemonClient.get_tcp_endpoint
 
-      Get the tcp endpoint string for a circus daemon endpoint.
-
-      If the port is unspecified, the operating system will be asked for a currently available port.
-
-      :param port: A port to use for the endpoint.
-      :return: The tcp endpoint string.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_tcp_endpoint
+         :renderer: rst
 
    .. py:method:: get_client() -> circus.client.CircusClient
       :canonical: aiida.engine.daemon.client.DaemonClient.get_client
 
-      Return an instance of the CircusClient.
-
-      The endpoint is defined by the controller endpoint, which used the port that was written to the port file upon
-      starting of the daemon.
-
-      :return: CircusClient instance
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_client
+         :renderer: rst
 
    .. py:method:: call_client(command: aiida.engine.daemon.client.JsonDictType) -> aiida.engine.daemon.client.JsonDictType
       :canonical: aiida.engine.daemon.client.DaemonClient.call_client
 
-      Call the client with a specific command.
-
-      Will check whether the daemon is running first by checking for the pid file. When the pid is found yet the call
-      still fails with a timeout, this means the daemon was actually not running and it was terminated unexpectedly
-      causing the pid file to not be cleaned up properly.
-
-      :param command: Command to call the circus client with.
-      :return: The result of the circus client call.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.call_client
+         :renderer: rst
 
    .. py:method:: get_status() -> aiida.engine.daemon.client.JsonDictType
       :canonical: aiida.engine.daemon.client.DaemonClient.get_status
 
-      Get the daemon running status.
-
-      :return: The client call response. If successful, will will contain 'status' key.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_status
+         :renderer: rst
 
    .. py:method:: get_numprocesses() -> aiida.engine.daemon.client.JsonDictType
       :canonical: aiida.engine.daemon.client.DaemonClient.get_numprocesses
 
-      Get the number of running daemon processes.
-
-      :return: The client call response. If successful, will contain 'numprocesses' key.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_numprocesses
+         :renderer: rst
 
    .. py:method:: get_worker_info() -> aiida.engine.daemon.client.JsonDictType
       :canonical: aiida.engine.daemon.client.DaemonClient.get_worker_info
 
-      Get workers statistics for this daemon.
-
-      :return: The client call response. If successful, will contain 'info' key.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_worker_info
+         :renderer: rst
 
    .. py:method:: get_daemon_info() -> aiida.engine.daemon.client.JsonDictType
       :canonical: aiida.engine.daemon.client.DaemonClient.get_daemon_info
 
-      Get statistics about this daemon itself.
-
-      :return: The client call response. If successful, will contain 'info' key.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.get_daemon_info
+         :renderer: rst
 
    .. py:method:: increase_workers(number: int) -> aiida.engine.daemon.client.JsonDictType
       :canonical: aiida.engine.daemon.client.DaemonClient.increase_workers
 
-      Increase the number of workers.
-
-      :param number: The number of workers to add.
-      :return: The client call response.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.increase_workers
+         :renderer: rst
 
    .. py:method:: decrease_workers(number: int) -> aiida.engine.daemon.client.JsonDictType
       :canonical: aiida.engine.daemon.client.DaemonClient.decrease_workers
 
-      Decrease the number of workers.
-
-      :param number: The number of workers to remove.
-      :return: The client call response.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.decrease_workers
+         :renderer: rst
 
    .. py:method:: stop_daemon(wait: bool = True, timeout: int = 5) -> aiida.engine.daemon.client.JsonDictType
       :canonical: aiida.engine.daemon.client.DaemonClient.stop_daemon
 
-      Stop the daemon.
-
-      :param wait: Boolean to indicate whether to wait for the result of the command.
-      :param timeout: Wait this number of seconds for the ``is_daemon_running`` to return ``False`` before raising.
-      :return: The client call response.
-      :raises DaemonException: If ``is_daemon_running`` returns ``True`` after the ``timeout`` has passed.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.stop_daemon
+         :renderer: rst
 
    .. py:method:: restart_daemon(wait: bool) -> aiida.engine.daemon.client.JsonDictType
       :canonical: aiida.engine.daemon.client.DaemonClient.restart_daemon
 
-      Restart the daemon.
-
-      :param wait: Boolean to indicate whether to wait for the result of the command.
-      :return: The client call response.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.restart_daemon
+         :renderer: rst
 
    .. py:method:: start_daemon(number_workers: int = 1, foreground: bool = False, timeout: int = 5) -> None
       :canonical: aiida.engine.daemon.client.DaemonClient.start_daemon
 
-      Start the daemon in a sub process running in the background.
-
-      :param number_workers: Number of daemon workers to start.
-      :param foreground: Whether to launch the subprocess in the background or not.
-      :param timeout: Wait this number of seconds for the ``is_daemon_running`` to return ``True`` before raising.
-      :raises DaemonException: If the daemon fails to start.
-      :raises DaemonException: If the daemon starts but then is unresponsive or in an unexpected state.
-      :raises DaemonException: If ``is_daemon_running`` returns ``False`` after the ``timeout`` has passed.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient.start_daemon
+         :renderer: rst
 
    .. py:method:: _await_condition(condition: typing.Callable, exception: Exception, timeout: int = 5, interval: float = 0.1)
       :canonical: aiida.engine.daemon.client.DaemonClient._await_condition
       :staticmethod:
 
-      Await a condition to evaluate to ``True`` or raise the exception if the timeout is reached.
-
-      :param condition: A callable that is waited for to return ``True``.
-      :param exception: Raise this exception if ``condition`` does not return ``True`` after ``timeout`` seconds.
-      :param timeout: Wait this number of seconds for ``condition`` to return ``True`` before raising.
-      :param interval: The time in seconds to wait between invocations of ``condition``.
-      :raises: The exception provided by ``exception`` if timeout is reached.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient._await_condition
+         :renderer: rst
 
    .. py:method:: _start_daemon(number_workers: int = 1, foreground: bool = False) -> None
       :canonical: aiida.engine.daemon.client.DaemonClient._start_daemon
 
-      Start the daemon.
-
-      .. warning:: This will daemonize the current process and put it in the background. It is most likely not what
-          you want to call if you want to start the daemon from the Python API. Instead you probably will want to use
-          the :meth:`aiida.engine.daemon.client.DaemonClient.start_daemon` function instead.
-
-      :param number_workers: Number of daemon workers to start.
-      :param foreground: Whether to launch the subprocess in the background or not.
+      .. autodoc2-docstring:: aiida.engine.daemon.client.DaemonClient._start_daemon
+         :renderer: rst
 
 .. py:class:: ExitCode
    :canonical: aiida.engine.processes.exit_code.ExitCode
 
    Bases: :py:obj:`typing.NamedTuple`
 
-   A simple data class to define an exit code for a :class:`~aiida.engine.processes.process.Process`.
-
-   When an instance of this class is returned from a `Process._run()` call, it will be interpreted that the `Process`
-   should be terminated and that the exit status and message of the namedtuple should be set to the corresponding
-   attributes of the node.
-
-   :param status: positive integer exit status, where a non-zero value indicated the process failed, default is `0`
-   :param message: optional message with more details about the failure mode
-   :param invalidates_cache: optional flag, indicating that a process should not be used in caching
+   .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCode
+      :renderer: rst
 
    .. py:attribute:: status
       :canonical: aiida.engine.processes.exit_code.ExitCode.status
       :type: int
       :value: 0
 
+      .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCode.status
+         :renderer: rst
+
    .. py:attribute:: message
       :canonical: aiida.engine.processes.exit_code.ExitCode.message
       :type: typing.Optional[str]
       :value: None
+
+      .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCode.message
+         :renderer: rst
 
    .. py:attribute:: invalidates_cache
       :canonical: aiida.engine.processes.exit_code.ExitCode.invalidates_cache
       :type: bool
       :value: False
 
+      .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCode.invalidates_cache
+         :renderer: rst
+
    .. py:method:: format(**kwargs: str) -> aiida.engine.processes.exit_code.ExitCode
       :canonical: aiida.engine.processes.exit_code.ExitCode.format
 
-      Create a clone of this exit code where the template message is replaced by the keyword arguments.
-
-      :param kwargs: replacement parameters for the template message
-
+      .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCode.format
+         :renderer: rst
 
 .. py:class:: ExitCodesNamespace(dictionary=None)
    :canonical: aiida.engine.processes.exit_code.ExitCodesNamespace
 
    Bases: :py:obj:`aiida.common.extendeddicts.AttributeDict`
 
-   A namespace of `ExitCode` instances that can be accessed through getattr as well as getitem.
-
-   Additionally, the collection can be called with an identifier, that can either reference the integer `status` of the
-   `ExitCode` that needs to be retrieved or the key in the collection.
+   .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCodesNamespace
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCodesNamespace.__init__
+      :renderer: rst
 
    .. py:method:: __call__(identifier: typing.Union[int, str]) -> aiida.engine.processes.exit_code.ExitCode
       :canonical: aiida.engine.processes.exit_code.ExitCodesNamespace.__call__
 
-      Return a specific exit code identified by either its exit status or label.
-
-      :param identifier: the identifier of the exit code. If the type is integer, it will be interpreted as the exit
-          code status, otherwise it be interpreted as the exit code label
-
-      :returns: an `ExitCode` instance
-
-      :raises ValueError: if no exit code with the given label is defined for this process
+      .. autodoc2-docstring:: aiida.engine.processes.exit_code.ExitCodesNamespace.__call__
+         :renderer: rst
 
 .. py:class:: FunctionProcess(*args, **kwargs)
    :canonical: aiida.engine.processes.functions.FunctionProcess
 
    Bases: :py:obj:`aiida.engine.processes.process.Process`
 
-   Function process class used for turning functions into a Process
+   .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess.__init__
+      :renderer: rst
 
    .. py:attribute:: _func_args
       :canonical: aiida.engine.processes.functions.FunctionProcess._func_args
       :type: typing.Sequence[str]
       :value: ()
 
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess._func_args
+         :renderer: rst
+
    .. py:method:: _func(*_args, **_kwargs) -> dict
       :canonical: aiida.engine.processes.functions.FunctionProcess._func
       :staticmethod:
 
-      This is used internally to store the actual function that is being
-      wrapped and will be replaced by the build method.
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess._func
+         :renderer: rst
 
    .. py:method:: build(func: typing.Callable[..., typing.Any], node_class: typing.Type[aiida.orm.ProcessNode]) -> typing.Type[aiida.engine.processes.functions.FunctionProcess]
       :canonical: aiida.engine.processes.functions.FunctionProcess.build
       :staticmethod:
 
-      Build a Process from the given function.
-
-      All function arguments will be assigned as process inputs. If keyword arguments are specified then
-      these will also become inputs.
-
-      :param func: The function to build a process from
-      :param node_class: Provide a custom node class to be used, has to be constructable with no arguments. It has to
-          be a sub class of `ProcessNode` and the mixin :class:`~aiida.orm.utils.mixins.FunctionCalculationMixin`.
-
-      :return: A Process class that represents the function
-
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess.build
+         :renderer: rst
 
    .. py:method:: validate_inputs(*args: typing.Any, **kwargs: typing.Any) -> None
       :canonical: aiida.engine.processes.functions.FunctionProcess.validate_inputs
       :classmethod:
 
-      Validate the positional and keyword arguments passed in the function call.
-
-      :raises TypeError: if more positional arguments are passed than the function defines
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess.validate_inputs
+         :renderer: rst
 
    .. py:method:: create_inputs(*args: typing.Any, **kwargs: typing.Any) -> typing.Dict[str, typing.Any]
       :canonical: aiida.engine.processes.functions.FunctionProcess.create_inputs
       :classmethod:
 
-      Create the input args for the FunctionProcess.
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess.create_inputs
+         :renderer: rst
 
    .. py:method:: args_to_dict(*args: typing.Any) -> typing.Dict[str, typing.Any]
       :canonical: aiida.engine.processes.functions.FunctionProcess.args_to_dict
       :classmethod:
 
-      Create an input dictionary (of form label -> value) from supplied args.
-
-      :param args: The values to use for the dictionary
-
-      :return: A label -> value dictionary
-
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess.args_to_dict
+         :renderer: rst
 
    .. py:method:: get_or_create_db_record() -> aiida.orm.ProcessNode
       :canonical: aiida.engine.processes.functions.FunctionProcess.get_or_create_db_record
       :classmethod:
 
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess.get_or_create_db_record
+         :renderer: rst
+
    .. py:property:: process_class
       :canonical: aiida.engine.processes.functions.FunctionProcess.process_class
       :type: typing.Callable[..., typing.Any]
 
-      Return the class that represents this Process, for the FunctionProcess this is the function itself.
-
-      For a standard Process or sub class of Process, this is the class itself. However, for legacy reasons,
-      the Process class is a wrapper around another class. This function returns that original class, i.e. the
-      class that really represents what was being executed.
-
-      :return: A Process class that represents the function
-
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess.process_class
+         :renderer: rst
 
    .. py:method:: execute() -> typing.Optional[typing.Dict[str, typing.Any]]
       :canonical: aiida.engine.processes.functions.FunctionProcess.execute
 
-      Execute the process.
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess.execute
+         :renderer: rst
 
    .. py:method:: _setup_db_record() -> None
       :canonical: aiida.engine.processes.functions.FunctionProcess._setup_db_record
 
-      Set up the database record for the process.
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess._setup_db_record
+         :renderer: rst
 
    .. py:method:: run() -> typing.Optional[aiida.engine.processes.exit_code.ExitCode]
       :canonical: aiida.engine.processes.functions.FunctionProcess.run
 
-      Run the process.
+      .. autodoc2-docstring:: aiida.engine.processes.functions.FunctionProcess.run
+         :renderer: rst
 
 .. py:class:: InputPort(*args, **kwargs)
    :canonical: aiida.engine.processes.ports.InputPort
 
    Bases: :py:obj:`aiida.engine.processes.ports.WithSerialize`, :py:obj:`aiida.engine.processes.ports.WithNonDb`, :py:obj:`plumpy.ports.InputPort`
 
-   Sub class of plumpy.InputPort which mixes in the WithSerialize and WithNonDb mixins to support automatic
-   value serialization to database storable types and support non database storable input types as well.
+   .. autodoc2-docstring:: aiida.engine.processes.ports.InputPort
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Override the constructor to check the type of the default if set and warn if not immutable.
+   .. autodoc2-docstring:: aiida.engine.processes.ports.InputPort.__init__
+      :renderer: rst
 
    .. py:method:: get_description() -> typing.Dict[str, str]
       :canonical: aiida.engine.processes.ports.InputPort.get_description
 
-      Return a description of the InputPort, which will be a dictionary of its attributes
-
-      :returns: a dictionary of the stringified InputPort attributes
+      .. autodoc2-docstring:: aiida.engine.processes.ports.InputPort.get_description
+         :renderer: rst
 
 .. py:class:: InterruptableFuture(*, loop=None)
    :canonical: aiida.engine.utils.InterruptableFuture
 
    Bases: :py:obj:`asyncio.Future`
 
-   A future that can be interrupted by calling `interrupt`.
+   .. autodoc2-docstring:: aiida.engine.utils.InterruptableFuture
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize the future.
-
-   The optional event_loop argument allows explicitly setting the event
-   loop object used by the future. If it's not provided, the future uses
-   the default event loop.
+   .. autodoc2-docstring:: aiida.engine.utils.InterruptableFuture.__init__
+      :renderer: rst
 
    .. py:method:: interrupt(reason: Exception) -> None
       :canonical: aiida.engine.utils.InterruptableFuture.interrupt
 
-      This method should be called to interrupt the coroutine represented by this InterruptableFuture.
+      .. autodoc2-docstring:: aiida.engine.utils.InterruptableFuture.interrupt
+         :renderer: rst
 
    .. py:method:: with_interrupt(coro: typing.Awaitable[typing.Any]) -> typing.Any
       :canonical: aiida.engine.utils.InterruptableFuture.with_interrupt
       :async:
 
-      return result of a coroutine which will be interrupted if this future is interrupted ::
-
-          import asyncio
-          loop = asyncio.get_event_loop()
-
-          interruptable = InterutableFuture()
-          loop.call_soon(interruptable.interrupt, RuntimeError("STOP"))
-          loop.run_until_complete(interruptable.with_interrupt(asyncio.sleep(2.)))
-          >>> RuntimeError: STOP
-
-
-      :param coro: The coroutine that can be interrupted
-      :return: The result of the coroutine
+      .. autodoc2-docstring:: aiida.engine.utils.InterruptableFuture.with_interrupt
+         :renderer: rst
 
 .. py:class:: JobManager(transport_queue: aiida.engine.transports.TransportQueue)
    :canonical: aiida.engine.processes.calcjobs.manager.JobManager
 
-   A manager for :py:class:`~aiida.engine.processes.calcjobs.calcjob.CalcJob` submitted to ``Computer`` instances.
+   .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobManager
+      :renderer: rst
 
-   When a calculation job is submitted to a :py:class:`~aiida.orm.computers.Computer`, it actually uses a specific
-   :py:class:`~aiida.orm.authinfos.AuthInfo`, which is a computer configured for a :py:class:`~aiida.orm.users.User`.
-   The ``JobManager`` maintains a mapping of :py:class:`~aiida.engine.processes.calcjobs.manager.JobsList` instances
-   for each authinfo that has active calculation jobs. These jobslist instances are then responsible for bundling
-   scheduler updates for all the jobs they maintain (i.e. that all share the same authinfo) and update their status.
+   .. rubric:: Initialization
 
-   As long as a :py:class:`~aiida.engine.runners.Runner` will create a single ``JobManager`` instance and use that for
-   its lifetime, the guarantees made by the ``JobsList`` about respecting the minimum polling interval of the scheduler
-   will be maintained. Note, however, that since each ``Runner`` will create its own job manager, these guarantees
-   only hold per runner.
+   .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobManager.__init__
+      :renderer: rst
 
    .. py:method:: get_jobs_list(authinfo: aiida.orm.AuthInfo) -> aiida.engine.processes.calcjobs.manager.JobsList
       :canonical: aiida.engine.processes.calcjobs.manager.JobManager.get_jobs_list
 
-      Get or create a new `JobLists` instance for the given authinfo.
-
-      :param authinfo: the `AuthInfo`
-      :return: a `JobsList` instance
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobManager.get_jobs_list
+         :renderer: rst
 
    .. py:method:: request_job_info_update(authinfo: aiida.orm.AuthInfo, job_id: typing.Hashable) -> typing.Iterator[asyncio.Future[JobInfo]]
       :canonical: aiida.engine.processes.calcjobs.manager.JobManager.request_job_info_update
 
-      Get a future that will resolve to information about a given job.
-
-      This is a context manager so that if the user leaves the context the request is automatically cancelled.
-
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobManager.request_job_info_update
+         :renderer: rst
 
 .. py:class:: JobsList(authinfo: aiida.orm.AuthInfo, transport_queue: aiida.engine.transports.TransportQueue, last_updated: typing.Optional[float] = None)
    :canonical: aiida.engine.processes.calcjobs.manager.JobsList
 
-   Manager of calculation jobs submitted with a specific ``AuthInfo``, i.e. computer configured for a specific user.
-
-   This container of active calculation jobs is used to update their status periodically in batches, ensuring that
-   even when a lot of jobs are running, the scheduler update command is not triggered for each job individually.
-
-   In addition, the :py:class:`~aiida.orm.computers.Computer` for which the :py:class:`~aiida.orm.authinfos.AuthInfo`
-   is configured, can define a minimum polling interval. This class will guarantee that the time between update calls
-   to the scheduler is larger or equal to that minimum interval.
-
-   Note that since each instance operates on a specific authinfo, the guarantees of batching scheduler update calls
-   and the limiting of number of calls per unit time, through the minimum polling interval, is only applicable for jobs
-   launched with that particular authinfo. If multiple authinfo instances with the same computer, have active jobs
-   these limitations are not respected between them, since there is no communication between ``JobsList`` instances.
-   See the :py:class:`~aiida.engine.processes.calcjobs.manager.JobManager` for example usage.
+   .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct an instance for the given authinfo and transport queue.
-
-   :param authinfo: The authinfo used to check the jobs list
-   :param transport_queue: A transport queue
-   :param last_updated: initialize the last updated timestamp
-
+   .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList.__init__
+      :renderer: rst
 
    .. py:property:: logger
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList.logger
       :type: logging.Logger
 
-      Return the logger configured for this instance.
-
-      :return: the logger
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList.logger
+         :renderer: rst
 
    .. py:method:: get_minimum_update_interval() -> float
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList.get_minimum_update_interval
 
-      Get the minimum interval that should be respected between updates of the list.
-
-      :return: the minimum interval
-
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList.get_minimum_update_interval
+         :renderer: rst
 
    .. py:property:: last_updated
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList.last_updated
       :type: typing.Optional[float]
 
-      Get the timestamp of when the list was last updated as produced by `time.time()`
-
-      :return: The last update point
-
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList.last_updated
+         :renderer: rst
 
    .. py:method:: _get_jobs_from_scheduler() -> typing.Dict[typing.Hashable, aiida.schedulers.datastructures.JobInfo]
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList._get_jobs_from_scheduler
       :async:
 
-      Get the current jobs list from the scheduler.
-
-      :return: a mapping of job ids to :py:class:`~aiida.schedulers.datastructures.JobInfo` instances
-
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList._get_jobs_from_scheduler
+         :renderer: rst
 
    .. py:method:: _update_job_info() -> None
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList._update_job_info
       :async:
 
-      Update all of the job information objects.
-
-      This will set the futures for all pending update requests where the corresponding job has a new status compared
-      to the last update.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList._update_job_info
+         :renderer: rst
 
    .. py:method:: request_job_info_update(job_id: typing.Hashable) -> typing.Iterator[asyncio.Future[JobInfo]]
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList.request_job_info_update
 
-      Request job info about a job when the job next changes state.
-
-      If the job is not found in the jobs list at the update, the future will resolve to `None`.
-
-      :param job_id: job identifier
-      :return: future that will resolve to a `JobInfo` object when the job changes state
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList.request_job_info_update
+         :renderer: rst
 
    .. py:method:: _ensure_updating() -> None
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList._ensure_updating
 
-      Ensure that we are updating the job list from the remote resource.
-
-      This will automatically stop if there are no outstanding requests.
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList._ensure_updating
+         :renderer: rst
 
    .. py:method:: _has_job_state_changed(old: typing.Optional[aiida.schedulers.datastructures.JobInfo], new: typing.Optional[aiida.schedulers.datastructures.JobInfo]) -> bool
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList._has_job_state_changed
       :staticmethod:
 
-      Return whether the states `old` and `new` are different.
-
-
-        
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList._has_job_state_changed
+         :renderer: rst
 
    .. py:method:: _get_next_update_delay() -> float
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList._get_next_update_delay
 
-      Calculate when we are next allowed to poll the scheduler.
-
-      This delay is calculated as the minimum polling interval defined by the authentication info for this instance,
-      minus time elapsed since the last update.
-
-      :return: delay (in seconds) after which the scheduler may be polled again
-
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList._get_next_update_delay
+         :renderer: rst
 
    .. py:method:: _update_requests_outstanding() -> bool
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList._update_requests_outstanding
 
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList._update_requests_outstanding
+         :renderer: rst
+
    .. py:method:: _get_jobs_with_scheduler() -> typing.List[str]
       :canonical: aiida.engine.processes.calcjobs.manager.JobsList._get_jobs_with_scheduler
 
-      Get all the jobs that are currently with scheduler.
-
-      :return: the list of jobs with the scheduler
-      :rtype: list
+      .. autodoc2-docstring:: aiida.engine.processes.calcjobs.manager.JobsList._get_jobs_with_scheduler
+         :renderer: rst
 
 .. py:class:: ObjectLoader
    :canonical: aiida.engine.persistence.ObjectLoader
 
    Bases: :py:obj:`plumpy.loaders.DefaultObjectLoader`
 
-   Custom object loader for `aiida-core`.
+   .. autodoc2-docstring:: aiida.engine.persistence.ObjectLoader
+      :renderer: rst
 
    .. py:method:: load_object(identifier: str) -> typing.Any
       :canonical: aiida.engine.persistence.ObjectLoader.load_object
 
-      Attempt to load the object identified by the given `identifier`.
-
-      .. note:: We override the `plumpy.DefaultObjectLoader` to be able to throw an `ImportError` instead of a
-          `ValueError` which in the context of `aiida-core` is not as apt, since we are loading classes.
-
-      :param identifier: concatenation of module and resource name
-      :return: loaded object
-      :raises ImportError: if the object cannot be loaded
+      .. autodoc2-docstring:: aiida.engine.persistence.ObjectLoader.load_object
+         :renderer: rst
 
 .. py:data:: OutputPort
    :canonical: aiida.engine.processes.ports.OutputPort
    :value: None
 
+   .. autodoc2-docstring:: aiida.engine.processes.ports.OutputPort
+      :renderer: rst
+
 .. py:data:: PORT_NAMESPACE_SEPARATOR
    :canonical: aiida.engine.processes.ports.PORT_NAMESPACE_SEPARATOR
    :value: '__'
+
+   .. autodoc2-docstring:: aiida.engine.processes.ports.PORT_NAMESPACE_SEPARATOR
+      :renderer: rst
 
 .. py:exception:: PastException()
    :canonical: aiida.engine.exceptions.PastException
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when an attempt is made to continue a Process that has already excepted before.
+   .. autodoc2-docstring:: aiida.engine.exceptions.PastException
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.engine.exceptions.PastException.__init__
+      :renderer: rst
 
 .. py:class:: PortNamespace(*args, **kwargs)
    :canonical: aiida.engine.processes.ports.PortNamespace
 
    Bases: :py:obj:`aiida.engine.processes.ports.WithNonDb`, :py:obj:`plumpy.ports.PortNamespace`
 
-   Sub class of plumpy.PortNamespace which implements the serialize method to support automatic recursive
-   serialization of a given mapping onto the ports of the PortNamespace.
+   .. autodoc2-docstring:: aiida.engine.processes.ports.PortNamespace
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.engine.processes.ports.PortNamespace.__init__
+      :renderer: rst
 
    .. py:method:: __setitem__(key: str, port: plumpy.ports.Port) -> None
       :canonical: aiida.engine.processes.ports.PortNamespace.__setitem__
 
-      Ensure that a `Port` being added inherits the `non_db` attribute if not explicitly defined at construction.
-
-      The reasoning is that if a `PortNamespace` has `non_db=True`, which is different from the default value, very
-      often all leaves should be also `non_db=True`. To prevent a user from having to specify it manually everytime
-      we overload the value here, unless it was specifically set during construction.
-
-      Note that the `non_db` attribute is not present for all `Port` sub classes so we have to check for it first.
+      .. autodoc2-docstring:: aiida.engine.processes.ports.PortNamespace.__setitem__
+         :renderer: rst
 
    .. py:method:: validate_port_name(port_name: str) -> None
       :canonical: aiida.engine.processes.ports.PortNamespace.validate_port_name
       :staticmethod:
 
-      Validate the given port name.
-
-      Valid port names adhere to the following restrictions:
-
-          * Is a valid link label (see below)
-          * Does not contain two or more consecutive underscores
-
-      Valid link labels adhere to the following restrictions:
-
-          * Has to be a valid python identifier
-          * Can only contain alphanumeric characters and underscores
-          * Can not start or end with an underscore
-
-      :param port_name: the proposed name of the port to be added
-      :raise TypeError: if the port name is not a string type
-      :raise ValueError: if the port name is invalid
+      .. autodoc2-docstring:: aiida.engine.processes.ports.PortNamespace.validate_port_name
+         :renderer: rst
 
    .. py:method:: serialize(mapping: typing.Optional[typing.Dict[str, typing.Any]], breadcrumbs: typing.Sequence[str] = ()) -> typing.Optional[typing.Dict[str, typing.Any]]
       :canonical: aiida.engine.processes.ports.PortNamespace.serialize
 
-      Serialize the given mapping onto this `Portnamespace`.
-
-      It will recursively call this function on any nested `PortNamespace` or the serialize function on any `Ports`.
-
-      :param mapping: a mapping of values to be serialized
-      :param breadcrumbs: a tuple with the namespaces of parent namespaces
-      :returns: the serialized mapping
+      .. autodoc2-docstring:: aiida.engine.processes.ports.PortNamespace.serialize
+         :renderer: rst
 
 .. py:class:: Process(inputs: typing.Optional[typing.Dict[str, typing.Any]] = None, logger: typing.Optional[logging.Logger] = None, runner: typing.Optional[aiida.engine.runners.Runner] = None, parent_pid: typing.Optional[int] = None, enable_persistence: bool = True)
    :canonical: aiida.engine.processes.process.Process
 
    Bases: :py:obj:`plumpy.processes.Process`
 
-   This class represents an AiiDA process which can be executed and will
-   have full provenance saved in the database.
+   .. autodoc2-docstring:: aiida.engine.processes.process.Process
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Process constructor.
-
-   :param inputs: process inputs
-   :param logger: aiida logger
-   :param runner: process runner
-   :param parent_pid: id of parent process
-   :param enable_persistence: whether to persist this process
-
+   .. autodoc2-docstring:: aiida.engine.processes.process.Process.__init__
+      :renderer: rst
 
    .. py:attribute:: _node_class
       :canonical: aiida.engine.processes.process.Process._node_class
       :value: None
 
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._node_class
+         :renderer: rst
+
    .. py:attribute:: _spec_class
       :canonical: aiida.engine.processes.process.Process._spec_class
       :value: None
+
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._spec_class
+         :renderer: rst
 
    .. py:attribute:: SINGLE_OUTPUT_LINKNAME
       :canonical: aiida.engine.processes.process.Process.SINGLE_OUTPUT_LINKNAME
       :type: str
       :value: 'result'
 
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.SINGLE_OUTPUT_LINKNAME
+         :renderer: rst
+
    .. py:class:: SaveKeys
       :canonical: aiida.engine.processes.process.Process.SaveKeys
 
       Bases: :py:obj:`enum.Enum`
 
-      Keys used to identify things in the saved instance state bundle.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.SaveKeys
+         :renderer: rst
 
       .. py:attribute:: CALC_ID
          :canonical: aiida.engine.processes.process.Process.SaveKeys.CALC_ID
          :type: str
          :value: 'calc_id'
 
+         .. autodoc2-docstring:: aiida.engine.processes.process.Process.SaveKeys.CALC_ID
+            :renderer: rst
+
    .. py:method:: spec() -> aiida.engine.processes.process_spec.ProcessSpec
       :canonical: aiida.engine.processes.process.Process.spec
       :classmethod:
+
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.spec
+         :renderer: rst
 
    .. py:method:: define(spec: aiida.engine.processes.process_spec.ProcessSpec) -> None
       :canonical: aiida.engine.processes.process.Process.define
       :classmethod:
 
-      Define the specification of the process, including its inputs, outputs and known exit codes.
-
-      A `metadata` input namespace is defined, with optional ports that are not stored in the database.
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.define
+         :renderer: rst
 
    .. py:method:: get_builder() -> aiida.engine.processes.builder.ProcessBuilder
       :canonical: aiida.engine.processes.process.Process.get_builder
       :classmethod:
 
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.get_builder
+         :renderer: rst
+
    .. py:method:: get_or_create_db_record() -> aiida.orm.ProcessNode
       :canonical: aiida.engine.processes.process.Process.get_or_create_db_record
       :classmethod:
 
-      Create a process node that represents what happened in this process.
-
-      :return: A process node
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.get_or_create_db_record
+         :renderer: rst
 
    .. py:method:: init() -> None
       :canonical: aiida.engine.processes.process.Process.init
+
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.init
+         :renderer: rst
 
    .. py:method:: get_exit_statuses(exit_code_labels: typing.Iterable[str]) -> typing.List[int]
       :canonical: aiida.engine.processes.process.Process.get_exit_statuses
       :classmethod:
 
-      Return the exit status (integers) for the given exit code labels.
-
-      :param exit_code_labels: a list of strings that reference exit code labels of this process class
-      :return: list of exit status integers that correspond to the given exit code labels
-      :raises AttributeError: if at least one of the labels does not correspond to an existing exit code
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.get_exit_statuses
+         :renderer: rst
 
    .. py:method:: exit_codes() -> aiida.engine.processes.exit_code.ExitCodesNamespace
       :canonical: aiida.engine.processes.process.Process.exit_codes
 
-      Return the namespace of exit codes defined for this WorkChain through its ProcessSpec.
-
-      The namespace supports getitem and getattr operations with an ExitCode label to retrieve a specific code.
-      Additionally, the namespace can also be called with either the exit code integer status to retrieve it.
-
-      :returns: ExitCodesNamespace of ExitCode named tuples
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.exit_codes
+         :renderer: rst
 
    .. py:method:: spec_metadata() -> aiida.engine.processes.ports.PortNamespace
       :canonical: aiida.engine.processes.process.Process.spec_metadata
 
-      Return the metadata port namespace of the process specification of this process.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.spec_metadata
+         :renderer: rst
 
    .. py:property:: node
       :canonical: aiida.engine.processes.process.Process.node
       :type: aiida.orm.ProcessNode
 
-      Return the ProcessNode used by this process to represent itself in the database.
-
-      :return: instance of sub class of ProcessNode
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.node
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.engine.processes.process.Process.uuid
       :type: str
 
-      Return the UUID of the process which corresponds to the UUID of its associated `ProcessNode`.
-
-      :return: the UUID associated to this process instance
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.uuid
+         :renderer: rst
 
    .. py:property:: metadata
       :canonical: aiida.engine.processes.process.Process.metadata
       :type: aiida.common.extendeddicts.AttributeDict
 
-      Return the metadata that were specified when this process instance was launched.
-
-      :return: metadata dictionary
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.metadata
+         :renderer: rst
 
    .. py:method:: _save_checkpoint() -> None
       :canonical: aiida.engine.processes.process.Process._save_checkpoint
 
-      Save the current state in a chechpoint if persistence is enabled and the process state is not terminal
-
-      If the persistence call excepts with a PersistenceError, it will be caught and a warning will be logged.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._save_checkpoint
+         :renderer: rst
 
    .. py:method:: save_instance_state(out_state: typing.MutableMapping[str, typing.Any], save_context: typing.Optional[plumpy.persistence.LoadSaveContext]) -> None
       :canonical: aiida.engine.processes.process.Process.save_instance_state
 
-      Save instance state.
-
-      See documentation of :meth:`!plumpy.processes.Process.save_instance_state`.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.save_instance_state
+         :renderer: rst
 
    .. py:method:: get_provenance_inputs_iterator() -> typing.Iterator[typing.Tuple[str, typing.Union[aiida.engine.processes.ports.InputPort, aiida.engine.processes.ports.PortNamespace]]]
       :canonical: aiida.engine.processes.process.Process.get_provenance_inputs_iterator
 
-      Get provenance input iterator.
-
-      :rtype: filter
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.get_provenance_inputs_iterator
+         :renderer: rst
 
    .. py:method:: load_instance_state(saved_state: typing.MutableMapping[str, typing.Any], load_context: plumpy.persistence.LoadSaveContext) -> None
       :canonical: aiida.engine.processes.process.Process.load_instance_state
 
-      Load instance state.
-
-      :param saved_state: saved instance state
-      :param load_context:
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.load_instance_state
+         :renderer: rst
 
    .. py:method:: kill(msg: typing.Union[str, None] = None) -> typing.Union[bool, plumpy.futures.Future]
       :canonical: aiida.engine.processes.process.Process.kill
 
-      Kill the process and all the children calculations it called
-
-      :param msg: message
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.kill
+         :renderer: rst
 
    .. py:method:: out(output_port: str, value: typing.Any = None) -> None
       :canonical: aiida.engine.processes.process.Process.out
 
-      Attach output to output port.
-
-      The name of the port will be used as the link label.
-
-      :param output_port: name of output port
-      :param value: value to put inside output port
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.out
+         :renderer: rst
 
    .. py:method:: out_many(out_dict: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.engine.processes.process.Process.out_many
 
-      Attach outputs to multiple output ports.
-
-      Keys of the dictionary will be used as output port names, values as outputs.
-
-      :param out_dict: output dictionary
-      :type out_dict: dict
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.out_many
+         :renderer: rst
 
    .. py:method:: on_create() -> None
       :canonical: aiida.engine.processes.process.Process.on_create
 
-      Called when a Process is created.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.on_create
+         :renderer: rst
 
    .. py:method:: on_entered(from_state: typing.Optional[plumpy.process_states.State]) -> None
       :canonical: aiida.engine.processes.process.Process.on_entered
 
-      After entering a new state, save a checkpoint and update the latest process state change timestamp.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.on_entered
+         :renderer: rst
 
    .. py:method:: on_terminated() -> None
       :canonical: aiida.engine.processes.process.Process.on_terminated
 
-      Called when a Process enters a terminal state.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.on_terminated
+         :renderer: rst
 
    .. py:method:: on_except(exc_info: typing.Tuple[typing.Any, Exception, types.TracebackType]) -> None
       :canonical: aiida.engine.processes.process.Process.on_except
 
-      Log the exception by calling the report method with formatted stack trace from exception info object
-      and store the exception string as a node attribute
-
-      :param exc_info: the sys.exc_info() object (type, value, traceback)
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.on_except
+         :renderer: rst
 
    .. py:method:: on_finish(result: typing.Union[int, aiida.engine.processes.exit_code.ExitCode], successful: bool) -> None
       :canonical: aiida.engine.processes.process.Process.on_finish
 
-      Set the finish status on the process node.
-
-      :param result: result of the process
-      :param successful: whether execution was successful
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.on_finish
+         :renderer: rst
 
    .. py:method:: on_paused(msg: typing.Optional[str] = None) -> None
       :canonical: aiida.engine.processes.process.Process.on_paused
 
-      The Process was paused so set the paused attribute on the process node
-
-      :param msg: message
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.on_paused
+         :renderer: rst
 
    .. py:method:: on_playing() -> None
       :canonical: aiida.engine.processes.process.Process.on_playing
 
-      The Process was unpaused so remove the paused attribute on the process node
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.on_playing
+         :renderer: rst
 
    .. py:method:: on_output_emitting(output_port: str, value: typing.Any) -> None
       :canonical: aiida.engine.processes.process.Process.on_output_emitting
 
-      The process has emitted a value on the given output port.
-
-      :param output_port: The output port name the value was emitted on
-      :param value: The value emitted
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.on_output_emitting
+         :renderer: rst
 
    .. py:method:: set_status(status: typing.Optional[str]) -> None
       :canonical: aiida.engine.processes.process.Process.set_status
 
-      The status of the Process is about to be changed, so we reflect this is in node's attribute proxy.
-
-      :param status: the status message
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.set_status
+         :renderer: rst
 
    .. py:method:: submit(process: typing.Type[aiida.engine.processes.process.Process], **kwargs) -> aiida.orm.ProcessNode
       :canonical: aiida.engine.processes.process.Process.submit
 
-      Submit process for execution.
-
-      :param process: process
-      :return: the calculation node of the process
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.submit
+         :renderer: rst
 
    .. py:property:: runner
       :canonical: aiida.engine.processes.process.Process.runner
       :type: aiida.engine.runners.Runner
 
-      Get process runner.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.runner
+         :renderer: rst
 
    .. py:method:: get_parent_calc() -> typing.Optional[aiida.orm.ProcessNode]
       :canonical: aiida.engine.processes.process.Process.get_parent_calc
 
-      Get the parent process node
-
-      :return: the parent process node if there is one
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.get_parent_calc
+         :renderer: rst
 
    .. py:method:: build_process_type() -> str
       :canonical: aiida.engine.processes.process.Process.build_process_type
       :classmethod:
 
-      The process type.
-
-      :return: string of the process type
-
-      Note: This could be made into a property 'process_type' but in order to have it be a property of the class
-      it would need to be defined in the metaclass, see https://bugs.python.org/issue20659
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.build_process_type
+         :renderer: rst
 
    .. py:method:: report(msg: str, *args, **kwargs) -> None
       :canonical: aiida.engine.processes.process.Process.report
 
-      Log a message to the logger, which should get saved to the database through the attached DbLogHandler.
-
-      The pk, class name and function name of the caller are prepended to the given message
-
-      :param msg: message to log
-      :param args: args to pass to the log call
-      :param kwargs: kwargs to pass to the log call
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.report
+         :renderer: rst
 
    .. py:method:: _create_and_setup_db_record() -> typing.Union[int, uuid.UUID]
       :canonical: aiida.engine.processes.process.Process._create_and_setup_db_record
 
-      Create and setup the database record for this process
-
-      :return: the uuid or pk of the process
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._create_and_setup_db_record
+         :renderer: rst
 
    .. py:method:: encode_input_args(inputs: typing.Dict[str, typing.Any]) -> str
       :canonical: aiida.engine.processes.process.Process.encode_input_args
 
-      Encode input arguments such that they may be saved in a Bundle
-
-      :param inputs: A mapping of the inputs as passed to the process
-      :return: The encoded (serialized) inputs
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.encode_input_args
+         :renderer: rst
 
    .. py:method:: decode_input_args(encoded: str) -> typing.Dict[str, typing.Any]
       :canonical: aiida.engine.processes.process.Process.decode_input_args
 
-      Decode saved input arguments as they came from the saved instance state Bundle
-
-      :param encoded: encoded (serialized) inputs
-      :return: The decoded input args
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.decode_input_args
+         :renderer: rst
 
    .. py:method:: update_outputs() -> None
       :canonical: aiida.engine.processes.process.Process.update_outputs
 
-      Attach new outputs to the node since the last call.
-
-      Does nothing, if self.metadata.store_provenance is False.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.update_outputs
+         :renderer: rst
 
    .. py:method:: _build_process_label() -> str
       :canonical: aiida.engine.processes.process.Process._build_process_label
 
-      Construct the process label that should be set on ``ProcessNode`` instances for this process class.
-
-      .. note:: By default this returns the name of the process class itself. It can be overridden by ``Process``
-          subclasses to provide a more specific label.
-
-      :returns: The process label to use for ``ProcessNode`` instances.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._build_process_label
+         :renderer: rst
 
    .. py:method:: _setup_db_record() -> None
       :canonical: aiida.engine.processes.process.Process._setup_db_record
 
-      Create the database record for this process and the links with respect to its inputs
-
-      This function will set various attributes on the node that serve as a proxy for attributes of the Process.
-      This is essential as otherwise this information could only be introspected through the Process itself, which
-      is only available to the interpreter that has it in memory. To make this data introspectable from any
-      interpreter, for example for the command line interface, certain Process attributes are proxied through the
-      calculation node.
-
-      In addition, the parent calculation will be setup with a CALL link if applicable and all inputs will be
-      linked up as well.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._setup_db_record
+         :renderer: rst
 
    .. py:method:: _setup_version_info() -> None
       :canonical: aiida.engine.processes.process.Process._setup_version_info
 
-      Store relevant plugin version information.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._setup_version_info
+         :renderer: rst
 
    .. py:method:: _setup_metadata(metadata: dict) -> None
       :canonical: aiida.engine.processes.process.Process._setup_metadata
 
-      Store the metadata on the ProcessNode.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._setup_metadata
+         :renderer: rst
 
    .. py:method:: _setup_inputs() -> None
       :canonical: aiida.engine.processes.process.Process._setup_inputs
 
-      Create the links between the input nodes and the ProcessNode that represents this process.
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._setup_inputs
+         :renderer: rst
 
    .. py:method:: _flat_inputs() -> typing.Dict[str, typing.Any]
       :canonical: aiida.engine.processes.process.Process._flat_inputs
 
-      Return a flattened version of the parsed inputs dictionary.
-
-      The eventual keys will be a concatenation of the nested keys. Note that the `metadata` dictionary, if present,
-      is not passed, as those are dealt with separately in `_setup_metadata`.
-
-      :return: flat dictionary of parsed inputs
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._flat_inputs
+         :renderer: rst
 
    .. py:method:: _flat_outputs() -> typing.Dict[str, typing.Any]
       :canonical: aiida.engine.processes.process.Process._flat_outputs
 
-      Return a flattened version of the registered outputs dictionary.
-
-      The eventual keys will be a concatenation of the nested keys.
-
-      :return: flat dictionary of parsed outputs
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._flat_outputs
+         :renderer: rst
 
    .. py:method:: _flatten_inputs(port: typing.Union[None, aiida.engine.processes.ports.InputPort, aiida.engine.processes.ports.PortNamespace], port_value: typing.Any, parent_name: str = '', separator: str = PORT_NAMESPACE_SEPARATOR) -> typing.List[typing.Tuple[str, typing.Any]]
       :canonical: aiida.engine.processes.process.Process._flatten_inputs
 
-      Function that will recursively flatten the inputs dictionary, omitting inputs for ports that
-      are marked as being non database storable
-
-      :param port: port against which to map the port value, can be InputPort or PortNamespace
-      :param port_value: value for the current port, can be a Mapping
-      :param parent_name: the parent key with which to prefix the keys
-      :param separator: character to use for the concatenation of keys
-      :return: flat list of inputs
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._flatten_inputs
+         :renderer: rst
 
    .. py:method:: _flatten_outputs(port: typing.Union[None, aiida.engine.processes.ports.OutputPort, aiida.engine.processes.ports.PortNamespace], port_value: typing.Any, parent_name: str = '', separator: str = PORT_NAMESPACE_SEPARATOR) -> typing.List[typing.Tuple[str, typing.Any]]
       :canonical: aiida.engine.processes.process.Process._flatten_outputs
 
-      Function that will recursively flatten the outputs dictionary.
-
-      :param port: port against which to map the port value, can be OutputPort or PortNamespace
-      :param port_value: value for the current port, can be a Mapping
-      :param parent_name: the parent key with which to prefix the keys
-      :param separator: character to use for the concatenation of keys
-
-      :return: flat list of outputs
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._flatten_outputs
+         :renderer: rst
 
    .. py:method:: exposed_inputs(process_class: typing.Type[aiida.engine.processes.process.Process], namespace: typing.Optional[str] = None, agglomerate: bool = True) -> aiida.common.extendeddicts.AttributeDict
       :canonical: aiida.engine.processes.process.Process.exposed_inputs
 
-      Gather a dictionary of the inputs that were exposed for a given Process class under an optional namespace.
-
-      :param process_class: Process class whose inputs to try and retrieve
-      :param namespace: PortNamespace in which to look for the inputs
-      :param agglomerate: If set to true, all parent namespaces of the given ``namespace`` will also be
-          searched for inputs. Inputs in lower-lying namespaces take precedence.
-
-      :returns: exposed inputs
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.exposed_inputs
+         :renderer: rst
 
    .. py:method:: exposed_outputs(node: aiida.orm.ProcessNode, process_class: typing.Type[aiida.engine.processes.process.Process], namespace: typing.Optional[str] = None, agglomerate: bool = True) -> aiida.common.extendeddicts.AttributeDict
       :canonical: aiida.engine.processes.process.Process.exposed_outputs
 
-      Return the outputs which were exposed from the ``process_class`` and emitted by the specific ``node``
-
-      :param node: process node whose outputs to try and retrieve
-      :param namespace: Namespace in which to search for exposed outputs.
-      :param agglomerate: If set to true, all parent namespaces of the given ``namespace`` will also
-          be searched for outputs. Outputs in lower-lying namespaces take precedence.
-
-      :returns: exposed outputs
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.exposed_outputs
+         :renderer: rst
 
    .. py:method:: _get_namespace_list(namespace: typing.Optional[str] = None, agglomerate: bool = True) -> typing.List[typing.Optional[str]]
       :canonical: aiida.engine.processes.process.Process._get_namespace_list
       :staticmethod:
 
-      Get the list of namespaces in a given namespace.
-
-      :param namespace: name space
-      :param agglomerate: If set to true, all parent namespaces of the given ``namespace`` will also
-          be searched.
-
-      :returns: namespace list
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process._get_namespace_list
+         :renderer: rst
 
    .. py:method:: is_valid_cache(node: aiida.orm.ProcessNode) -> bool
       :canonical: aiida.engine.processes.process.Process.is_valid_cache
       :classmethod:
 
-      Check if the given node can be cached from.
-
-      Overriding this method allows ``Process`` sub-classes to modify when
-      corresponding process nodes are considered as a cache.
-
-      .. warning :: When overriding this method, make sure to return ``False``
-          *at least* in all cases when ``super()._node.base.caching.is_valid_cache(node)``
-          returns ``False``. Otherwise, the ``invalidates_cache`` keyword on exit
-          codes may have no effect.
-
+      .. autodoc2-docstring:: aiida.engine.processes.process.Process.is_valid_cache
+         :renderer: rst
 
 .. py:class:: ProcessBuilder(process_class: typing.Type[aiida.engine.processes.process.Process])
    :canonical: aiida.engine.processes.builder.ProcessBuilder
 
    Bases: :py:obj:`aiida.engine.processes.builder.ProcessBuilderNamespace`
 
-   A process builder that helps setting up the inputs for creating a new process.
+   .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilder
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a `ProcessBuilder` instance for the given `Process` class.
-
-   :param process_class: the `Process` subclass
+   .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilder.__init__
+      :renderer: rst
 
    .. py:property:: process_class
       :canonical: aiida.engine.processes.builder.ProcessBuilder.process_class
       :type: typing.Type[aiida.engine.processes.process.Process]
 
-      Return the process class for which this builder is constructed.
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilder.process_class
+         :renderer: rst
 
    .. py:method:: _repr_pretty_(p, _) -> str
       :canonical: aiida.engine.processes.builder.ProcessBuilder._repr_pretty_
 
-      Pretty representation for in the IPython console and notebooks.
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilder._repr_pretty_
+         :renderer: rst
 
 .. py:class:: ProcessBuilderNamespace(port_namespace: aiida.engine.processes.ports.PortNamespace)
    :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace
 
    Bases: :py:obj:`collections.abc.MutableMapping`
 
-   Input namespace for the `ProcessBuilder`.
-
-   Dynamically generates the getters and setters for the input ports of a given PortNamespace
+   .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Dynamically construct the get and set properties for the ports of the given port namespace.
-
-   For each port in the given port namespace a get and set property will be constructed dynamically
-   and added to the ProcessBuilderNamespace. The docstring for these properties will be defined
-   by calling str() on the Port, which should return the description of the Port.
-
-   :param port_namespace: the inputs PortNamespace for which to construct the builder
-
+   .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__init__
+      :renderer: rst
 
    .. py:method:: __setattr__(attr: str, value: typing.Any) -> None
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace.__setattr__
 
-      Assign the given value to the port with key `attr`.
-
-      .. note:: Any attributes without a leading underscore being set correspond to inputs and should hence be
-          validated with respect to the corresponding input port from the process spec
-
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__setattr__
+         :renderer: rst
 
    .. py:method:: __repr__()
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace.__repr__
 
-      Return repr(self).
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__repr__
+         :renderer: rst
 
    .. py:method:: __dir__()
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace.__dir__
 
-      Default dir() implementation.
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__dir__
+         :renderer: rst
 
    .. py:method:: __iter__()
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace.__iter__
 
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__iter__
+         :renderer: rst
+
    .. py:method:: __len__()
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace.__len__
+
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__len__
+         :renderer: rst
 
    .. py:method:: __getitem__(item)
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace.__getitem__
 
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__getitem__
+         :renderer: rst
+
    .. py:method:: __setitem__(item, value)
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace.__setitem__
+
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__setitem__
+         :renderer: rst
 
    .. py:method:: __delitem__(item)
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace.__delitem__
 
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__delitem__
+         :renderer: rst
+
    .. py:method:: __delattr__(item)
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace.__delattr__
 
-      Implement delattr(self, name).
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace.__delattr__
+         :renderer: rst
 
    .. py:method:: _recursive_merge(dictionary, key, value)
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace._recursive_merge
 
-      Recursively merge the contents of ``dictionary`` setting its ``key`` to ``value``.
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace._recursive_merge
+         :renderer: rst
 
    .. py:method:: _merge(*args, **kwds)
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace._merge
 
-      Merge the content of a dictionary or keyword arguments in .
-
-      .. note:: This method differs in behavior from ``_update`` in that ``_merge`` will recursively update the
-          existing dictionary with the one that is specified in the arguments. The ``_update`` method will merge only
-          the keys on the top level, but any lower lying nested namespace will be replaced entirely.
-
-      The method is prefixed with an underscore in order to not reserve the name for a potential port.
-
-      :param args: a single mapping that should be mapped on the namespace.
-      :param kwds: keyword value pairs that should be mapped onto the ports.
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace._merge
+         :renderer: rst
 
    .. py:method:: _update(*args, **kwds)
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace._update
 
-      Update the values of the builder namespace passing a mapping as argument or individual keyword value pairs.
-
-      The method functions just as `collections.abc.MutableMapping.update` and is merely prefixed with an underscore
-      in order to not reserve the name for a potential port.
-
-      :param args: a single mapping that should be mapped on the namespace.
-      :param kwds: keyword value pairs that should be mapped onto the ports.
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace._update
+         :renderer: rst
 
    .. py:method:: _inputs(prune: bool = False) -> dict
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace._inputs
 
-      Return the entire mapping of inputs specified for this builder.
-
-      :param prune: boolean, when True, will prune nested namespaces that contain no actual values whatsoever
-      :return: mapping of inputs ports and their input values.
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace._inputs
+         :renderer: rst
 
    .. py:method:: _prune(value)
       :canonical: aiida.engine.processes.builder.ProcessBuilderNamespace._prune
 
-      Prune a nested mapping from all mappings that are completely empty.
-
-      .. note:: a nested mapping that is completely empty means it contains at most other empty mappings. Other null
-          values, such as `None` or empty lists, should not be pruned.
-
-      :param value: a nested mapping of port values
-      :return: the same mapping but without any nested namespace that is completely empty.
+      .. autodoc2-docstring:: aiida.engine.processes.builder.ProcessBuilderNamespace._prune
+         :renderer: rst
 
 .. py:class:: ProcessFuture(pk: int, loop: typing.Optional[asyncio.AbstractEventLoop] = None, poll_interval: typing.Union[None, int, float] = None, communicator: typing.Optional[kiwipy.Communicator] = None)
    :canonical: aiida.engine.processes.futures.ProcessFuture
 
    Bases: :py:obj:`asyncio.Future`
 
-   Future that waits for a process to complete using both polling and listening for broadcast events if possible.
+   .. autodoc2-docstring:: aiida.engine.processes.futures.ProcessFuture
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a future for a process node being finished.
-
-   If a None poll_interval is supplied polling will not be used.
-   If a communicator is supplied it will be used to listen for broadcast messages.
-
-   :param pk: process pk
-   :param loop: An event loop
-   :param poll_interval: optional polling interval, if None, polling is not activated.
-   :param communicator: optional communicator, if None, will not subscribe to broadcasts.
+   .. autodoc2-docstring:: aiida.engine.processes.futures.ProcessFuture.__init__
+      :renderer: rst
 
    .. py:attribute:: _filtered
       :canonical: aiida.engine.processes.futures.ProcessFuture._filtered
       :value: None
 
+      .. autodoc2-docstring:: aiida.engine.processes.futures.ProcessFuture._filtered
+         :renderer: rst
+
    .. py:method:: cleanup() -> None
       :canonical: aiida.engine.processes.futures.ProcessFuture.cleanup
 
-      Clean up the future by removing broadcast subscribers from the communicator if it still exists.
+      .. autodoc2-docstring:: aiida.engine.processes.futures.ProcessFuture.cleanup
+         :renderer: rst
 
    .. py:method:: _poll_process(node: aiida.orm.Node, poll_interval: typing.Union[int, float]) -> None
       :canonical: aiida.engine.processes.futures.ProcessFuture._poll_process
       :async:
 
-      Poll whether the process node has reached a terminal state.
+      .. autodoc2-docstring:: aiida.engine.processes.futures.ProcessFuture._poll_process
+         :renderer: rst
 
 .. py:class:: ProcessHandlerReport
    :canonical: aiida.engine.processes.workchains.utils.ProcessHandlerReport
 
    Bases: :py:obj:`typing.NamedTuple`
 
-   A namedtuple to define a process handler report for a :class:`aiida.engine.BaseRestartWorkChain`.
-
-   This namedtuple should be returned by a process handler of a work chain instance if the condition of the handler was
-   met by the completed process. If no further handling should be performed after this method the `do_break` field
-   should be set to `True`.
-   If the handler encountered a fatal error and the work chain needs to be terminated, an `ExitCode` with
-   non-zero exit status can be set. This exit code is what will be set on the work chain itself. This works because the
-   value of the `exit_code` field returned by the handler, will in turn be returned by the `inspect_process` step and
-   returning a non-zero exit code from any work chain step will instruct the engine to abort the work chain.
-
-   :param do_break: boolean, set to `True` if no further process handlers should be called, default is `False`
-   :param exit_code: an instance of the :class:`~aiida.engine.processes.exit_code.ExitCode` tuple.
-       If not explicitly set, the default `ExitCode` will be instantiated,
-       which has status `0` meaning that the work chain step will be considered
-       successful and the work chain will continue to the next step.
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.utils.ProcessHandlerReport
+      :renderer: rst
 
    .. py:attribute:: do_break
       :canonical: aiida.engine.processes.workchains.utils.ProcessHandlerReport.do_break
       :type: bool
       :value: False
 
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.utils.ProcessHandlerReport.do_break
+         :renderer: rst
+
    .. py:attribute:: exit_code
       :canonical: aiida.engine.processes.workchains.utils.ProcessHandlerReport.exit_code
       :type: aiida.engine.processes.exit_code.ExitCode
       :value: None
+
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.utils.ProcessHandlerReport.exit_code
+         :renderer: rst
 
 .. py:class:: ProcessSpec()
    :canonical: aiida.engine.processes.process_spec.ProcessSpec
 
    Bases: :py:obj:`plumpy.process_spec.ProcessSpec`
 
-   Default process spec for process classes defined in `aiida-core`.
+   .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec
+      :renderer: rst
 
-   This sub class defines custom classes for input ports and port namespaces. It also adds support for the definition
-   of exit codes and retrieving them subsequently.
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.__init__
+      :renderer: rst
 
    .. py:attribute:: METADATA_KEY
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.METADATA_KEY
       :type: str
       :value: 'metadata'
 
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.METADATA_KEY
+         :renderer: rst
+
    .. py:attribute:: METADATA_OPTIONS_KEY
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.METADATA_OPTIONS_KEY
       :type: str
       :value: 'options'
 
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.METADATA_OPTIONS_KEY
+         :renderer: rst
+
    .. py:attribute:: INPUT_PORT_TYPE
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.INPUT_PORT_TYPE
       :value: None
+
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.INPUT_PORT_TYPE
+         :renderer: rst
 
    .. py:attribute:: PORT_NAMESPACE_TYPE
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.PORT_NAMESPACE_TYPE
       :value: None
 
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.PORT_NAMESPACE_TYPE
+         :renderer: rst
+
    .. py:property:: metadata_key
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.metadata_key
       :type: str
+
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.metadata_key
+         :renderer: rst
 
    .. py:property:: options_key
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.options_key
       :type: str
 
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.options_key
+         :renderer: rst
+
    .. py:property:: exit_codes
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.exit_codes
       :type: aiida.engine.processes.exit_code.ExitCodesNamespace
 
-      Return the namespace of exit codes defined for this ProcessSpec
-
-      :returns: ExitCodesNamespace of ExitCode named tuples
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.exit_codes
+         :renderer: rst
 
    .. py:method:: exit_code(status: int, label: str, message: str, invalidates_cache: bool = False) -> None
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.exit_code
 
-      Add an exit code to the ProcessSpec
-
-      :param status: the exit status integer
-      :param label: a label by which the exit code can be addressed
-      :param message: a more detailed description of the exit code
-      :param invalidates_cache: when set to `True`, a process exiting
-          with this exit code will not be considered for caching
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.exit_code
+         :renderer: rst
 
    .. py:property:: ports
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.ports
       :type: aiida.engine.processes.ports.PortNamespace
 
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.ports
+         :renderer: rst
+
    .. py:property:: inputs
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.inputs
       :type: aiida.engine.processes.ports.PortNamespace
+
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.inputs
+         :renderer: rst
 
    .. py:property:: outputs
       :canonical: aiida.engine.processes.process_spec.ProcessSpec.outputs
       :type: aiida.engine.processes.ports.PortNamespace
 
+      .. autodoc2-docstring:: aiida.engine.processes.process_spec.ProcessSpec.outputs
+         :renderer: rst
+
 .. py:class:: Runner(poll_interval: typing.Union[int, float] = 0, loop: typing.Optional[asyncio.AbstractEventLoop] = None, communicator: typing.Optional[kiwipy.Communicator] = None, rmq_submit: bool = False, persister: typing.Optional[plumpy.persistence.Persister] = None)
    :canonical: aiida.engine.runners.Runner
 
-   Class that can launch processes by running in the current interpreter or by submitting them to the daemon.
+   .. autodoc2-docstring:: aiida.engine.runners.Runner
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new runner.
-
-   :param poll_interval: interval in seconds between polling for status of active sub processes
-   :param loop: an asyncio event loop, if none is suppled a new one will be created
-   :param communicator: the communicator to use
-   :param rmq_submit: if True, processes will be submitted to RabbitMQ, otherwise they will be scheduled here
-   :param persister: the persister to use to persist processes
-
+   .. autodoc2-docstring:: aiida.engine.runners.Runner.__init__
+      :renderer: rst
 
    .. py:attribute:: _persister
       :canonical: aiida.engine.runners.Runner._persister
       :type: typing.Optional[plumpy.persistence.Persister]
       :value: None
 
+      .. autodoc2-docstring:: aiida.engine.runners.Runner._persister
+         :renderer: rst
+
    .. py:attribute:: _communicator
       :canonical: aiida.engine.runners.Runner._communicator
       :type: typing.Optional[kiwipy.Communicator]
       :value: None
+
+      .. autodoc2-docstring:: aiida.engine.runners.Runner._communicator
+         :renderer: rst
 
    .. py:attribute:: _controller
       :canonical: aiida.engine.runners.Runner._controller
       :type: typing.Optional[plumpy.process_comms.RemoteProcessThreadController]
       :value: None
 
+      .. autodoc2-docstring:: aiida.engine.runners.Runner._controller
+         :renderer: rst
+
    .. py:attribute:: _closed
       :canonical: aiida.engine.runners.Runner._closed
       :type: bool
       :value: False
 
+      .. autodoc2-docstring:: aiida.engine.runners.Runner._closed
+         :renderer: rst
+
    .. py:method:: __enter__() -> aiida.engine.runners.Runner
       :canonical: aiida.engine.runners.Runner.__enter__
 
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.__enter__
+         :renderer: rst
+
    .. py:method:: __exit__(exc_type, exc_val, exc_tb)
       :canonical: aiida.engine.runners.Runner.__exit__
+
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.__exit__
+         :renderer: rst
 
    .. py:property:: loop
       :canonical: aiida.engine.runners.Runner.loop
       :type: asyncio.AbstractEventLoop
 
-      Get the event loop of this runner.
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.loop
+         :renderer: rst
 
    .. py:property:: transport
       :canonical: aiida.engine.runners.Runner.transport
       :type: aiida.engine.transports.TransportQueue
 
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.transport
+         :renderer: rst
+
    .. py:property:: persister
       :canonical: aiida.engine.runners.Runner.persister
       :type: typing.Optional[plumpy.persistence.Persister]
 
-      Get the persister used by this runner.
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.persister
+         :renderer: rst
 
    .. py:property:: communicator
       :canonical: aiida.engine.runners.Runner.communicator
       :type: typing.Optional[kiwipy.Communicator]
 
-      Get the communicator used by this runner.
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.communicator
+         :renderer: rst
 
    .. py:property:: plugin_version_provider
       :canonical: aiida.engine.runners.Runner.plugin_version_provider
       :type: aiida.plugins.utils.PluginVersionProvider
 
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.plugin_version_provider
+         :renderer: rst
+
    .. py:property:: job_manager
       :canonical: aiida.engine.runners.Runner.job_manager
       :type: aiida.engine.processes.calcjobs.manager.JobManager
+
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.job_manager
+         :renderer: rst
 
    .. py:property:: controller
       :canonical: aiida.engine.runners.Runner.controller
       :type: typing.Optional[plumpy.process_comms.RemoteProcessThreadController]
 
-      Get the controller used by this runner.
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.controller
+         :renderer: rst
 
    .. py:property:: is_daemon_runner
       :canonical: aiida.engine.runners.Runner.is_daemon_runner
       :type: bool
 
-      Return whether the runner is a daemon runner, which means it submits processes over RabbitMQ.
-
-      :return: True if the runner is a daemon runner
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.is_daemon_runner
+         :renderer: rst
 
    .. py:method:: is_closed() -> bool
       :canonical: aiida.engine.runners.Runner.is_closed
 
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.is_closed
+         :renderer: rst
+
    .. py:method:: start() -> None
       :canonical: aiida.engine.runners.Runner.start
 
-      Start the internal event loop.
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.start
+         :renderer: rst
 
    .. py:method:: stop() -> None
       :canonical: aiida.engine.runners.Runner.stop
 
-      Stop the internal event loop.
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.stop
+         :renderer: rst
 
    .. py:method:: run_until_complete(future: asyncio.Future) -> typing.Any
       :canonical: aiida.engine.runners.Runner.run_until_complete
 
-      Run the loop until the future has finished and return the result.
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.run_until_complete
+         :renderer: rst
 
    .. py:method:: close() -> None
       :canonical: aiida.engine.runners.Runner.close
 
-      Close the runner by stopping the loop.
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.close
+         :renderer: rst
 
    .. py:method:: instantiate_process(process: aiida.engine.runners.TYPE_RUN_PROCESS, **inputs)
       :canonical: aiida.engine.runners.Runner.instantiate_process
 
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.instantiate_process
+         :renderer: rst
+
    .. py:method:: submit(process: aiida.engine.runners.TYPE_SUBMIT_PROCESS, **inputs: typing.Any)
       :canonical: aiida.engine.runners.Runner.submit
 
-      Submit the process with the supplied inputs to this runner immediately returning control to
-      the interpreter. The return value will be the calculation node of the submitted process
-
-      :param process: the process class to submit
-      :param inputs: the inputs to be passed to the process
-      :return: the calculation node of the process
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.submit
+         :renderer: rst
 
    .. py:method:: schedule(process: aiida.engine.runners.TYPE_SUBMIT_PROCESS, *args: typing.Any, **inputs: typing.Any) -> aiida.orm.ProcessNode
       :canonical: aiida.engine.runners.Runner.schedule
 
-      Schedule a process to be executed by this runner
-
-      :param process: the process class to submit
-      :param inputs: the inputs to be passed to the process
-      :return: the calculation node of the process
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.schedule
+         :renderer: rst
 
    .. py:method:: _run(process: aiida.engine.runners.TYPE_RUN_PROCESS, *args: typing.Any, **inputs: typing.Any) -> typing.Tuple[typing.Dict[str, typing.Any], aiida.orm.ProcessNode]
       :canonical: aiida.engine.runners.Runner._run
 
-      Run the process with the supplied inputs in this runner that will block until the process is completed.
-      The return value will be the results of the completed process
-
-      :param process: the process class or process function to run
-      :param inputs: the inputs to be passed to the process
-      :return: tuple of the outputs of the process and the calculation node
+      .. autodoc2-docstring:: aiida.engine.runners.Runner._run
+         :renderer: rst
 
    .. py:method:: run(process: aiida.engine.runners.TYPE_RUN_PROCESS, *args: typing.Any, **inputs: typing.Any) -> typing.Dict[str, typing.Any]
       :canonical: aiida.engine.runners.Runner.run
 
-      Run the process with the supplied inputs in this runner that will block until the process is completed.
-      The return value will be the results of the completed process
-
-      :param process: the process class or process function to run
-      :param inputs: the inputs to be passed to the process
-      :return: the outputs of the process
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.run
+         :renderer: rst
 
    .. py:method:: run_get_node(process: aiida.engine.runners.TYPE_RUN_PROCESS, *args: typing.Any, **inputs: typing.Any) -> aiida.engine.runners.ResultAndNode
       :canonical: aiida.engine.runners.Runner.run_get_node
 
-      Run the process with the supplied inputs in this runner that will block until the process is completed.
-      The return value will be the results of the completed process
-
-      :param process: the process class or process function to run
-      :param inputs: the inputs to be passed to the process
-      :return: tuple of the outputs of the process and the calculation node
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.run_get_node
+         :renderer: rst
 
    .. py:method:: run_get_pk(process: aiida.engine.runners.TYPE_RUN_PROCESS, *args: typing.Any, **inputs: typing.Any) -> aiida.engine.runners.ResultAndPk
       :canonical: aiida.engine.runners.Runner.run_get_pk
 
-      Run the process with the supplied inputs in this runner that will block until the process is completed.
-      The return value will be the results of the completed process
-
-      :param process: the process class or process function to run
-      :param inputs: the inputs to be passed to the process
-      :return: tuple of the outputs of the process and process node pk
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.run_get_pk
+         :renderer: rst
 
    .. py:method:: call_on_process_finish(pk: int, callback: typing.Callable[[], typing.Any]) -> None
       :canonical: aiida.engine.runners.Runner.call_on_process_finish
 
-      Schedule a callback when the process of the given pk is terminated.
-
-      This method will add a broadcast subscriber that will listen for state changes of the target process to be
-      terminated. As a fail-safe, a polling-mechanism is used to check the state of the process, should the broadcast
-      message be missed by the subscriber, in order to prevent the caller to wait indefinitely.
-
-      :param pk: pk of the process
-      :param callback: function to be called upon process termination
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.call_on_process_finish
+         :renderer: rst
 
    .. py:method:: get_process_future(pk: int) -> aiida.engine.processes.futures.ProcessFuture
       :canonical: aiida.engine.runners.Runner.get_process_future
 
-      Return a future for a process.
-
-      The future will have the process node as the result when finished.
-
-      :return: A future representing the completion of the process node
+      .. autodoc2-docstring:: aiida.engine.runners.Runner.get_process_future
+         :renderer: rst
 
    .. py:method:: _poll_process(node, callback)
       :canonical: aiida.engine.runners.Runner._poll_process
 
-      Check whether the process state of the node is terminated and call the callback or reschedule it.
-
-      :param node: the process node
-      :param callback: callback to be called when process is terminated
+      .. autodoc2-docstring:: aiida.engine.runners.Runner._poll_process
+         :renderer: rst
 
 .. py:data:: ToContext
    :canonical: aiida.engine.processes.workchains.context.ToContext
    :value: None
 
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.context.ToContext
+      :renderer: rst
+
 .. py:class:: WithNonDb(*args, **kwargs)
    :canonical: aiida.engine.processes.ports.WithNonDb
 
-   A mixin that adds support to a port to flag that it should not be stored
-   in the database using the non_db=True flag.
+   .. autodoc2-docstring:: aiida.engine.processes.ports.WithNonDb
+      :renderer: rst
 
-   The mixins have to go before the main port class in the superclass order
-   to make sure the mixin has the chance to strip out the non_db keyword.
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.engine.processes.ports.WithNonDb.__init__
+      :renderer: rst
 
    .. py:property:: non_db_explicitly_set
       :canonical: aiida.engine.processes.ports.WithNonDb.non_db_explicitly_set
       :type: bool
 
-      Return whether the a value for `non_db` was explicitly passed in the construction of the `Port`.
-
-      :return: boolean, True if `non_db` was explicitly defined during construction, False otherwise
+      .. autodoc2-docstring:: aiida.engine.processes.ports.WithNonDb.non_db_explicitly_set
+         :renderer: rst
 
    .. py:property:: non_db
       :canonical: aiida.engine.processes.ports.WithNonDb.non_db
       :type: bool
 
-      Return whether the value of this `Port` should be stored as a `Node` in the database.
-
-      :return: boolean, True if it should be storable as a `Node`, False otherwise
+      .. autodoc2-docstring:: aiida.engine.processes.ports.WithNonDb.non_db
+         :renderer: rst
 
 .. py:class:: WithSerialize(*args, **kwargs)
    :canonical: aiida.engine.processes.ports.WithSerialize
 
-   A mixin that adds support for a serialization function which is automatically applied on inputs
-   that are not AiiDA data types.
+   .. autodoc2-docstring:: aiida.engine.processes.ports.WithSerialize
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.engine.processes.ports.WithSerialize.__init__
+      :renderer: rst
 
    .. py:method:: serialize(value: typing.Any) -> aiida.orm.Data
       :canonical: aiida.engine.processes.ports.WithSerialize.serialize
 
-      Serialize the given value, unless it is ``None``, already a Data type, or no serializer function is defined.
-
-      :param value: the value to be serialized
-      :returns: a serialized version of the value or the unchanged value
+      .. autodoc2-docstring:: aiida.engine.processes.ports.WithSerialize.serialize
+         :renderer: rst
 
 .. py:class:: WorkChain(inputs: dict | None = None, logger: logging.Logger | None = None, runner: aiida.engine.runners.Runner | None = None, enable_persistence: bool = True)
    :canonical: aiida.engine.processes.workchains.workchain.WorkChain
 
    Bases: :py:obj:`aiida.engine.processes.process.Process`
 
-   The `WorkChain` class is the principle component to implement workflows in AiiDA.
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a WorkChain instance.
-
-   Construct the instance only if it is a sub class of `WorkChain`, otherwise raise `InvalidOperation`.
-
-   :param inputs: work chain inputs
-   :param logger: aiida logger
-   :param runner: work chain runner
-   :param enable_persistence: whether to persist this work chain
-
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.__init__
+      :renderer: rst
 
    .. py:attribute:: _node_class
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._node_class
       :value: None
 
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._node_class
+         :renderer: rst
+
    .. py:attribute:: _spec_class
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._spec_class
       :value: None
+
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._spec_class
+         :renderer: rst
 
    .. py:attribute:: _STEPPER_STATE
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._STEPPER_STATE
       :value: 'stepper_state'
 
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._STEPPER_STATE
+         :renderer: rst
+
    .. py:attribute:: _CONTEXT
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._CONTEXT
       :value: 'CONTEXT'
+
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._CONTEXT
+         :renderer: rst
 
    .. py:method:: spec() -> aiida.engine.processes.workchains.workchain.WorkChainSpec
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.spec
       :classmethod:
 
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.spec
+         :renderer: rst
+
    .. py:property:: node
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.node
       :type: aiida.orm.WorkChainNode
 
-      Return the ProcessNode used by this process to represent itself in the database.
-
-      :return: instance of sub class of ProcessNode
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.node
+         :renderer: rst
 
    .. py:property:: ctx
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.ctx
       :type: aiida.common.extendeddicts.AttributeDict
 
-      Get the context.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.ctx
+         :renderer: rst
 
    .. py:method:: save_instance_state(out_state, save_context)
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.save_instance_state
 
-      Save instance state.
-
-      :param out_state: state to save in
-
-      :param save_context:
-      :type save_context: :class:`!plumpy.persistence.LoadSaveContext`
-
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.save_instance_state
+         :renderer: rst
 
    .. py:method:: load_instance_state(saved_state, load_context)
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.load_instance_state
 
-      Load instance state.
-
-      :param saved_state: saved instance state
-      :param load_context:
-
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.load_instance_state
+         :renderer: rst
 
    .. py:method:: on_run()
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.on_run
 
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.on_run
+         :renderer: rst
+
    .. py:method:: _resolve_nested_context(key: str) -> tuple[aiida.common.extendeddicts.AttributeDict, str]
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._resolve_nested_context
 
-      Returns a reference to a sub-dictionary of the context and the last key,
-      after resolving a potentially segmented key where required sub-dictionaries are created as needed.
-
-      :param key: A key into the context, where words before a dot are interpreted as a key for a sub-dictionary
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._resolve_nested_context
+         :renderer: rst
 
    .. py:method:: _insert_awaitable(awaitable: aiida.engine.processes.workchains.awaitable.Awaitable) -> None
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._insert_awaitable
 
-      Insert an awaitable that should be terminated before before continuing to the next step.
-
-      :param awaitable: the thing to await
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._insert_awaitable
+         :renderer: rst
 
    .. py:method:: _resolve_awaitable(awaitable: aiida.engine.processes.workchains.awaitable.Awaitable, value: typing.Any) -> None
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._resolve_awaitable
 
-      Resolve an awaitable.
-
-      Precondition: must be an awaitable that was previously inserted.
-
-      :param awaitable: the awaitable to resolve
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._resolve_awaitable
+         :renderer: rst
 
    .. py:method:: to_context(**kwargs: aiida.engine.processes.workchains.awaitable.Awaitable | aiida.orm.ProcessNode) -> None
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.to_context
 
-      Add a dictionary of awaitables to the context.
-
-      This is a convenience method that provides syntactic sugar, for a user to add multiple intersteps that will
-      assign a certain value to the corresponding key in the context of the work chain.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.to_context
+         :renderer: rst
 
    .. py:method:: _update_process_status() -> None
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._update_process_status
 
-      Set the process status with a message accounting the current sub processes that we are waiting for.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._update_process_status
+         :renderer: rst
 
    .. py:method:: run() -> typing.Any
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.run
 
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.run
+         :renderer: rst
+
    .. py:method:: _do_step() -> typing.Any
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._do_step
 
-      Execute the next step in the outline and return the result.
-
-      If the stepper returns a non-finished status and the return value is of type ToContext, the contents of the
-      ToContext container will be turned into awaitables if necessary. If any awaitables were created, the process
-      will enter in the Wait state, otherwise it will go to Continue. When the stepper returns that it is done, the
-      stepper result will be converted to None and returned, unless it is an integer or instance of ExitCode.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._do_step
+         :renderer: rst
 
    .. py:method:: _store_nodes(data: typing.Any) -> None
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._store_nodes
 
-      Recurse through a data structure and store any unstored nodes that are found along the way
-
-      :param data: a data structure potentially containing unstored nodes
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._store_nodes
+         :renderer: rst
 
    .. py:method:: on_exiting() -> None
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.on_exiting
 
-      Ensure that any unstored nodes in the context are stored, before the state is exited
-
-      After the state is exited the next state will be entered and if persistence is enabled, a checkpoint will
-      be saved. If the context contains unstored nodes, the serialization necessary for checkpointing will fail.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.on_exiting
+         :renderer: rst
 
    .. py:method:: on_wait(awaitables: typing.Sequence[aiida.engine.processes.workchains.awaitable.Awaitable])
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain.on_wait
 
-      Entering the WAITING state.
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain.on_wait
+         :renderer: rst
 
    .. py:method:: _action_awaitables() -> None
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._action_awaitables
 
-      Handle the awaitables that are currently registered with the work chain.
-
-      Depending on the class type of the awaitable's target a different callback
-      function will be bound with the awaitable and the runner will be asked to
-      call it when the target is completed
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._action_awaitables
+         :renderer: rst
 
    .. py:method:: _on_awaitable_finished(awaitable: aiida.engine.processes.workchains.awaitable.Awaitable) -> None
       :canonical: aiida.engine.processes.workchains.workchain.WorkChain._on_awaitable_finished
 
-      Callback function, for when an awaitable process instance is completed.
-
-      The awaitable will be effectuated on the context of the work chain and removed from the internal list. If all
-      awaitables have been dealt with, the work chain process is resumed.
-
-      :param awaitable: an Awaitable instance
+      .. autodoc2-docstring:: aiida.engine.processes.workchains.workchain.WorkChain._on_awaitable_finished
+         :renderer: rst
 
 .. py:function:: append_(target: typing.Union[aiida.engine.processes.workchains.awaitable.Awaitable, aiida.orm.ProcessNode]) -> aiida.engine.processes.workchains.awaitable.Awaitable
    :canonical: aiida.engine.processes.workchains.context.append_
 
-   Convenience function that will construct an Awaitable for a given class instance
-   with the context action set to APPEND. When the awaitable target is completed
-   it will be appended to a list in the context for a key that is to be defined later
-
-   :param target: an instance of a Process or Awaitable
-
-   :returns: the awaitable
-
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.context.append_
+      :renderer: rst
 
 .. py:function:: assign_(target: typing.Union[aiida.engine.processes.workchains.awaitable.Awaitable, aiida.orm.ProcessNode]) -> aiida.engine.processes.workchains.awaitable.Awaitable
    :canonical: aiida.engine.processes.workchains.context.assign_
 
-   Convenience function that will construct an Awaitable for a given class instance
-   with the context action set to ASSIGN. When the awaitable target is completed
-   it will be assigned to the context for a key that is to be defined later
-
-   :param target: an instance of a Process or Awaitable
-
-   :returns: the awaitable
-
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.context.assign_
+      :renderer: rst
 
 .. py:function:: calcfunction(function: aiida.engine.processes.functions.FunctionType) -> aiida.engine.processes.functions.FunctionType
    :canonical: aiida.engine.processes.functions.calcfunction
 
-   A decorator to turn a standard python function into a calcfunction.
-   Example usage:
-
-   >>> from aiida.orm import Int
-   >>>
-   >>> # Define the calcfunction
-   >>> @calcfunction
-   >>> def sum(a, b):
-   >>>    return a + b
-   >>> # Run it with some input
-   >>> r = sum(Int(4), Int(5))
-   >>> print(r)
-   9
-   >>> r.base.links.get_incoming().all() # doctest: +SKIP
-   [Neighbor(link_type='', link_label='result',
-   node=<CalcFunctionNode: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>)]
-   >>> r.base.links.get_incoming().get_node_by_label('result').base.links.get_incoming().all_nodes()
-   [4, 5]
-
-   :param function: The function to decorate.
-   :return: The decorated function.
+   .. autodoc2-docstring:: aiida.engine.processes.functions.calcfunction
+      :renderer: rst
 
 .. py:function:: construct_awaitable(target: typing.Union[aiida.engine.processes.workchains.awaitable.Awaitable, aiida.orm.ProcessNode]) -> aiida.engine.processes.workchains.awaitable.Awaitable
    :canonical: aiida.engine.processes.workchains.awaitable.construct_awaitable
 
-   Construct an instance of the Awaitable class that will contain the information
-   related to the action to be taken with respect to the context once the awaitable
-   object is completed.
-
-   The awaitable is a simple dictionary with the following keys
-
-       * pk: the pk of the node that is being waited on
-       * action: the context action to be performed upon completion
-       * outputs: a boolean that toggles whether the node itself
-
-   Currently the only awaitable classes are ProcessNode and Workflow
-   The only awaitable actions are the Assign and Append operators
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.awaitable.construct_awaitable
+      :renderer: rst
 
 .. py:function:: get_object_loader() -> aiida.engine.persistence.ObjectLoader
    :canonical: aiida.engine.persistence.get_object_loader
 
-   Return the global AiiDA object loader.
-
-   :return: The global object loader
-
+   .. autodoc2-docstring:: aiida.engine.persistence.get_object_loader
+      :renderer: rst
 
 .. py:function:: interruptable_task(coro: typing.Callable[[aiida.engine.utils.InterruptableFuture], typing.Awaitable[typing.Any]], loop: typing.Optional[asyncio.AbstractEventLoop] = None) -> aiida.engine.utils.InterruptableFuture
    :canonical: aiida.engine.utils.interruptable_task
 
-   Turn the given coroutine into an interruptable task by turning it into an InterruptableFuture and returning it.
-
-   :param coro: the coroutine that should be made interruptable with object of InterutableFuture as last paramenter
-   :param loop: the event loop in which to run the coroutine, by default uses asyncio.get_event_loop()
-   :return: an InterruptableFuture
+   .. autodoc2-docstring:: aiida.engine.utils.interruptable_task
+      :renderer: rst
 
 .. py:function:: is_process_function(function: typing.Any) -> bool
    :canonical: aiida.engine.utils.is_process_function
 
-   Return whether the given function is a process function
-
-   :param function: a function
-   :returns: True if the function is a wrapped process function, False otherwise
+   .. autodoc2-docstring:: aiida.engine.utils.is_process_function
+      :renderer: rst
 
 .. py:function:: process_handler(wrapped: typing.Optional[types.FunctionType] = None, *, priority: int = 0, exit_codes: typing.Union[None, aiida.engine.processes.exit_code.ExitCode, typing.List[aiida.engine.processes.exit_code.ExitCode]] = None, enabled: bool = True) -> types.FunctionType
    :canonical: aiida.engine.processes.workchains.utils.process_handler
 
-   Decorator to register a :class:`~aiida.engine.BaseRestartWorkChain` instance method as a process handler.
-
-   The decorator will validate the `priority` and `exit_codes` optional keyword arguments and then add itself as an
-   attribute to the `wrapped` instance method. This is used in the `inspect_process` to return all instance methods of
-   the class that have been decorated by this function and therefore are considered to be process handlers.
-
-   Requirements on the function signature of process handling functions. The function to which the decorator is applied
-   needs to take two arguments:
-
-       * `self`: This is the instance of the work chain itself
-       * `node`: This is the process node that finished and is to be investigated
-
-   The function body typically consists of a conditional that will check for a particular problem that might have
-   occurred for the sub process. If a particular problem is handled, the process handler should return an instance of
-   the :class:`aiida.engine.ProcessHandlerReport` tuple. If no other process handlers should be considered, the set
-   `do_break` attribute should be set to `True`. If the work chain is to be aborted entirely, the `exit_code` of the
-   report can be set to an `ExitCode` instance with a non-zero status.
-
-   :param wrapped: the work chain method to register the process handler with
-   :param priority: optional integer that defines the order in which registered handlers will be called during the
-       handling of a finished process. Higher priorities will be handled first. Default value is `0`. Multiple handlers
-       with the same priority is allowed, but the order of those is not well defined.
-   :param exit_codes: single or list of `ExitCode` instances. If defined, the handler will return `None` if the exit
-       code set on the `node` does not appear in the `exit_codes`. This is useful to have a handler called only when
-       the process failed with a specific exit code.
-   :param enabled: boolean, by default True, which will cause the handler to be called during `inspect_process`. When
-       set to `False`, the handler will be skipped. This static value can be overridden on a per work chain instance
-       basis through the input `handler_overrides`.
+   .. autodoc2-docstring:: aiida.engine.processes.workchains.utils.process_handler
+      :renderer: rst
 
 .. py:function:: run(process: aiida.engine.launch.TYPE_RUN_PROCESS, *args: typing.Any, **inputs: typing.Any) -> typing.Dict[str, typing.Any]
    :canonical: aiida.engine.launch.run
 
-   Run the process with the supplied inputs in a local runner that will block until the process is completed.
-
-   :param process: the process class or process function to run
-   :param inputs: the inputs to be passed to the process
-
-   :return: the outputs of the process
-
+   .. autodoc2-docstring:: aiida.engine.launch.run
+      :renderer: rst
 
 .. py:function:: run_get_node(process: aiida.engine.launch.TYPE_RUN_PROCESS, *args: typing.Any, **inputs: typing.Any) -> typing.Tuple[typing.Dict[str, typing.Any], aiida.orm.ProcessNode]
    :canonical: aiida.engine.launch.run_get_node
 
-   Run the process with the supplied inputs in a local runner that will block until the process is completed.
-
-   :param process: the process class, instance, builder or function to run
-   :param inputs: the inputs to be passed to the process
-
-   :return: tuple of the outputs of the process and the process node
-
+   .. autodoc2-docstring:: aiida.engine.launch.run_get_node
+      :renderer: rst
 
 .. py:function:: run_get_pk(process: aiida.engine.launch.TYPE_RUN_PROCESS, *args: typing.Any, **inputs: typing.Any) -> typing.Tuple[typing.Dict[str, typing.Any], int]
    :canonical: aiida.engine.launch.run_get_pk
 
-   Run the process with the supplied inputs in a local runner that will block until the process is completed.
-
-   :param process: the process class, instance, builder or function to run
-   :param inputs: the inputs to be passed to the process
-
-   :return: tuple of the outputs of the process and process node pk
-
+   .. autodoc2-docstring:: aiida.engine.launch.run_get_pk
+      :renderer: rst
 
 .. py:function:: submit(process: aiida.engine.launch.TYPE_SUBMIT_PROCESS, **inputs: typing.Any) -> aiida.orm.ProcessNode
    :canonical: aiida.engine.launch.submit
 
-   Submit the process with the supplied inputs to the daemon immediately returning control to the interpreter.
-
-   .. warning: this should not be used within another process. Instead, there one should use the `submit` method of
-       the wrapping process itself, i.e. use `self.submit`.
-
-   .. warning: submission of processes requires `store_provenance=True`
-
-   :param process: the process class, instance or builder to submit
-   :param inputs: the inputs to be passed to the process
-
-   :return: the calculation node of the process
-
+   .. autodoc2-docstring:: aiida.engine.launch.submit
+      :renderer: rst
 
 .. py:function:: workfunction(function: aiida.engine.processes.functions.FunctionType) -> aiida.engine.processes.functions.FunctionType
    :canonical: aiida.engine.processes.functions.workfunction
 
-   A decorator to turn a standard python function into a workfunction.
-   Example usage:
-
-   >>> from aiida.orm import Int
-   >>>
-   >>> # Define the workfunction
-   >>> @workfunction
-   >>> def select(a, b):
-   >>>    return a
-   >>> # Run it with some input
-   >>> r = select(Int(4), Int(5))
-   >>> print(r)
-   4
-   >>> r.base.links.get_incoming().all() # doctest: +SKIP
-   [Neighbor(link_type='', link_label='result',
-   node=<WorkFunctionNode: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>)]
-   >>> r.base.links.get_incoming().get_node_by_label('result').base.links.get_incoming().all_nodes()
-   [4, 5]
-
-   :param function: The function to decorate.
-   :return: The decorated function.
+   .. autodoc2-docstring:: aiida.engine.processes.functions.workfunction
+      :renderer: rst

--- a/docs/apidocs/aiida/aiida.manage.rst
+++ b/docs/apidocs/aiida/aiida.manage.rst
@@ -7,15 +7,9 @@
 Description
 -----------
 
-Managing an AiiDA instance:
-
-    * configuration file
-    * profiles
-    * databases
-    * repositories
-    * external components (such as Postgres, RabbitMQ)
-
-.. note:: Modules in this sub package may require the database environment to be loaded
+.. autodoc2-docstring:: aiida.manage
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -28,17 +22,29 @@ Classes
    :align: left
 
    * - :py:obj:`Config <aiida.manage.configuration.config.Config>`
-     - Object that represents the configuration file of an AiiDA instance.
+     - .. autodoc2-docstring:: aiida.manage.configuration.config.Config
+          :renderer: rst
+          :summary:
    * - :py:obj:`Option <aiida.manage.configuration.options.Option>`
-     - Represent a configuration option schema.
+     - .. autodoc2-docstring:: aiida.manage.configuration.options.Option
+          :renderer: rst
+          :summary:
    * - :py:obj:`Postgres <aiida.manage.external.postgres.Postgres>`
-     - Adds convenience functions to :py:class:`pgsu.PGSU`.
+     - .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProcessLauncher <aiida.manage.external.rmq.launcher.ProcessLauncher>`
-     - A sub class of :class:`plumpy.ProcessLauncher` to launch a ``Process``.
+     - .. autodoc2-docstring:: aiida.manage.external.rmq.launcher.ProcessLauncher
+          :renderer: rst
+          :summary:
    * - :py:obj:`Profile <aiida.manage.configuration.profile.Profile>`
-     - Class that models a profile as it is stored in the configuration file of an AiiDA instance.
+     - .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile
+          :renderer: rst
+          :summary:
    * - :py:obj:`RabbitmqManagementClient <aiida.manage.external.rmq.client.RabbitmqManagementClient>`
-     - Client for RabbitMQ Management HTTP API.
+     - .. autodoc2-docstring:: aiida.manage.external.rmq.client.RabbitmqManagementClient
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -48,39 +54,73 @@ Functions
    :align: left
 
    * - :py:obj:`check_and_migrate_config <aiida.manage.configuration.migrations.migrations.check_and_migrate_config>`
-     - Checks if the config needs to be migrated, and performs the migration if needed.
+     - .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.check_and_migrate_config
+          :renderer: rst
+          :summary:
    * - :py:obj:`config_needs_migrating <aiida.manage.configuration.migrations.migrations.config_needs_migrating>`
-     - Checks if the config needs to be migrated.
+     - .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.config_needs_migrating
+          :renderer: rst
+          :summary:
    * - :py:obj:`config_schema <aiida.manage.configuration.config.config_schema>`
-     - Return the configuration schema.
+     - .. autodoc2-docstring:: aiida.manage.configuration.config.config_schema
+          :renderer: rst
+          :summary:
    * - :py:obj:`disable_caching <aiida.manage.caching.disable_caching>`
-     - Context manager to disable caching, either for a specific node class, or globally.
+     - .. autodoc2-docstring:: aiida.manage.caching.disable_caching
+          :renderer: rst
+          :summary:
    * - :py:obj:`downgrade_config <aiida.manage.configuration.migrations.migrations.downgrade_config>`
-     - Run the registered configuration migrations down to the target version.
+     - .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.downgrade_config
+          :renderer: rst
+          :summary:
    * - :py:obj:`enable_caching <aiida.manage.caching.enable_caching>`
-     - Context manager to enable caching, either for a specific node class, or globally.
+     - .. autodoc2-docstring:: aiida.manage.caching.enable_caching
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_current_version <aiida.manage.configuration.migrations.migrations.get_current_version>`
-     - Return the current version of the config.
+     - .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.get_current_version
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_launch_queue_name <aiida.manage.external.rmq.utils.get_launch_queue_name>`
-     - Return the launch queue name with an optional prefix.
+     - .. autodoc2-docstring:: aiida.manage.external.rmq.utils.get_launch_queue_name
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_manager <aiida.manage.manager.get_manager>`
-     - Return the AiiDA global manager instance.
+     - .. autodoc2-docstring:: aiida.manage.manager.get_manager
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_message_exchange_name <aiida.manage.external.rmq.utils.get_message_exchange_name>`
-     - Return the message exchange name for a given prefix.
+     - .. autodoc2-docstring:: aiida.manage.external.rmq.utils.get_message_exchange_name
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_option <aiida.manage.configuration.options.get_option>`
-     - Return option.
+     - .. autodoc2-docstring:: aiida.manage.configuration.options.get_option
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_option_names <aiida.manage.configuration.options.get_option_names>`
-     - Return a list of available option names.
+     - .. autodoc2-docstring:: aiida.manage.configuration.options.get_option_names
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_rmq_url <aiida.manage.external.rmq.utils.get_rmq_url>`
-     - Return the URL to connect to RabbitMQ.
+     - .. autodoc2-docstring:: aiida.manage.external.rmq.utils.get_rmq_url
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_task_exchange_name <aiida.manage.external.rmq.utils.get_task_exchange_name>`
-     - Return the task exchange name for a given prefix.
+     - .. autodoc2-docstring:: aiida.manage.external.rmq.utils.get_task_exchange_name
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_use_cache <aiida.manage.caching.get_use_cache>`
-     - Return whether the caching mechanism should be used for the given process type according to the configuration.
+     - .. autodoc2-docstring:: aiida.manage.caching.get_use_cache
+          :renderer: rst
+          :summary:
    * - :py:obj:`parse_option <aiida.manage.configuration.options.parse_option>`
-     - Parse and validate a value for a configuration option.
+     - .. autodoc2-docstring:: aiida.manage.configuration.options.parse_option
+          :renderer: rst
+          :summary:
    * - :py:obj:`upgrade_config <aiida.manage.configuration.migrations.migrations.upgrade_config>`
-     - Run the registered configuration migrations up to the target version.
+     - .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.upgrade_config
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -90,13 +130,21 @@ Data
    :align: left
 
    * - :py:obj:`BROKER_DEFAULTS <aiida.manage.external.rmq.defaults.BROKER_DEFAULTS>`
-     - 
+     - .. autodoc2-docstring:: aiida.manage.external.rmq.defaults.BROKER_DEFAULTS
+          :renderer: rst
+          :summary:
    * - :py:obj:`CURRENT_CONFIG_VERSION <aiida.manage.configuration.migrations.migrations.CURRENT_CONFIG_VERSION>`
-     - 
+     - .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.CURRENT_CONFIG_VERSION
+          :renderer: rst
+          :summary:
    * - :py:obj:`MIGRATIONS <aiida.manage.configuration.migrations.migrations.MIGRATIONS>`
-     - 
+     - .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.MIGRATIONS
+          :renderer: rst
+          :summary:
    * - :py:obj:`OLDEST_COMPATIBLE_CONFIG_VERSION <aiida.manage.configuration.migrations.migrations.OLDEST_COMPATIBLE_CONFIG_VERSION>`
-     - 
+     - .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.OLDEST_COMPATIBLE_CONFIG_VERSION
+          :renderer: rst
+          :summary:
 
 External
 ~~~~~~~~
@@ -106,9 +154,13 @@ External
    :align: left
 
    * - :py:obj:`DEFAULT_DSN <pgsu.DEFAULT_DSN>`
-     - 
+     - .. autodoc2-docstring:: pgsu.DEFAULT_DSN
+          :renderer: rst
+          :summary:
    * - :py:obj:`PostgresConnectionMode <pgsu.PostgresConnectionMode>`
-     - 
+     - .. autodoc2-docstring:: pgsu.PostgresConnectionMode
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -117,909 +169,844 @@ API
    :canonical: aiida.manage.external.rmq.defaults.BROKER_DEFAULTS
    :value: None
 
+   .. autodoc2-docstring:: aiida.manage.external.rmq.defaults.BROKER_DEFAULTS
+      :renderer: rst
+
 .. py:data:: CURRENT_CONFIG_VERSION
    :canonical: aiida.manage.configuration.migrations.migrations.CURRENT_CONFIG_VERSION
    :value: 9
 
+   .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.CURRENT_CONFIG_VERSION
+      :renderer: rst
+
 .. py:class:: Config(filepath: str, config: dict, validate: bool = True)
    :canonical: aiida.manage.configuration.config.Config
 
-   Object that represents the configuration file of an AiiDA instance.
+   .. autodoc2-docstring:: aiida.manage.configuration.config.Config
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Instantiate a configuration object from a configuration dictionary and its filepath.
-
-   If an empty dictionary is passed, the constructor will create the skeleton configuration dictionary.
-
-   :param filepath: the absolute filepath of the configuration file
-   :param config: the content of the configuration file in dictionary form
-   :param validate: validate the dictionary against the schema
+   .. autodoc2-docstring:: aiida.manage.configuration.config.Config.__init__
+      :renderer: rst
 
    .. py:attribute:: KEY_VERSION
       :canonical: aiida.manage.configuration.config.Config.KEY_VERSION
       :value: 'CONFIG_VERSION'
 
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.KEY_VERSION
+         :renderer: rst
+
    .. py:attribute:: KEY_VERSION_CURRENT
       :canonical: aiida.manage.configuration.config.Config.KEY_VERSION_CURRENT
       :value: 'CURRENT'
+
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.KEY_VERSION_CURRENT
+         :renderer: rst
 
    .. py:attribute:: KEY_VERSION_OLDEST_COMPATIBLE
       :canonical: aiida.manage.configuration.config.Config.KEY_VERSION_OLDEST_COMPATIBLE
       :value: 'OLDEST_COMPATIBLE'
 
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.KEY_VERSION_OLDEST_COMPATIBLE
+         :renderer: rst
+
    .. py:attribute:: KEY_DEFAULT_PROFILE
       :canonical: aiida.manage.configuration.config.Config.KEY_DEFAULT_PROFILE
       :value: 'default_profile'
+
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.KEY_DEFAULT_PROFILE
+         :renderer: rst
 
    .. py:attribute:: KEY_PROFILES
       :canonical: aiida.manage.configuration.config.Config.KEY_PROFILES
       :value: 'profiles'
 
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.KEY_PROFILES
+         :renderer: rst
+
    .. py:attribute:: KEY_OPTIONS
       :canonical: aiida.manage.configuration.config.Config.KEY_OPTIONS
       :value: 'options'
+
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.KEY_OPTIONS
+         :renderer: rst
 
    .. py:attribute:: KEY_SCHEMA
       :canonical: aiida.manage.configuration.config.Config.KEY_SCHEMA
       :value: '$schema'
 
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.KEY_SCHEMA
+         :renderer: rst
+
    .. py:method:: from_file(filepath)
       :canonical: aiida.manage.configuration.config.Config.from_file
       :classmethod:
 
-      Instantiate a configuration object from the contents of a given file.
-
-      .. note:: if the filepath does not exist an empty file will be created with the current default configuration
-          and will be written to disk. If the filepath does already exist but contains a configuration with an
-          outdated schema, the content will be migrated and then written to disk.
-
-      :param filepath: the absolute path to the configuration file
-      :return: `Config` instance
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.from_file
+         :renderer: rst
 
    .. py:method:: _backup(filepath)
       :canonical: aiida.manage.configuration.config.Config._backup
       :classmethod:
 
-      Create a backup of the configuration file with the given filepath.
-
-      :param filepath: absolute path to the configuration file to backup
-      :return: the absolute path of the created backup
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config._backup
+         :renderer: rst
 
    .. py:method:: validate(config: dict, filepath: typing.Optional[str] = None)
       :canonical: aiida.manage.configuration.config.Config.validate
       :staticmethod:
 
-      Validate a configuration dictionary.
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.validate
+         :renderer: rst
 
    .. py:method:: __eq__(other)
       :canonical: aiida.manage.configuration.config.Config.__eq__
 
-      Two configurations are considered equal, when their dictionaries are equal.
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.__eq__
+         :renderer: rst
 
    .. py:method:: __ne__(other)
       :canonical: aiida.manage.configuration.config.Config.__ne__
 
-      Two configurations are considered unequal, when their dictionaries are unequal.
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.__ne__
+         :renderer: rst
 
    .. py:method:: handle_invalid(message)
       :canonical: aiida.manage.configuration.config.Config.handle_invalid
 
-      Handle an incoming invalid configuration dictionary.
-
-      The current content of the configuration file will be written to a backup file.
-
-      :param message: a string message to echo with describing the infraction
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.handle_invalid
+         :renderer: rst
 
    .. py:property:: dictionary
       :canonical: aiida.manage.configuration.config.Config.dictionary
       :type: dict
 
-      Return the dictionary representation of the config as it would be written to file.
-
-      :return: dictionary representation of config as it should be written to file
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.dictionary
+         :renderer: rst
 
    .. py:property:: version
       :canonical: aiida.manage.configuration.config.Config.version
 
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.version
+         :renderer: rst
+
    .. py:property:: version_oldest_compatible
       :canonical: aiida.manage.configuration.config.Config.version_oldest_compatible
+
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.version_oldest_compatible
+         :renderer: rst
 
    .. py:property:: version_settings
       :canonical: aiida.manage.configuration.config.Config.version_settings
 
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.version_settings
+         :renderer: rst
+
    .. py:property:: filepath
       :canonical: aiida.manage.configuration.config.Config.filepath
+
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.filepath
+         :renderer: rst
 
    .. py:property:: dirpath
       :canonical: aiida.manage.configuration.config.Config.dirpath
 
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.dirpath
+         :renderer: rst
+
    .. py:property:: default_profile_name
       :canonical: aiida.manage.configuration.config.Config.default_profile_name
 
-      Return the default profile name.
-
-      :return: the default profile name or None if not defined
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.default_profile_name
+         :renderer: rst
 
    .. py:property:: profile_names
       :canonical: aiida.manage.configuration.config.Config.profile_names
 
-      Return the list of profile names.
-
-      :return: list of profile names
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.profile_names
+         :renderer: rst
 
    .. py:property:: profiles
       :canonical: aiida.manage.configuration.config.Config.profiles
 
-      Return the list of profiles.
-
-      :return: the profiles
-      :rtype: list of `Profile` instances
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.profiles
+         :renderer: rst
 
    .. py:method:: validate_profile(name)
       :canonical: aiida.manage.configuration.config.Config.validate_profile
 
-      Validate that a profile exists.
-
-      :param name: name of the profile:
-      :raises aiida.common.ProfileConfigurationError: if the name is not found in the configuration file
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.validate_profile
+         :renderer: rst
 
    .. py:method:: get_profile(name: typing.Optional[str] = None) -> aiida.manage.configuration.profile.Profile
       :canonical: aiida.manage.configuration.config.Config.get_profile
 
-      Return the profile for the given name or the default one if not specified.
-
-      :return: the profile instance or None if it does not exist
-      :raises aiida.common.ProfileConfigurationError: if the name is not found in the configuration file
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.get_profile
+         :renderer: rst
 
    .. py:method:: add_profile(profile)
       :canonical: aiida.manage.configuration.config.Config.add_profile
 
-      Add a profile to the configuration.
-
-      :param profile: the profile configuration dictionary
-      :return: self
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.add_profile
+         :renderer: rst
 
    .. py:method:: update_profile(profile)
       :canonical: aiida.manage.configuration.config.Config.update_profile
 
-      Update a profile in the configuration.
-
-      :param profile: the profile instance to update
-      :return: self
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.update_profile
+         :renderer: rst
 
    .. py:method:: remove_profile(name)
       :canonical: aiida.manage.configuration.config.Config.remove_profile
 
-      Remove a profile from the configuration.
-
-      :param name: the name of the profile to remove
-      :raises aiida.common.ProfileConfigurationError: if the given profile does not exist
-      :return: self
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.remove_profile
+         :renderer: rst
 
    .. py:method:: delete_profile(name: str, include_database: bool = True, include_database_user: bool = False, include_repository: bool = True)
       :canonical: aiida.manage.configuration.config.Config.delete_profile
 
-      Delete a profile including its storage.
-
-      :param include_database: also delete the database configured for the profile.
-      :param include_database_user: also delete the database user configured for the profile.
-      :param include_repository: also delete the repository configured for the profile.
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.delete_profile
+         :renderer: rst
 
    .. py:method:: set_default_profile(name, overwrite=False)
       :canonical: aiida.manage.configuration.config.Config.set_default_profile
 
-      Set the given profile as the new default.
-
-      :param name: name of the profile to set as new default
-      :param overwrite: when True, set the profile as the new default even if a default profile is already defined
-      :raises aiida.common.ProfileConfigurationError: if the given profile does not exist
-      :return: self
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.set_default_profile
+         :renderer: rst
 
    .. py:property:: options
       :canonical: aiida.manage.configuration.config.Config.options
 
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.options
+         :renderer: rst
+
    .. py:method:: set_option(option_name, option_value, scope=None, override=True)
       :canonical: aiida.manage.configuration.config.Config.set_option
 
-      Set a configuration option for a certain scope.
-
-      :param option_name: the name of the configuration option
-      :param option_value: the option value
-      :param scope: set the option for this profile or globally if not specified
-      :param override: boolean, if False, will not override the option if it already exists
-
-      :returns: the parsed value (potentially cast to a valid type)
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.set_option
+         :renderer: rst
 
    .. py:method:: unset_option(option_name: str, scope=None)
       :canonical: aiida.manage.configuration.config.Config.unset_option
 
-      Unset a configuration option for a certain scope.
-
-      :param option_name: the name of the configuration option
-      :param scope: unset the option for this profile or globally if not specified
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.unset_option
+         :renderer: rst
 
    .. py:method:: get_option(option_name, scope=None, default=True)
       :canonical: aiida.manage.configuration.config.Config.get_option
 
-      Get a configuration option for a certain scope.
-
-      :param option_name: the name of the configuration option
-      :param scope: get the option for this profile or globally if not specified
-      :param default: boolean, If True will return the option default, even if not defined within the given scope
-      :return: the option value or None if not set for the given scope
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.get_option
+         :renderer: rst
 
    .. py:method:: get_options(scope: typing.Optional[str] = None) -> typing.Dict[str, typing.Tuple[aiida.manage.configuration.options.Option, str, typing.Any]]
       :canonical: aiida.manage.configuration.config.Config.get_options
 
-      Return a dictionary of all option values and their source ('profile', 'global', or 'default').
-
-      :param scope: the profile name or globally if not specified
-      :returns: (option, source, value)
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.get_options
+         :renderer: rst
 
    .. py:method:: store()
       :canonical: aiida.manage.configuration.config.Config.store
 
-      Write the current config to file.
-
-      .. note:: if the configuration file already exists on disk and its contents differ from those in memory, a
-          backup of the original file on disk will be created before overwriting it.
-
-      :return: self
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config.store
+         :renderer: rst
 
    .. py:method:: _atomic_write(filepath=None)
       :canonical: aiida.manage.configuration.config.Config._atomic_write
 
-      Write the config as it is in memory, i.e. the contents of ``self.dictionary``, to disk.
-
-      .. note:: this command will write the config from memory to a temporary file in the same directory as the
-          target file ``filepath``. It will then use ``os.rename`` to move the temporary file to ``filepath`` which
-          will be overwritten if it already exists. The ``os.rename`` is the operation that gives the best guarantee
-          of being atomic within the limitations of the application.
-
-      :param filepath: optional filepath to write the contents to, if not specified, the default filename is used.
+      .. autodoc2-docstring:: aiida.manage.configuration.config.Config._atomic_write
+         :renderer: rst
 
 .. py:exception:: ConfigValidationError(message: str, keypath: typing.Sequence[typing.Any] = (), schema: typing.Optional[dict] = None, filepath: typing.Optional[str] = None)
    :canonical: aiida.manage.configuration.config.ConfigValidationError
 
    Bases: :py:obj:`aiida.common.exceptions.ConfigurationError`
 
-   Configuration error raised when the file contents fails validation.
+   .. autodoc2-docstring:: aiida.manage.configuration.config.ConfigValidationError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.manage.configuration.config.ConfigValidationError.__init__
+      :renderer: rst
 
    .. py:method:: __str__() -> str
       :canonical: aiida.manage.configuration.config.ConfigValidationError.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.manage.configuration.config.ConfigValidationError.__str__
+         :renderer: rst
 
 .. py:data:: MIGRATIONS
    :canonical: aiida.manage.configuration.migrations.migrations.MIGRATIONS
    :value: ()
+
+   .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.MIGRATIONS
+      :renderer: rst
 
 .. py:exception:: ManagementApiConnectionError()
    :canonical: aiida.manage.external.rmq.client.ManagementApiConnectionError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
-   Raised when no connection can be made to the management HTTP API.
+   .. autodoc2-docstring:: aiida.manage.external.rmq.client.ManagementApiConnectionError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.manage.external.rmq.client.ManagementApiConnectionError.__init__
+      :renderer: rst
 
 .. py:data:: OLDEST_COMPATIBLE_CONFIG_VERSION
    :canonical: aiida.manage.configuration.migrations.migrations.OLDEST_COMPATIBLE_CONFIG_VERSION
    :value: 9
 
+   .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.OLDEST_COMPATIBLE_CONFIG_VERSION
+      :renderer: rst
+
 .. py:class:: Option(name: str, schema: typing.Dict[str, typing.Any])
    :canonical: aiida.manage.configuration.options.Option
 
-   Represent a configuration option schema.
+   .. autodoc2-docstring:: aiida.manage.configuration.options.Option
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.manage.configuration.options.Option.__init__
+      :renderer: rst
 
    .. py:method:: __str__() -> str
       :canonical: aiida.manage.configuration.options.Option.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.manage.configuration.options.Option.__str__
+         :renderer: rst
 
    .. py:property:: name
       :canonical: aiida.manage.configuration.options.Option.name
       :type: str
 
+      .. autodoc2-docstring:: aiida.manage.configuration.options.Option.name
+         :renderer: rst
+
    .. py:property:: schema
       :canonical: aiida.manage.configuration.options.Option.schema
       :type: typing.Dict[str, typing.Any]
+
+      .. autodoc2-docstring:: aiida.manage.configuration.options.Option.schema
+         :renderer: rst
 
    .. py:property:: valid_type
       :canonical: aiida.manage.configuration.options.Option.valid_type
       :type: typing.Any
 
+      .. autodoc2-docstring:: aiida.manage.configuration.options.Option.valid_type
+         :renderer: rst
+
    .. py:property:: default
       :canonical: aiida.manage.configuration.options.Option.default
       :type: typing.Any
+
+      .. autodoc2-docstring:: aiida.manage.configuration.options.Option.default
+         :renderer: rst
 
    .. py:property:: description
       :canonical: aiida.manage.configuration.options.Option.description
       :type: str
 
+      .. autodoc2-docstring:: aiida.manage.configuration.options.Option.description
+         :renderer: rst
+
    .. py:property:: global_only
       :canonical: aiida.manage.configuration.options.Option.global_only
       :type: bool
 
+      .. autodoc2-docstring:: aiida.manage.configuration.options.Option.global_only
+         :renderer: rst
+
    .. py:method:: validate(value: typing.Any, cast: bool = True) -> typing.Any
       :canonical: aiida.manage.configuration.options.Option.validate
 
-      Validate a value
-
-      :param value: The input value
-      :param cast: Attempt to cast the value to the required type
-
-      :return: The output value
-      :raise: ConfigValidationError
-
+      .. autodoc2-docstring:: aiida.manage.configuration.options.Option.validate
+         :renderer: rst
 
 .. py:class:: Postgres(dbinfo=None, **kwargs)
    :canonical: aiida.manage.external.postgres.Postgres
 
    Bases: :py:obj:`pgsu.PGSU`
 
-   Adds convenience functions to :py:class:`pgsu.PGSU`.
-
-   Provides convenience functions for
-     * creating/dropping users
-     * creating/dropping databases
-
-   etc.
-
-   Example::
-
-       postgres = Postgres()
-       postgres.create_dbuser('username', 'password')
-       if not postgres.db_exists('dbname'):
-           postgres.create_db('username', 'dbname')
+   .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   See documentation of :py:meth:`pgsu.PGSU.__init__`.
+   .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.__init__
+      :renderer: rst
 
    .. py:method:: from_profile(profile: aiida.manage.configuration.Profile, **kwargs)
       :canonical: aiida.manage.external.postgres.Postgres.from_profile
       :classmethod:
 
-      Create Postgres instance with dbinfo from AiiDA profile data.
-
-      Note: This only uses host and port from the profile, since the others are not going to be relevant for the
-        database superuser.
-
-      :param profile: AiiDA profile instance
-      :param kwargs: keyword arguments forwarded to PGSU constructor
-
-      :returns: Postgres instance pre-populated with data from AiiDA profile
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.from_profile
+         :renderer: rst
 
    .. py:method:: dbuser_exists(dbuser)
       :canonical: aiida.manage.external.postgres.Postgres.dbuser_exists
 
-      Find out if postgres user with name dbuser exists
-
-      :param str dbuser: database user to check for
-      :return: (bool) True if user exists, False otherwise
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.dbuser_exists
+         :renderer: rst
 
    .. py:method:: create_dbuser(dbuser, dbpass, privileges='')
       :canonical: aiida.manage.external.postgres.Postgres.create_dbuser
 
-      Create a database user in postgres
-
-      :param str dbuser: Name of the user to be created.
-      :param str dbpass: Password the user should be given.
-      :raises: psycopg2.errors.DuplicateObject if user already exists and
-          self.connection_mode == PostgresConnectionMode.PSYCOPG
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.create_dbuser
+         :renderer: rst
 
    .. py:method:: drop_dbuser(dbuser)
       :canonical: aiida.manage.external.postgres.Postgres.drop_dbuser
 
-      Drop a database user in postgres
-
-      :param str dbuser: Name of the user to be dropped.
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.drop_dbuser
+         :renderer: rst
 
    .. py:method:: check_dbuser(dbuser)
       :canonical: aiida.manage.external.postgres.Postgres.check_dbuser
 
-      Looks up if a given user already exists, prompts for using or creating a differently named one.
-
-      :param str dbuser: Name of the user to be created or reused.
-      :returns: tuple (dbuser, created)
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.check_dbuser
+         :renderer: rst
 
    .. py:method:: db_exists(dbname)
       :canonical: aiida.manage.external.postgres.Postgres.db_exists
 
-      Check wether a postgres database with dbname exists
-
-      :param str dbname: Name of the database to check for
-      :return: (bool), True if database exists, False otherwise
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.db_exists
+         :renderer: rst
 
    .. py:method:: create_db(dbuser, dbname)
       :canonical: aiida.manage.external.postgres.Postgres.create_db
 
-      Create a database in postgres
-
-      :param str dbuser: Name of the user which should own the db.
-      :param str dbname: Name of the database.
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.create_db
+         :renderer: rst
 
    .. py:method:: drop_db(dbname)
       :canonical: aiida.manage.external.postgres.Postgres.drop_db
 
-      Drop a database in postgres
-
-      :param str dbname: Name of the database.
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.drop_db
+         :renderer: rst
 
    .. py:method:: copy_db(src_db, dest_db, dbuser)
       :canonical: aiida.manage.external.postgres.Postgres.copy_db
 
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.copy_db
+         :renderer: rst
+
    .. py:method:: check_db(dbname)
       :canonical: aiida.manage.external.postgres.Postgres.check_db
 
-      Looks up if a database with the name exists, prompts for using or creating a differently named one.
-
-      :param str dbname: Name of the database to be created or reused.
-      :returns: tuple (dbname, created)
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.check_db
+         :renderer: rst
 
    .. py:method:: create_dbuser_db_safe(dbname, dbuser, dbpass)
       :canonical: aiida.manage.external.postgres.Postgres.create_dbuser_db_safe
 
-      Create DB and user + grant privileges.
-
-      Prompts when reusing existing users / databases.
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.create_dbuser_db_safe
+         :renderer: rst
 
    .. py:property:: host_for_psycopg2
       :canonical: aiida.manage.external.postgres.Postgres.host_for_psycopg2
 
-      Return correct host for psycopg2 connection (as required by regular AiiDA operation).
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.host_for_psycopg2
+         :renderer: rst
 
    .. py:property:: port_for_psycopg2
       :canonical: aiida.manage.external.postgres.Postgres.port_for_psycopg2
 
-      Return port for psycopg2 connection (as required by regular AiiDA operation).
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.port_for_psycopg2
+         :renderer: rst
 
    .. py:property:: dbinfo
       :canonical: aiida.manage.external.postgres.Postgres.dbinfo
 
-      Alias for Postgres.dsn.
+      .. autodoc2-docstring:: aiida.manage.external.postgres.Postgres.dbinfo
+         :renderer: rst
 
 .. py:class:: ProcessLauncher
    :canonical: aiida.manage.external.rmq.launcher.ProcessLauncher
 
    Bases: :py:obj:`plumpy.ProcessLauncher`
 
-   A sub class of :class:`plumpy.ProcessLauncher` to launch a ``Process``.
-
-   It overrides the _continue method to make sure the node corresponding to the task can be loaded and
-   that if it is already marked as terminated, it is not continued but the future is reconstructed and returned
+   .. autodoc2-docstring:: aiida.manage.external.rmq.launcher.ProcessLauncher
+      :renderer: rst
 
    .. py:method:: handle_continue_exception(node, exception, message)
       :canonical: aiida.manage.external.rmq.launcher.ProcessLauncher.handle_continue_exception
       :staticmethod:
 
-      Handle exception raised in `_continue` call.
-
-      If the process state of the node has not yet been put to excepted, the exception was raised before the process
-      instance could be reconstructed, for example when the process class could not be loaded, thereby circumventing
-      the exception handling of the state machine. Raising this exception will then acknowledge the process task with
-      RabbitMQ leaving an uncleaned node in the `CREATED` state for ever. Therefore we have to perform the node
-      cleaning manually.
-
-      :param exception: the exception object
-      :param message: string message to use for the log message
+      .. autodoc2-docstring:: aiida.manage.external.rmq.launcher.ProcessLauncher.handle_continue_exception
+         :renderer: rst
 
    .. py:method:: _continue(communicator, pid, nowait, tag=None)
       :canonical: aiida.manage.external.rmq.launcher.ProcessLauncher._continue
       :async:
 
-      Continue the task.
-
-      Note that the task may already have been completed, as indicated from the corresponding the node, in which
-      case it is not continued, but the corresponding future is reconstructed and returned. This scenario may
-      occur when the Process was already completed by another worker that however failed to send the acknowledgment.
-
-      :param communicator: the communicator that called this method
-      :param pid: the pid of the process to continue
-      :param nowait: if True don't wait for the process to finish, just return the pid, otherwise wait and
-          return the results
-      :param tag: the tag of the checkpoint to continue from
+      .. autodoc2-docstring:: aiida.manage.external.rmq.launcher.ProcessLauncher._continue
+         :renderer: rst
 
 .. py:class:: Profile(name: str, config: typing.Mapping[str, typing.Any], validate=True)
    :canonical: aiida.manage.configuration.profile.Profile
 
-   Class that models a profile as it is stored in the configuration file of an AiiDA instance.
+   .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Load a profile with the profile configuration.
+   .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.__init__
+      :renderer: rst
 
    .. py:attribute:: KEY_UUID
       :canonical: aiida.manage.configuration.profile.Profile.KEY_UUID
       :value: 'PROFILE_UUID'
 
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_UUID
+         :renderer: rst
+
    .. py:attribute:: KEY_DEFAULT_USER_EMAIL
       :canonical: aiida.manage.configuration.profile.Profile.KEY_DEFAULT_USER_EMAIL
       :value: 'default_user_email'
+
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_DEFAULT_USER_EMAIL
+         :renderer: rst
 
    .. py:attribute:: KEY_STORAGE
       :canonical: aiida.manage.configuration.profile.Profile.KEY_STORAGE
       :value: 'storage'
 
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_STORAGE
+         :renderer: rst
+
    .. py:attribute:: KEY_PROCESS
       :canonical: aiida.manage.configuration.profile.Profile.KEY_PROCESS
       :value: 'process_control'
+
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_PROCESS
+         :renderer: rst
 
    .. py:attribute:: KEY_STORAGE_BACKEND
       :canonical: aiida.manage.configuration.profile.Profile.KEY_STORAGE_BACKEND
       :value: 'backend'
 
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_STORAGE_BACKEND
+         :renderer: rst
+
    .. py:attribute:: KEY_STORAGE_CONFIG
       :canonical: aiida.manage.configuration.profile.Profile.KEY_STORAGE_CONFIG
       :value: 'config'
+
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_STORAGE_CONFIG
+         :renderer: rst
 
    .. py:attribute:: KEY_PROCESS_BACKEND
       :canonical: aiida.manage.configuration.profile.Profile.KEY_PROCESS_BACKEND
       :value: 'backend'
 
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_PROCESS_BACKEND
+         :renderer: rst
+
    .. py:attribute:: KEY_PROCESS_CONFIG
       :canonical: aiida.manage.configuration.profile.Profile.KEY_PROCESS_CONFIG
       :value: 'config'
+
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_PROCESS_CONFIG
+         :renderer: rst
 
    .. py:attribute:: KEY_OPTIONS
       :canonical: aiida.manage.configuration.profile.Profile.KEY_OPTIONS
       :value: 'options'
 
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_OPTIONS
+         :renderer: rst
+
    .. py:attribute:: KEY_TEST_PROFILE
       :canonical: aiida.manage.configuration.profile.Profile.KEY_TEST_PROFILE
       :value: 'test_profile'
+
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.KEY_TEST_PROFILE
+         :renderer: rst
 
    .. py:attribute:: REQUIRED_KEYS
       :canonical: aiida.manage.configuration.profile.Profile.REQUIRED_KEYS
       :value: ()
 
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.REQUIRED_KEYS
+         :renderer: rst
+
    .. py:method:: __repr__() -> str
       :canonical: aiida.manage.configuration.profile.Profile.__repr__
 
-      Return repr(self).
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.__repr__
+         :renderer: rst
 
    .. py:method:: copy()
       :canonical: aiida.manage.configuration.profile.Profile.copy
 
-      Return a copy of the profile.
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.copy
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.manage.configuration.profile.Profile.uuid
       :type: str
 
-      Return the profile uuid.
-
-      :return: string UUID
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.uuid
+         :renderer: rst
 
    .. py:property:: default_user_email
       :canonical: aiida.manage.configuration.profile.Profile.default_user_email
       :type: typing.Optional[str]
 
-      Return the default user email.
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.default_user_email
+         :renderer: rst
 
    .. py:property:: storage_backend
       :canonical: aiida.manage.configuration.profile.Profile.storage_backend
       :type: str
 
-      Return the type of the storage backend.
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.storage_backend
+         :renderer: rst
 
    .. py:property:: storage_config
       :canonical: aiida.manage.configuration.profile.Profile.storage_config
       :type: typing.Dict[str, typing.Any]
 
-      Return the configuration required by the storage backend.
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.storage_config
+         :renderer: rst
 
    .. py:method:: set_storage(name: str, config: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.manage.configuration.profile.Profile.set_storage
 
-      Set the storage backend and its configuration.
-
-      :param name: the name of the storage backend
-      :param config: the configuration of the storage backend
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.set_storage
+         :renderer: rst
 
    .. py:property:: storage_cls
       :canonical: aiida.manage.configuration.profile.Profile.storage_cls
       :type: typing.Type[aiida.orm.implementation.StorageBackend]
 
-      Return the storage backend class for this profile.
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.storage_cls
+         :renderer: rst
 
    .. py:property:: process_control_backend
       :canonical: aiida.manage.configuration.profile.Profile.process_control_backend
       :type: str
 
-      Return the type of the process control backend.
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.process_control_backend
+         :renderer: rst
 
    .. py:property:: process_control_config
       :canonical: aiida.manage.configuration.profile.Profile.process_control_config
       :type: typing.Dict[str, typing.Any]
 
-      Return the configuration required by the process control backend.
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.process_control_config
+         :renderer: rst
 
    .. py:method:: set_process_controller(name: str, config: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.manage.configuration.profile.Profile.set_process_controller
 
-      Set the process control backend and its configuration.
-
-      :param name: the name of the process backend
-      :param config: the configuration of the process backend
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.set_process_controller
+         :renderer: rst
 
    .. py:property:: options
       :canonical: aiida.manage.configuration.profile.Profile.options
 
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.options
+         :renderer: rst
+
    .. py:method:: get_option(option_key, default=None)
       :canonical: aiida.manage.configuration.profile.Profile.get_option
+
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.get_option
+         :renderer: rst
 
    .. py:method:: set_option(option_key, value, override=True)
       :canonical: aiida.manage.configuration.profile.Profile.set_option
 
-      Set a configuration option for a certain scope.
-
-      :param option_key: the key of the configuration option
-      :param option_value: the option value
-      :param override: boolean, if False, will not override the option if it already exists
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.set_option
+         :renderer: rst
 
    .. py:method:: unset_option(option_key)
       :canonical: aiida.manage.configuration.profile.Profile.unset_option
 
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.unset_option
+         :renderer: rst
+
    .. py:property:: name
       :canonical: aiida.manage.configuration.profile.Profile.name
 
-      Return the profile name.
-
-      :return: the profile name
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.name
+         :renderer: rst
 
    .. py:property:: dictionary
       :canonical: aiida.manage.configuration.profile.Profile.dictionary
       :type: typing.Dict[str, typing.Any]
 
-      Return the profile attributes as a dictionary with keys as it is stored in the config
-
-      :return: the profile configuration dictionary
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.dictionary
+         :renderer: rst
 
    .. py:property:: is_test_profile
       :canonical: aiida.manage.configuration.profile.Profile.is_test_profile
       :type: bool
 
-      Return whether the profile is a test profile
-
-      :return: boolean, True if test profile, False otherwise
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.is_test_profile
+         :renderer: rst
 
    .. py:property:: repository_path
       :canonical: aiida.manage.configuration.profile.Profile.repository_path
       :type: pathlib.Path
 
-      Return the absolute path of the repository configured for this profile.
-
-      The URI should be in the format `protocol://address`
-
-      :note: At the moment, only the file protocol is supported.
-
-      :return: absolute filepath of the profile's file repository
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.repository_path
+         :renderer: rst
 
    .. py:property:: rmq_prefix
       :canonical: aiida.manage.configuration.profile.Profile.rmq_prefix
       :type: str
 
-      Return the prefix that should be used for RMQ resources
-
-      :return: the rmq prefix string
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.rmq_prefix
+         :renderer: rst
 
    .. py:method:: get_rmq_url() -> str
       :canonical: aiida.manage.configuration.profile.Profile.get_rmq_url
 
-      Return the RMQ url for this profile.
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.get_rmq_url
+         :renderer: rst
 
    .. py:property:: filepaths
       :canonical: aiida.manage.configuration.profile.Profile.filepaths
 
-      Return the filepaths used by this profile.
-
-      :return: a dictionary of filepaths
+      .. autodoc2-docstring:: aiida.manage.configuration.profile.Profile.filepaths
+         :renderer: rst
 
 .. py:class:: RabbitmqManagementClient(username: str, password: str, hostname: str, virtual_host: str)
    :canonical: aiida.manage.external.rmq.client.RabbitmqManagementClient
 
-   Client for RabbitMQ Management HTTP API.
-
-   This requires the ``rabbitmq_management`` plugin (https://www.rabbitmq.com/management.html) to be enabled. Typically
-   this is enabled by running ``rabbitmq-plugins enable rabbitmq_management``.
+   .. autodoc2-docstring:: aiida.manage.external.rmq.client.RabbitmqManagementClient
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance.
-
-   :param username: The username to authenticate with.
-   :param password: The password to authenticate with.
-   :param hostname: The hostname of the RabbitMQ server.
-   :param virtual_host: The virtual host.
+   .. autodoc2-docstring:: aiida.manage.external.rmq.client.RabbitmqManagementClient.__init__
+      :renderer: rst
 
    .. py:method:: format_url(url: str, url_params: dict[str, str] | None = None) -> str
       :canonical: aiida.manage.external.rmq.client.RabbitmqManagementClient.format_url
 
-      Format the complete URL from a partial resource path with placeholders.
-
-      The base URL will be automatically prepended.
-
-      :param url: The resource path with placeholders, e.g., ``queues/{virtual_host}/{queue}``.
-      :param url_params: Dictionary with values for the placeholders in the ``url``. The ``virtual_host`` value is
-          automatically inserted and should not be specified.
-      :returns: The complete URL.
+      .. autodoc2-docstring:: aiida.manage.external.rmq.client.RabbitmqManagementClient.format_url
+         :renderer: rst
 
    .. py:method:: request(url: str, url_params: dict[str, str] | None = None, method: str = 'GET', params: dict[str, typing.Any] | None = None) -> requests.Response
       :canonical: aiida.manage.external.rmq.client.RabbitmqManagementClient.request
 
-      Make a request.
-
-      :param url: The resource path with placeholders, e.g., ``queues/{virtual_host}/{queue}``.
-      :param url_params: Dictionary with values for the placeholders in the ``url``. The ``virtual_host`` value is
-          automatically inserted and should not be specified.
-      :param method: The HTTP method.
-      :param params: Query parameters to add to the URL.
-      :returns: The response of the request.
-      :raises `ManagementApiConnectionError`: If connection to the API cannot be made.
+      .. autodoc2-docstring:: aiida.manage.external.rmq.client.RabbitmqManagementClient.request
+         :renderer: rst
 
    .. py:property:: is_connected
       :canonical: aiida.manage.external.rmq.client.RabbitmqManagementClient.is_connected
       :type: bool
 
-      Return whether the API server can be connected to.
-
-      .. note:: Tries to reach the server at the ``/api/cluster-name`` end-point.
-
-      :returns: ``True`` if the server can be reached, ``False`` otherwise.
+      .. autodoc2-docstring:: aiida.manage.external.rmq.client.RabbitmqManagementClient.is_connected
+         :renderer: rst
 
 .. py:function:: check_and_migrate_config(config, filepath: typing.Optional[str] = None)
    :canonical: aiida.manage.configuration.migrations.migrations.check_and_migrate_config
 
-   Checks if the config needs to be migrated, and performs the migration if needed.
-
-   :param config: the configuration dictionary
-   :param filepath: the path to the configuration file (optional, for error reporting)
-   :return: the migrated configuration dictionary
+   .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.check_and_migrate_config
+      :renderer: rst
 
 .. py:function:: config_needs_migrating(config, filepath: typing.Optional[str] = None)
    :canonical: aiida.manage.configuration.migrations.migrations.config_needs_migrating
 
-   Checks if the config needs to be migrated.
-
-   If the oldest compatible version of the configuration is higher than the current configuration version defined
-   in the code, the config cannot be used and so the function will raise.
-
-   :param filepath: the path to the configuration file (optional, for error reporting)
-   :return: True if the configuration has an older version and needs to be migrated, False otherwise
-   :raises aiida.common.ConfigurationVersionError: if the config's oldest compatible version is higher than the current
+   .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.config_needs_migrating
+      :renderer: rst
 
 .. py:function:: config_schema() -> typing.Dict[str, typing.Any]
    :canonical: aiida.manage.configuration.config.config_schema
 
-   Return the configuration schema.
+   .. autodoc2-docstring:: aiida.manage.configuration.config.config_schema
+      :renderer: rst
 
 .. py:function:: disable_caching(*, identifier=None)
    :canonical: aiida.manage.caching.disable_caching
 
-   Context manager to disable caching, either for a specific node class, or globally.
-
-   .. warning:: this does not affect the behavior of the daemon, only the local Python interpreter.
-
-   :param identifier: Process type string of the node, or a pattern with '*' wildcard that matches it.
-       If not provided, caching is disabled for all classes.
-   :type identifier: str
+   .. autodoc2-docstring:: aiida.manage.caching.disable_caching
+      :renderer: rst
 
 .. py:function:: downgrade_config(config: aiida.manage.configuration.migrations.migrations.ConfigType, target: int, migrations: typing.Iterable[typing.Type[aiida.manage.configuration.migrations.migrations.SingleMigration]] = MIGRATIONS) -> aiida.manage.configuration.migrations.migrations.ConfigType
    :canonical: aiida.manage.configuration.migrations.migrations.downgrade_config
 
-   Run the registered configuration migrations down to the target version.
-
-   :param config: the configuration dictionary
-   :return: the migrated configuration dictionary
+   .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.downgrade_config
+      :renderer: rst
 
 .. py:function:: enable_caching(*, identifier=None)
    :canonical: aiida.manage.caching.enable_caching
 
-   Context manager to enable caching, either for a specific node class, or globally.
-
-   .. warning:: this does not affect the behavior of the daemon, only the local Python interpreter.
-
-   :param identifier: Process type string of the node, or a pattern with '*' wildcard that matches it.
-       If not provided, caching is enabled for all classes.
-   :type identifier: str
+   .. autodoc2-docstring:: aiida.manage.caching.enable_caching
+      :renderer: rst
 
 .. py:function:: get_current_version(config)
    :canonical: aiida.manage.configuration.migrations.migrations.get_current_version
 
-   Return the current version of the config.
-
-   :return: current config version or 0 if not defined
+   .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.get_current_version
+      :renderer: rst
 
 .. py:function:: get_launch_queue_name(prefix=None)
    :canonical: aiida.manage.external.rmq.utils.get_launch_queue_name
 
-   Return the launch queue name with an optional prefix.
-
-   :returns: launch queue name
+   .. autodoc2-docstring:: aiida.manage.external.rmq.utils.get_launch_queue_name
+      :renderer: rst
 
 .. py:function:: get_manager() -> Manager
    :canonical: aiida.manage.manager.get_manager
 
-   Return the AiiDA global manager instance.
+   .. autodoc2-docstring:: aiida.manage.manager.get_manager
+      :renderer: rst
 
 .. py:function:: get_message_exchange_name(prefix)
    :canonical: aiida.manage.external.rmq.utils.get_message_exchange_name
 
-   Return the message exchange name for a given prefix.
-
-   :returns: message exchange name
+   .. autodoc2-docstring:: aiida.manage.external.rmq.utils.get_message_exchange_name
+      :renderer: rst
 
 .. py:function:: get_option(name: str) -> aiida.manage.configuration.options.Option
    :canonical: aiida.manage.configuration.options.get_option
 
-   Return option.
+   .. autodoc2-docstring:: aiida.manage.configuration.options.get_option
+      :renderer: rst
 
 .. py:function:: get_option_names() -> typing.List[str]
    :canonical: aiida.manage.configuration.options.get_option_names
 
-   Return a list of available option names.
+   .. autodoc2-docstring:: aiida.manage.configuration.options.get_option_names
+      :renderer: rst
 
 .. py:function:: get_rmq_url(protocol=None, username=None, password=None, host=None, port=None, virtual_host=None, **kwargs)
    :canonical: aiida.manage.external.rmq.utils.get_rmq_url
 
-   Return the URL to connect to RabbitMQ.
-
-   .. note::
-
-       The default of the ``host`` is set to ``127.0.0.1`` instead of ``localhost`` because on some computers localhost
-       resolves first to IPv6 with address ::1 and if RMQ is not running on IPv6 one gets an annoying warning. For more
-       info see: https://github.com/aiidateam/aiida-core/issues/1142
-
-   :param protocol: the protocol to use, `amqp` or `amqps`.
-   :param username: the username for authentication.
-   :param password: the password for authentication.
-   :param host: the hostname of the RabbitMQ server.
-   :param port: the port of the RabbitMQ server.
-   :param virtual_host: the virtual host to connect to.
-   :param kwargs: remaining keyword arguments that will be encoded as query parameters.
-   :returns: the connection URL string.
+   .. autodoc2-docstring:: aiida.manage.external.rmq.utils.get_rmq_url
+      :renderer: rst
 
 .. py:function:: get_task_exchange_name(prefix)
    :canonical: aiida.manage.external.rmq.utils.get_task_exchange_name
 
-   Return the task exchange name for a given prefix.
-
-   :returns: task exchange name
+   .. autodoc2-docstring:: aiida.manage.external.rmq.utils.get_task_exchange_name
+      :renderer: rst
 
 .. py:function:: get_use_cache(*, identifier=None)
    :canonical: aiida.manage.caching.get_use_cache
 
-   Return whether the caching mechanism should be used for the given process type according to the configuration.
-
-   :param identifier: Process type string of the node
-   :type identifier: str
-   :return: boolean, True if caching is enabled, False otherwise
-   :raises: `~aiida.common.exceptions.ConfigurationError` if the configuration is invalid, either due to a general
-       configuration error, or by defining the class both enabled and disabled
+   .. autodoc2-docstring:: aiida.manage.caching.get_use_cache
+      :renderer: rst
 
 .. py:function:: parse_option(option_name: str, option_value: typing.Any) -> typing.Tuple[aiida.manage.configuration.options.Option, typing.Any]
    :canonical: aiida.manage.configuration.options.parse_option
 
-   Parse and validate a value for a configuration option.
-
-   :param option_name: the name of the configuration option
-   :param option_value: the option value
-   :return: a tuple of the option and the parsed value
-
+   .. autodoc2-docstring:: aiida.manage.configuration.options.parse_option
+      :renderer: rst
 
 .. py:function:: upgrade_config(config: aiida.manage.configuration.migrations.migrations.ConfigType, target: int = CURRENT_CONFIG_VERSION, migrations: typing.Iterable[typing.Type[aiida.manage.configuration.migrations.migrations.SingleMigration]] = MIGRATIONS) -> aiida.manage.configuration.migrations.migrations.ConfigType
    :canonical: aiida.manage.configuration.migrations.migrations.upgrade_config
 
-   Run the registered configuration migrations up to the target version.
-
-   :param config: the configuration dictionary
-   :return: the migrated configuration dictionary
+   .. autodoc2-docstring:: aiida.manage.configuration.migrations.migrations.upgrade_config
+      :renderer: rst

--- a/docs/apidocs/aiida/aiida.orm.rst
+++ b/docs/apidocs/aiida/aiida.orm.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Main module to expose all orm classes and methods
+.. autodoc2-docstring:: aiida.orm
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -20,145 +22,285 @@ Classes
    :align: left
 
    * - :py:obj:`AbstractCode <aiida.orm.nodes.data.code.abstract.AbstractCode>`
-     - Abstract data plugin representing an executable code.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode
+          :renderer: rst
+          :summary:
    * - :py:obj:`AbstractNodeMeta <aiida.orm.utils.node.AbstractNodeMeta>`
-     - Some python black magic to set correctly the logger also in subclasses.
+     - .. autodoc2-docstring:: aiida.orm.utils.node.AbstractNodeMeta
+          :renderer: rst
+          :summary:
    * - :py:obj:`ArrayData <aiida.orm.nodes.data.array.array.ArrayData>`
-     - Store a set of arrays on disk (rather than on the database) in an efficient way using numpy.save() (therefore, this class requires numpy to be installed).
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData
+          :renderer: rst
+          :summary:
    * - :py:obj:`AttributeManager <aiida.orm.utils.managers.AttributeManager>`
-     - An object used internally to return the attributes as a dictionary. This is currently used in :py:class:`~aiida.orm.nodes.data.dict.Dict`, for instance.
+     - .. autodoc2-docstring:: aiida.orm.utils.managers.AttributeManager
+          :renderer: rst
+          :summary:
    * - :py:obj:`AuthInfo <aiida.orm.authinfos.AuthInfo>`
-     - ORM class that models the authorization information that allows a `User` to connect to a `Computer`.
+     - .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo
+          :renderer: rst
+          :summary:
    * - :py:obj:`AutoGroup <aiida.orm.groups.AutoGroup>`
-     - Group to be used to contain selected nodes generated, whilst autogrouping is enabled.
+     - .. autodoc2-docstring:: aiida.orm.groups.AutoGroup
+          :renderer: rst
+          :summary:
    * - :py:obj:`BandsData <aiida.orm.nodes.data.array.bands.BandsData>`
-     - Class to handle bands data
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData
+          :renderer: rst
+          :summary:
    * - :py:obj:`BaseType <aiida.orm.nodes.data.base.BaseType>`
-     - `Data` sub class to be used as a base for data containers that represent base python data types.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.base.BaseType
+          :renderer: rst
+          :summary:
    * - :py:obj:`Bool <aiida.orm.nodes.data.bool.Bool>`
-     - `Data` sub class to represent a boolean value.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.bool.Bool
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcFunctionNode <aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode>`
-     - ORM class for all nodes representing the execution of a calcfunction.
+     - .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcJobNode <aiida.orm.nodes.process.calculation.calcjob.CalcJobNode>`
-     - ORM class for all nodes representing the execution of a CalcJob.
+     - .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcJobResultManager <aiida.orm.utils.calcjob.CalcJobResultManager>`
-     - Utility class to easily access the contents of the 'default output' node of a `CalcJobNode`.
+     - .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalculationEntityLoader <aiida.orm.utils.loaders.CalculationEntityLoader>`
-     - Loader for the `Calculation` entity and sub classes.
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.CalculationEntityLoader
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalculationNode <aiida.orm.nodes.process.calculation.calculation.CalculationNode>`
-     - Base class for all nodes representing the execution of a calculation process.
+     - .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calculation.CalculationNode
+          :renderer: rst
+          :summary:
    * - :py:obj:`CifData <aiida.orm.nodes.data.cif.CifData>`
-     - Wrapper for Crystallographic Interchange File (CIF)
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData
+          :renderer: rst
+          :summary:
    * - :py:obj:`Code <aiida.orm.nodes.data.code.legacy.Code>`
-     - A code entity. It can either be 'local', or 'remote'.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code
+          :renderer: rst
+          :summary:
    * - :py:obj:`CodeEntityLoader <aiida.orm.utils.loaders.CodeEntityLoader>`
-     - Loader for the `Code` entity and sub classes.
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.CodeEntityLoader
+          :renderer: rst
+          :summary:
    * - :py:obj:`Collection <aiida.orm.entities.Collection>`
-     - Container class that represents the collection of objects of a particular entity type.
+     - .. autodoc2-docstring:: aiida.orm.entities.Collection
+          :renderer: rst
+          :summary:
    * - :py:obj:`Comment <aiida.orm.comments.Comment>`
-     - Base class to map a DbComment that represents a comment attached to a certain Node.
+     - .. autodoc2-docstring:: aiida.orm.comments.Comment
+          :renderer: rst
+          :summary:
    * - :py:obj:`Computer <aiida.orm.computers.Computer>`
-     - Computer entity.
+     - .. autodoc2-docstring:: aiida.orm.computers.Computer
+          :renderer: rst
+          :summary:
    * - :py:obj:`ComputerEntityLoader <aiida.orm.utils.loaders.ComputerEntityLoader>`
-     - Loader for the `Computer` entity and sub classes.
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.ComputerEntityLoader
+          :renderer: rst
+          :summary:
    * - :py:obj:`ContainerizedCode <aiida.orm.nodes.data.code.containerized.ContainerizedCode>`
-     - Data plugin representing an executable code in container on a remote computer.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode
+          :renderer: rst
+          :summary:
    * - :py:obj:`Data <aiida.orm.nodes.data.data.Data>`
-     - The base class for all Data nodes.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data
+          :renderer: rst
+          :summary:
    * - :py:obj:`Dict <aiida.orm.nodes.data.dict.Dict>`
-     - `Data` sub class to represent a dictionary.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict
+          :renderer: rst
+          :summary:
    * - :py:obj:`Entity <aiida.orm.entities.Entity>`
-     - An AiiDA entity
+     - .. autodoc2-docstring:: aiida.orm.entities.Entity
+          :renderer: rst
+          :summary:
    * - :py:obj:`EntityExtras <aiida.orm.extras.EntityExtras>`
-     - Interface to the extras of a node or group instance.
+     - .. autodoc2-docstring:: aiida.orm.extras.EntityExtras
+          :renderer: rst
+          :summary:
    * - :py:obj:`EntityTypes <aiida.orm.entities.EntityTypes>`
-     - Enum for referring to ORM entities in a backend-agnostic manner.
+     - .. autodoc2-docstring:: aiida.orm.entities.EntityTypes
+          :renderer: rst
+          :summary:
    * - :py:obj:`EnumData <aiida.orm.nodes.data.enum.EnumData>`
-     - Data plugin that allows to easily wrap an :class:`enum.Enum` member.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData
+          :renderer: rst
+          :summary:
    * - :py:obj:`Float <aiida.orm.nodes.data.float.Float>`
-     - `Data` sub class to represent a float value.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.float.Float
+          :renderer: rst
+          :summary:
    * - :py:obj:`FolderData <aiida.orm.nodes.data.folder.FolderData>`
-     - `Data` sub class to represent a folder on a file system.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.folder.FolderData
+          :renderer: rst
+          :summary:
    * - :py:obj:`Group <aiida.orm.groups.Group>`
-     - An AiiDA ORM implementation of group of nodes.
+     - .. autodoc2-docstring:: aiida.orm.groups.Group
+          :renderer: rst
+          :summary:
    * - :py:obj:`GroupEntityLoader <aiida.orm.utils.loaders.GroupEntityLoader>`
-     - Loader for the `Group` entity and sub classes.
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.GroupEntityLoader
+          :renderer: rst
+          :summary:
    * - :py:obj:`ImportGroup <aiida.orm.groups.ImportGroup>`
-     - Group to be used to contain all nodes from an export archive that has been imported.
+     - .. autodoc2-docstring:: aiida.orm.groups.ImportGroup
+          :renderer: rst
+          :summary:
    * - :py:obj:`InstalledCode <aiida.orm.nodes.data.code.installed.InstalledCode>`
-     - Data plugin representing an executable code on a remote computer.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode
+          :renderer: rst
+          :summary:
    * - :py:obj:`Int <aiida.orm.nodes.data.int.Int>`
-     - `Data` sub class to represent an integer value.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.int.Int
+          :renderer: rst
+          :summary:
    * - :py:obj:`JsonableData <aiida.orm.nodes.data.jsonable.JsonableData>`
-     - Data plugin that allows to easily wrap objects that are JSON-able.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.jsonable.JsonableData
+          :renderer: rst
+          :summary:
    * - :py:obj:`Kind <aiida.orm.nodes.data.structure.Kind>`
-     - This class contains the information about the species (kinds) of the system.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind
+          :renderer: rst
+          :summary:
    * - :py:obj:`KpointsData <aiida.orm.nodes.data.array.kpoints.KpointsData>`
-     - Class to handle array of kpoints in the Brillouin zone. Provide methods to generate either user-defined k-points or path of k-points along symmetry lines. Internally, all k-points are defined in terms of crystal (fractional) coordinates. Cell and lattice vector coordinates are in Angstroms, reciprocal lattice vectors in Angstrom^-1 . :note: The methods setting and using the Bravais lattice info assume the PRIMITIVE unit cell is provided in input to the set_cell or set_cell_from_structure methods.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData
+          :renderer: rst
+          :summary:
    * - :py:obj:`LinkManager <aiida.orm.utils.links.LinkManager>`
-     - Class to convert a list of LinkTriple tuples into an iterator.
+     - .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager
+          :renderer: rst
+          :summary:
    * - :py:obj:`LinkPair <aiida.orm.utils.links.LinkPair>`
-     - 
+     - .. autodoc2-docstring:: aiida.orm.utils.links.LinkPair
+          :renderer: rst
+          :summary:
    * - :py:obj:`LinkTriple <aiida.orm.utils.links.LinkTriple>`
-     - 
+     - .. autodoc2-docstring:: aiida.orm.utils.links.LinkTriple
+          :renderer: rst
+          :summary:
    * - :py:obj:`List <aiida.orm.nodes.data.list.List>`
-     - `Data` sub class to represent a list.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.list.List
+          :renderer: rst
+          :summary:
    * - :py:obj:`Log <aiida.orm.logs.Log>`
-     - An AiiDA Log entity.  Corresponds to a logged message against a particular AiiDA node.
+     - .. autodoc2-docstring:: aiida.orm.logs.Log
+          :renderer: rst
+          :summary:
    * - :py:obj:`Node <aiida.orm.nodes.node.Node>`
-     - Base class for all nodes in AiiDA.
+     - .. autodoc2-docstring:: aiida.orm.nodes.node.Node
+          :renderer: rst
+          :summary:
    * - :py:obj:`NodeAttributes <aiida.orm.nodes.attributes.NodeAttributes>`
-     - Interface to the attributes of a node instance.
+     - .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes
+          :renderer: rst
+          :summary:
    * - :py:obj:`NodeEntityLoader <aiida.orm.utils.loaders.NodeEntityLoader>`
-     - Loader for the `Node` entity and sub classes.
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.NodeEntityLoader
+          :renderer: rst
+          :summary:
    * - :py:obj:`NodeLinksManager <aiida.orm.utils.managers.NodeLinksManager>`
-     - A manager that allows to inspect, with tab-completion, nodes linked to a given one. See an example of its use in `CalculationNode.inputs`.
+     - .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager
+          :renderer: rst
+          :summary:
    * - :py:obj:`NodeRepository <aiida.orm.nodes.repository.NodeRepository>`
-     - Interface to the file repository of a node instance.
+     - .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository
+          :renderer: rst
+          :summary:
    * - :py:obj:`NumericType <aiida.orm.nodes.data.numeric.NumericType>`
-     - Sub class of Data to store numbers, overloading common operators (``+``, ``*``, ...).
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType
+          :renderer: rst
+          :summary:
    * - :py:obj:`OrbitalData <aiida.orm.nodes.data.orbital.OrbitalData>`
-     - Used for storing collections of orbitals, as well as providing methods for accessing them internally.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.orbital.OrbitalData
+          :renderer: rst
+          :summary:
    * - :py:obj:`OrmEntityLoader <aiida.orm.utils.loaders.OrmEntityLoader>`
-     - Base class for entity loaders.
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader
+          :renderer: rst
+          :summary:
    * - :py:obj:`PortableCode <aiida.orm.nodes.data.code.portable.PortableCode>`
-     - Data plugin representing an executable code stored in AiiDA's storage.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProcessNode <aiida.orm.nodes.process.process.ProcessNode>`
-     - Base class for all nodes representing the execution of a process
+     - .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode
+          :renderer: rst
+          :summary:
    * - :py:obj:`ProjectionData <aiida.orm.nodes.data.array.projection.ProjectionData>`
-     - A class to handle arrays of projected wavefunction data. That is projections of a orbitals, usually an atomic-hydrogen orbital, onto a given bloch wavefunction, the bloch wavefunction being indexed by s, n, and k. E.g. the elements are the projections described as < orbital | Bloch wavefunction (s,n,k) >
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData
+          :renderer: rst
+          :summary:
    * - :py:obj:`QueryBuilder <aiida.orm.querybuilder.QueryBuilder>`
-     - The class to query the AiiDA database.
+     - .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder
+          :renderer: rst
+          :summary:
    * - :py:obj:`RemoteData <aiida.orm.nodes.data.remote.base.RemoteData>`
-     - Store a link to a file or folder on a remote machine.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData
+          :renderer: rst
+          :summary:
    * - :py:obj:`RemoteStashData <aiida.orm.nodes.data.remote.stash.base.RemoteStashData>`
-     - Data plugin that models an archived folder on a remote computer.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.base.RemoteStashData
+          :renderer: rst
+          :summary:
    * - :py:obj:`RemoteStashFolderData <aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData>`
-     - Data plugin that models a folder with files of a completed calculation job that has been stashed through a copy.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData
+          :renderer: rst
+          :summary:
    * - :py:obj:`SinglefileData <aiida.orm.nodes.data.singlefile.SinglefileData>`
-     - Data class that can be used to store a single file in its repository.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.singlefile.SinglefileData
+          :renderer: rst
+          :summary:
    * - :py:obj:`Site <aiida.orm.nodes.data.structure.Site>`
-     - This class contains the information about a given site of the system.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Site
+          :renderer: rst
+          :summary:
    * - :py:obj:`Str <aiida.orm.nodes.data.str.Str>`
-     - `Data` sub class to represent a string value.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.str.Str
+          :renderer: rst
+          :summary:
    * - :py:obj:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-     - This class contains the information about a given structure, i.e. a collection of sites together with a cell, the boundary conditions (whether they are periodic or not) and other related useful information.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData
+          :renderer: rst
+          :summary:
    * - :py:obj:`TrajectoryData <aiida.orm.nodes.data.array.trajectory.TrajectoryData>`
-     - Stores a trajectory (a sequence of crystal structures with timestamps, and possibly with velocities).
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData
+          :renderer: rst
+          :summary:
    * - :py:obj:`UpfData <aiida.orm.nodes.data.upf.UpfData>`
-     - `Data` sub class to represent a pseudopotential single file in UPF format.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData
+          :renderer: rst
+          :summary:
    * - :py:obj:`UpfFamily <aiida.orm.groups.UpfFamily>`
-     - Group that represents a pseudo potential family containing `UpfData` nodes.
+     - .. autodoc2-docstring:: aiida.orm.groups.UpfFamily
+          :renderer: rst
+          :summary:
    * - :py:obj:`User <aiida.orm.users.User>`
-     - AiiDA User
+     - .. autodoc2-docstring:: aiida.orm.users.User
+          :renderer: rst
+          :summary:
    * - :py:obj:`WorkChainNode <aiida.orm.nodes.process.workflow.workchain.WorkChainNode>`
-     - ORM class for all nodes representing the execution of a WorkChain.
+     - .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workchain.WorkChainNode
+          :renderer: rst
+          :summary:
    * - :py:obj:`WorkFunctionNode <aiida.orm.nodes.process.workflow.workfunction.WorkFunctionNode>`
-     - ORM class for all nodes representing the execution of a workfunction.
+     - .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workfunction.WorkFunctionNode
+          :renderer: rst
+          :summary:
    * - :py:obj:`WorkflowNode <aiida.orm.nodes.process.workflow.workflow.WorkflowNode>`
-     - Base class for all nodes representing the execution of a workflow process.
+     - .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workflow.WorkflowNode
+          :renderer: rst
+          :summary:
    * - :py:obj:`XyData <aiida.orm.nodes.data.array.xy.XyData>`
-     - A subclass designed to handle arrays that have an "XY" relationship to each other. That is there is one array, the X array, and there are several Y arrays, which can be considered functions of X.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.array.xy.XyData
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -168,37 +310,69 @@ Functions
    :align: left
 
    * - :py:obj:`OrderSpecifier <aiida.orm.logs.OrderSpecifier>`
-     - 
+     - .. autodoc2-docstring:: aiida.orm.logs.OrderSpecifier
+          :renderer: rst
+          :summary:
    * - :py:obj:`cif_from_ase <aiida.orm.nodes.data.cif.cif_from_ase>`
-     - Construct a CIF datablock from the ASE structure. The code is taken from https://wiki.fysik.dtu.dk/ase/ase/io/formatoptions.html#ase.io.cif.write_cif, as the original ASE code contains a bug in printing the Hermann-Mauguin symmetry space group symbol.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.cif.cif_from_ase
+          :renderer: rst
+          :summary:
    * - :py:obj:`find_bandgap <aiida.orm.nodes.data.array.bands.find_bandgap>`
-     - Tries to guess whether the bandsdata represent an insulator. This method is meant to be used only for electronic bands (not phonons) By default, it will try to use the occupations to guess the number of electrons and find the Fermi Energy, otherwise, it can be provided explicitely. Also, there is an implicit assumption that the kpoints grid is "sufficiently" dense, so that the bandsdata are not missing the intersection between valence and conduction band if present. Use this function with care!
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.find_bandgap
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_loader <aiida.orm.utils.loaders.get_loader>`
-     - Return the correct OrmEntityLoader for the given orm class.
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.get_loader
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_query_type_from_type_string <aiida.orm.utils.node.get_query_type_from_type_string>`
-     - Take the type string of a Node and create the queryable type string
+     - .. autodoc2-docstring:: aiida.orm.utils.node.get_query_type_from_type_string
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_type_string_from_class <aiida.orm.utils.node.get_type_string_from_class>`
-     - Given the module and name of a class, determine the orm_class_type string, which codifies the orm class that is to be used. The returned string will always have a terminating period, which is required to query for the string in the database
+     - .. autodoc2-docstring:: aiida.orm.utils.node.get_type_string_from_class
+          :renderer: rst
+          :summary:
    * - :py:obj:`has_pycifrw <aiida.orm.nodes.data.cif.has_pycifrw>`
-     - :return: True if the PyCifRW module can be imported, False otherwise.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.cif.has_pycifrw
+          :renderer: rst
+          :summary:
    * - :py:obj:`load_code <aiida.orm.utils.loaders.load_code>`
-     - Load a Code instance by one of its identifiers: pk, uuid or label
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.load_code
+          :renderer: rst
+          :summary:
    * - :py:obj:`load_computer <aiida.orm.utils.loaders.load_computer>`
-     - Load a Computer instance by one of its identifiers: pk, uuid or label
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.load_computer
+          :renderer: rst
+          :summary:
    * - :py:obj:`load_entity <aiida.orm.utils.loaders.load_entity>`
-     - Load an entity instance by one of its identifiers: pk, uuid or label
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.load_entity
+          :renderer: rst
+          :summary:
    * - :py:obj:`load_group <aiida.orm.utils.loaders.load_group>`
-     - Load a Group instance by one of its identifiers: pk, uuid or label
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.load_group
+          :renderer: rst
+          :summary:
    * - :py:obj:`load_node <aiida.orm.utils.loaders.load_node>`
-     - Load a node by one of its identifiers: pk or uuid. If the type of the identifier is unknown simply pass it without a keyword and the loader will attempt to infer the type
+     - .. autodoc2-docstring:: aiida.orm.utils.loaders.load_node
+          :renderer: rst
+          :summary:
    * - :py:obj:`load_node_class <aiida.orm.utils.node.load_node_class>`
-     - Return the `Node` sub class that corresponds to the given type string.
+     - .. autodoc2-docstring:: aiida.orm.utils.node.load_node_class
+          :renderer: rst
+          :summary:
    * - :py:obj:`pycifrw_from_cif <aiida.orm.nodes.data.cif.pycifrw_from_cif>`
-     - Constructs PyCifRW's CifFile from an array of CIF datablocks.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.cif.pycifrw_from_cif
+          :renderer: rst
+          :summary:
    * - :py:obj:`to_aiida_type <aiida.orm.nodes.data.base.to_aiida_type>`
-     - Turns basic Python types (str, int, float, bool) into the corresponding AiiDA types.
+     - .. autodoc2-docstring:: aiida.orm.nodes.data.base.to_aiida_type
+          :renderer: rst
+          :summary:
    * - :py:obj:`validate_link <aiida.orm.utils.links.validate_link>`
-     - Validate adding a link of the given type and label from a given node to ourself.
+     - .. autodoc2-docstring:: aiida.orm.utils.links.validate_link
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -208,9 +382,13 @@ Data
    :align: left
 
    * - :py:obj:`ASCENDING <aiida.orm.logs.ASCENDING>`
-     - 
+     - .. autodoc2-docstring:: aiida.orm.logs.ASCENDING
+          :renderer: rst
+          :summary:
    * - :py:obj:`DESCENDING <aiida.orm.logs.DESCENDING>`
-     - 
+     - .. autodoc2-docstring:: aiida.orm.logs.DESCENDING
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -219,8172 +397,6379 @@ API
    :canonical: aiida.orm.logs.ASCENDING
    :value: 'asc'
 
+   .. autodoc2-docstring:: aiida.orm.logs.ASCENDING
+      :renderer: rst
+
 .. py:class:: AbstractCode(default_calc_job_plugin: str | None = None, append_text: str = '', prepend_text: str = '', use_double_quotes: bool = False, is_hidden: bool = False, **kwargs)
    :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   Abstract data plugin representing an executable code.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance.
-
-   :param default_calc_job_plugin: The entry point name of the default ``CalcJob`` plugin to use.
-   :param append_text: The text that should be appended to the run line in the job script.
-   :param prepend_text: The text that should be prepended to the run line in the job script.
-   :param use_double_quotes: Whether the command line invocation of this code should be escaped with double quotes.
-   :param is_hidden: Whether the code is hidden.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.__init__
+      :renderer: rst
 
    .. py:attribute:: _KEY_ATTRIBUTE_DEFAULT_CALC_JOB_PLUGIN
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_ATTRIBUTE_DEFAULT_CALC_JOB_PLUGIN
       :type: str
       :value: 'input_plugin'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_ATTRIBUTE_DEFAULT_CALC_JOB_PLUGIN
+         :renderer: rst
+
    .. py:attribute:: _KEY_ATTRIBUTE_APPEND_TEXT
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_ATTRIBUTE_APPEND_TEXT
       :type: str
       :value: 'append_text'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_ATTRIBUTE_APPEND_TEXT
+         :renderer: rst
 
    .. py:attribute:: _KEY_ATTRIBUTE_PREPEND_TEXT
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_ATTRIBUTE_PREPEND_TEXT
       :type: str
       :value: 'prepend_text'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_ATTRIBUTE_PREPEND_TEXT
+         :renderer: rst
+
    .. py:attribute:: _KEY_ATTRIBUTE_USE_DOUBLE_QUOTES
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_ATTRIBUTE_USE_DOUBLE_QUOTES
       :type: str
       :value: 'use_double_quotes'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_ATTRIBUTE_USE_DOUBLE_QUOTES
+         :renderer: rst
 
    .. py:attribute:: _KEY_EXTRA_IS_HIDDEN
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_EXTRA_IS_HIDDEN
       :type: str
       :value: 'hidden'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode._KEY_EXTRA_IS_HIDDEN
+         :renderer: rst
+
    .. py:method:: can_run_on_computer(computer: aiida.orm.Computer) -> bool
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.can_run_on_computer
       :abstractmethod:
 
-      Return whether the code can run on a given computer.
-
-      :param computer: The computer.
-      :return: ``True`` if the code can run on ``computer``, ``False`` otherwise.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.can_run_on_computer
+         :renderer: rst
 
    .. py:method:: get_executable() -> pathlib.PurePosixPath
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.get_executable
       :abstractmethod:
 
-      Return the executable that the submission script should execute to run the code.
-
-      :return: The executable to be called in the submission script.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.get_executable
+         :renderer: rst
 
    .. py:method:: get_executable_cmdline_params(cmdline_params: list[str] | None = None) -> list
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.get_executable_cmdline_params
 
-      Return the list of executable with its command line parameters.
-
-      :param cmdline_params: List of command line parameters provided by the ``CalcJob`` plugin.
-      :return: List of the executable followed by its command line parameters.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.get_executable_cmdline_params
+         :renderer: rst
 
    .. py:method:: get_prepend_cmdline_params(mpi_args: list[str] | None = None, extra_mpirun_params: list[str] | None = None) -> list[str]
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.get_prepend_cmdline_params
 
-      Return List of command line parameters to be prepended to the executable in submission line.
-      These command line parameters are typically parameters related to MPI invocations.
-
-      :param mpi_args: List of MPI parameters provided by the ``Computer.get_mpirun_command`` method.
-      :param extra_mpiruns_params: List of MPI parameters provided by the ``metadata.options.extra_mpirun_params``
-          input of the ``CalcJob``.
-      :return: List of command line parameters to be prepended to the executable in submission line.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.get_prepend_cmdline_params
+         :renderer: rst
 
    .. py:method:: validate_working_directory(folder: aiida.common.folders.Folder)
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.validate_working_directory
 
-      Validate content of the working directory created by the :class:`~aiida.engine.CalcJob` plugin.
-
-      This method will be called by :meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit` when a new
-      calculation job is launched, passing the :class:`~aiida.common.folders.Folder` that was used by the plugin used
-      for the calculation to create the input files for the working directory. This method can be overridden by
-      implementations of the ``AbstractCode`` class that need to validate the contents of that folder.
-
-      :param folder: A sandbox folder that the ``CalcJob`` plugin wrote input files to that will be copied to the
-          working directory for the corresponding calculation job instance.
-      :raises PluginInternalError: If the content of the sandbox folder is not valid.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.validate_working_directory
+         :renderer: rst
 
    .. py:property:: full_label
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.full_label
       :abstractmethod:
       :type: str
 
-      Return the full label of this code.
-
-      The full label can be just the label itself but it can be something else. However, it at the very least has to
-      include the label of the code.
-
-      :return: The full label of the code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.full_label
+         :renderer: rst
 
    .. py:property:: label
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.label
       :type: str
 
-      Return the label.
-
-      :return: The label.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.label
+         :renderer: rst
 
    .. py:property:: default_calc_job_plugin
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.default_calc_job_plugin
       :type: str | None
 
-      Return the optional default ``CalcJob`` plugin.
-
-      :return: The entry point name of the default ``CalcJob`` plugin to use.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.default_calc_job_plugin
+         :renderer: rst
 
    .. py:property:: append_text
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.append_text
       :type: str
 
-      Return the text that should be appended to the run line in the job script.
-
-      :return: The text that should be appended to the run line in the job script.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.append_text
+         :renderer: rst
 
    .. py:property:: prepend_text
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.prepend_text
       :type: str
 
-      Return the text that should be prepended to the run line in the job script.
-
-      :return: The text that should be prepended to the run line in the job script.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.prepend_text
+         :renderer: rst
 
    .. py:property:: use_double_quotes
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.use_double_quotes
       :type: bool
 
-      Return whether the command line invocation of this code should be escaped with double quotes.
-
-      :return: ``True`` if to escape with double quotes, ``False`` otherwise.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.use_double_quotes
+         :renderer: rst
 
    .. py:property:: is_hidden
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.is_hidden
       :type: bool
 
-      Return whether the code is hidden.
-
-      :return: ``True`` if the code is hidden, ``False`` otherwise, which is also the default.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.is_hidden
+         :renderer: rst
 
    .. py:method:: get_builder() -> aiida.engine.ProcessBuilder
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.get_builder
 
-      Create and return a new ``ProcessBuilder`` for the ``CalcJob`` class of the plugin configured for this code.
-
-      The configured calculation plugin class is defined by the ``default_calc_job_plugin`` property.
-
-      .. note:: it also sets the ``builder.code`` value.
-
-      :return: a ``ProcessBuilder`` instance with the ``code`` input already populated with ourselves
-      :raise aiida.common.EntryPointError: if the specified plugin does not exist.
-      :raise ValueError: if no default plugin was specified.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.get_builder
+         :renderer: rst
 
    .. py:method:: cli_validate_label_uniqueness(_, __, value)
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.cli_validate_label_uniqueness
       :staticmethod:
 
-      Validate the uniqueness of the label of the code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.cli_validate_label_uniqueness
+         :renderer: rst
 
    .. py:method:: get_cli_options() -> collections.OrderedDict
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode.get_cli_options
       :classmethod:
 
-      Return the CLI options that would allow to create an instance of this class.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode.get_cli_options
+         :renderer: rst
 
    .. py:method:: _get_cli_options() -> dict
       :canonical: aiida.orm.nodes.data.code.abstract.AbstractCode._get_cli_options
       :classmethod:
 
-      Return the CLI options that would allow to create an instance of this class.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.abstract.AbstractCode._get_cli_options
+         :renderer: rst
 
 .. py:class:: AbstractNodeMeta
    :canonical: aiida.orm.utils.node.AbstractNodeMeta
 
    Bases: :py:obj:`abc.ABCMeta`
 
-   Some python black magic to set correctly the logger also in subclasses.
+   .. autodoc2-docstring:: aiida.orm.utils.node.AbstractNodeMeta
+      :renderer: rst
 
    .. py:method:: __new__(name, bases, namespace, **kwargs)
       :canonical: aiida.orm.utils.node.AbstractNodeMeta.__new__
+
+      .. autodoc2-docstring:: aiida.orm.utils.node.AbstractNodeMeta.__new__
+         :renderer: rst
 
 .. py:class:: ArrayData(*args, source=None, **kwargs)
    :canonical: aiida.orm.nodes.data.array.array.ArrayData
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   Store a set of arrays on disk (rather than on the database) in an efficient
-   way using numpy.save() (therefore, this class requires numpy to be
-   installed).
-
-   Each array is stored within the Node folder as a different .npy file.
-
-   :note: Before storing, no caching is done: if you perform a
-     :py:meth:`.get_array` call, the array will be re-read from disk.
-     If instead the ArrayData node has already been stored,
-     the array is cached in memory after the first read, and the cached array
-     is used thereafter.
-     If too much RAM memory is used, you can clear the
-     cache with the :py:meth:`.clear_internal_cache` method.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance, setting the ``source`` attribute if provided as a keyword argument.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.__init__
+      :renderer: rst
 
    .. py:attribute:: array_prefix
       :canonical: aiida.orm.nodes.data.array.array.ArrayData.array_prefix
       :value: 'array|'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.array_prefix
+         :renderer: rst
+
    .. py:attribute:: _cached_arrays
       :canonical: aiida.orm.nodes.data.array.array.ArrayData._cached_arrays
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData._cached_arrays
+         :renderer: rst
+
    .. py:method:: initialize()
       :canonical: aiida.orm.nodes.data.array.array.ArrayData.initialize
 
-      Initialize instance attributes.
-
-      This will be called after the constructor is called or an entity is created from an existing backend entity.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.initialize
+         :renderer: rst
 
    .. py:method:: delete_array(name)
       :canonical: aiida.orm.nodes.data.array.array.ArrayData.delete_array
 
-      Delete an array from the node. Can only be called before storing.
-
-      :param name: The name of the array to delete from the node.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.delete_array
+         :renderer: rst
 
    .. py:method:: get_arraynames()
       :canonical: aiida.orm.nodes.data.array.array.ArrayData.get_arraynames
 
-      Return a list of all arrays stored in the node, listing the files (and
-      not relying on the properties).
-
-      .. versionadded:: 0.7
-         Renamed from arraynames
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.get_arraynames
+         :renderer: rst
 
    .. py:method:: _arraynames_from_files()
       :canonical: aiida.orm.nodes.data.array.array.ArrayData._arraynames_from_files
 
-      Return a list of all arrays stored in the node, listing the files (and
-      not relying on the properties).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData._arraynames_from_files
+         :renderer: rst
 
    .. py:method:: _arraynames_from_properties()
       :canonical: aiida.orm.nodes.data.array.array.ArrayData._arraynames_from_properties
 
-      Return a list of all arrays stored in the node, listing the attributes
-      starting with the correct prefix.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData._arraynames_from_properties
+         :renderer: rst
 
    .. py:method:: get_shape(name)
       :canonical: aiida.orm.nodes.data.array.array.ArrayData.get_shape
 
-      Return the shape of an array (read from the value cached in the
-      properties for efficiency reasons).
-
-      :param name: The name of the array.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.get_shape
+         :renderer: rst
 
    .. py:method:: get_iterarrays()
       :canonical: aiida.orm.nodes.data.array.array.ArrayData.get_iterarrays
 
-      Iterator that returns tuples (name, array) for each array stored in the node.
-
-      .. versionadded:: 1.0
-          Renamed from iterarrays
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.get_iterarrays
+         :renderer: rst
 
    .. py:method:: get_array(name)
       :canonical: aiida.orm.nodes.data.array.array.ArrayData.get_array
 
-      Return an array stored in the node
-
-      :param name: The name of the array to return.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.get_array
+         :renderer: rst
 
    .. py:method:: clear_internal_cache()
       :canonical: aiida.orm.nodes.data.array.array.ArrayData.clear_internal_cache
 
-      Clear the internal memory cache where the arrays are stored after being
-      read from disk (used in order to reduce at minimum the readings from
-      disk).
-      This function is useful if you want to keep the node in memory, but you
-      do not want to waste memory to cache the arrays in RAM.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.clear_internal_cache
+         :renderer: rst
 
    .. py:method:: set_array(name, array)
       :canonical: aiida.orm.nodes.data.array.array.ArrayData.set_array
 
-      Store a new numpy array inside the node. Possibly overwrite the array
-      if it already existed.
-
-      Internally, it stores a name.npy file in numpy format.
-
-      :param name: The name of the array.
-      :param array: The numpy array to store.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData.set_array
+         :renderer: rst
 
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.array.array.ArrayData._validate
 
-      Check if the list of .npy files stored inside the node and the
-      list of properties match. Just a name check, no check on the size
-      since this would require to reload all arrays and this may take time
-      and memory.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData._validate
+         :renderer: rst
 
    .. py:method:: _get_array_entries()
       :canonical: aiida.orm.nodes.data.array.array.ArrayData._get_array_entries
 
-      Return a dictionary with the different array entries.
-
-      The idea is that this dictionary contains the array name as a key and
-      the value is the numpy array transformed into a list. This is so that
-      it can be transformed into a json object.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData._get_array_entries
+         :renderer: rst
 
    .. py:method:: _prepare_json(main_file_name='', comments=True)
       :canonical: aiida.orm.nodes.data.array.array.ArrayData._prepare_json
 
-      Dump the content of the arrays stored in this node into JSON format.
-
-      :param comments: if True, includes comments (if it makes sense for the given format)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.array.ArrayData._prepare_json
+         :renderer: rst
 
 .. py:class:: AttributeManager(node)
    :canonical: aiida.orm.utils.managers.AttributeManager
 
-   An object used internally to return the attributes as a dictionary.
-   This is currently used in :py:class:`~aiida.orm.nodes.data.dict.Dict`,
-   for instance.
-
-   :note: Important! It cannot be used to change variables, just to read
-     them. To change values (of unstored nodes), use the proper Node methods.
+   .. autodoc2-docstring:: aiida.orm.utils.managers.AttributeManager
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   :param node: the node object.
+   .. autodoc2-docstring:: aiida.orm.utils.managers.AttributeManager.__init__
+      :renderer: rst
 
    .. py:method:: __dir__()
       :canonical: aiida.orm.utils.managers.AttributeManager.__dir__
 
-      Allow to list the keys of the dictionary
+      .. autodoc2-docstring:: aiida.orm.utils.managers.AttributeManager.__dir__
+         :renderer: rst
 
    .. py:method:: __iter__()
       :canonical: aiida.orm.utils.managers.AttributeManager.__iter__
 
-      Return the keys as an iterator
+      .. autodoc2-docstring:: aiida.orm.utils.managers.AttributeManager.__iter__
+         :renderer: rst
 
    .. py:method:: _get_dict()
       :canonical: aiida.orm.utils.managers.AttributeManager._get_dict
 
-      Return the internal dictionary
+      .. autodoc2-docstring:: aiida.orm.utils.managers.AttributeManager._get_dict
+         :renderer: rst
 
    .. py:method:: __getattr__(name)
       :canonical: aiida.orm.utils.managers.AttributeManager.__getattr__
 
-      Interface to get to dictionary values, using the key as an attribute.
-
-      :note: it works only for attributes that only contain letters, numbers
-        and underscores, and do not start with a number.
-
-      :param name: name of the key whose value is required.
+      .. autodoc2-docstring:: aiida.orm.utils.managers.AttributeManager.__getattr__
+         :renderer: rst
 
    .. py:method:: __setattr__(name, value)
       :canonical: aiida.orm.utils.managers.AttributeManager.__setattr__
 
-      Implement setattr(self, name, value).
+      .. autodoc2-docstring:: aiida.orm.utils.managers.AttributeManager.__setattr__
+         :renderer: rst
 
    .. py:method:: __getitem__(name)
       :canonical: aiida.orm.utils.managers.AttributeManager.__getitem__
 
-      Interface to get to dictionary values as a dictionary.
-
-      :param name: name of the key whose value is required.
+      .. autodoc2-docstring:: aiida.orm.utils.managers.AttributeManager.__getitem__
+         :renderer: rst
 
 .. py:class:: AuthInfo(computer: aiida.orm.Computer, user: aiida.orm.User, backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.authinfos.AuthInfo
 
    Bases: :py:obj:`aiida.orm.entities.Entity`\ [\ :py:obj:`aiida.orm.implementation.BackendAuthInfo`\ , :py:obj:`aiida.orm.authinfos.AuthInfoCollection`\ ]
 
-   ORM class that models the authorization information that allows a `User` to connect to a `Computer`.
+   .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Create an `AuthInfo` instance for the given computer and user.
-
-   :param computer: a `Computer` instance
-   :param user: a `User` instance
-   :param backend: the backend to use for the instance, or use the default backend if None
+   .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.__init__
+      :renderer: rst
 
    .. py:attribute:: _CLS_COLLECTION
       :canonical: aiida.orm.authinfos.AuthInfo._CLS_COLLECTION
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo._CLS_COLLECTION
+         :renderer: rst
+
    .. py:attribute:: PROPERTY_WORKDIR
       :canonical: aiida.orm.authinfos.AuthInfo.PROPERTY_WORKDIR
       :value: 'workdir'
 
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.PROPERTY_WORKDIR
+         :renderer: rst
+
    .. py:method:: __str__() -> str
       :canonical: aiida.orm.authinfos.AuthInfo.__str__
+
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.__str__
+         :renderer: rst
 
    .. py:property:: enabled
       :canonical: aiida.orm.authinfos.AuthInfo.enabled
       :type: bool
 
-      Return whether this instance is enabled.
-
-      :return: True if enabled, False otherwise
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.enabled
+         :renderer: rst
 
    .. py:property:: computer
       :canonical: aiida.orm.authinfos.AuthInfo.computer
       :type: aiida.orm.Computer
 
-      Return the computer associated with this instance.
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.computer
+         :renderer: rst
 
    .. py:property:: user
       :canonical: aiida.orm.authinfos.AuthInfo.user
       :type: aiida.orm.User
 
-      Return the user associated with this instance.
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.user
+         :renderer: rst
 
    .. py:method:: get_auth_params() -> typing.Dict[str, typing.Any]
       :canonical: aiida.orm.authinfos.AuthInfo.get_auth_params
 
-      Return the dictionary of authentication parameters
-
-      :return: a dictionary with authentication parameters
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.get_auth_params
+         :renderer: rst
 
    .. py:method:: set_auth_params(auth_params: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.orm.authinfos.AuthInfo.set_auth_params
 
-      Set the dictionary of authentication parameters
-
-      :param auth_params: a dictionary with authentication parameters
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.set_auth_params
+         :renderer: rst
 
    .. py:method:: get_metadata() -> typing.Dict[str, typing.Any]
       :canonical: aiida.orm.authinfos.AuthInfo.get_metadata
 
-      Return the dictionary of metadata
-
-      :return: a dictionary with metadata
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.get_metadata
+         :renderer: rst
 
    .. py:method:: set_metadata(metadata: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.orm.authinfos.AuthInfo.set_metadata
 
-      Set the dictionary of metadata
-
-      :param metadata: a dictionary with metadata
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.set_metadata
+         :renderer: rst
 
    .. py:method:: get_workdir() -> str
       :canonical: aiida.orm.authinfos.AuthInfo.get_workdir
 
-      Return the working directory.
-
-      If no explicit work directory is set for this instance, the working directory of the computer will be returned.
-
-      :return: the working directory
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.get_workdir
+         :renderer: rst
 
    .. py:method:: get_transport() -> aiida.transports.Transport
       :canonical: aiida.orm.authinfos.AuthInfo.get_transport
 
-      Return a fully configured transport that can be used to connect to the computer set for this instance.
+      .. autodoc2-docstring:: aiida.orm.authinfos.AuthInfo.get_transport
+         :renderer: rst
 
 .. py:class:: AutoGroup(label: typing.Optional[str] = None, user: typing.Optional[aiida.orm.User] = None, description: str = '', type_string: typing.Optional[str] = None, backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.groups.AutoGroup
 
    Bases: :py:obj:`aiida.orm.groups.Group`
 
-   Group to be used to contain selected nodes generated, whilst autogrouping is enabled.
+   .. autodoc2-docstring:: aiida.orm.groups.AutoGroup
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Create a new group. Either pass a dbgroup parameter, to reload
-   a group from the DB (and then, no further parameters are allowed),
-   or pass the parameters for the Group creation.
-
-   :param label: The group label, required on creation
-   :param description: The group description (by default, an empty string)
-   :param user: The owner of the group (by default, the automatic user)
-   :param type_string: a string identifying the type of group (by default,
-       an empty string, indicating an user-defined group.
+   .. autodoc2-docstring:: aiida.orm.groups.AutoGroup.__init__
+      :renderer: rst
 
 .. py:class:: BandsData
    :canonical: aiida.orm.nodes.data.array.bands.BandsData
 
    Bases: :py:obj:`aiida.orm.nodes.data.array.kpoints.KpointsData`
 
-   Class to handle bands data
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData
+      :renderer: rst
 
    .. py:method:: set_kpointsdata(kpointsdata)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData.set_kpointsdata
 
-      Load the kpoints from a kpoint object.
-      :param kpointsdata: an instance of KpointsData class
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData.set_kpointsdata
+         :renderer: rst
 
    .. py:method:: _validate_bands_occupations(bands, occupations=None, labels=None)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._validate_bands_occupations
 
-      Validate the list of bands and of occupations before storage.
-      Kpoints must be set in advance.
-      Bands and occupations must be convertible into arrays of
-      Nkpoints x Nbands floats or Nspins x Nkpoints x Nbands; Nkpoints must
-      correspond to the number of kpoints.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._validate_bands_occupations
+         :renderer: rst
 
    .. py:method:: set_bands(bands, units=None, occupations=None, labels=None)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData.set_bands
 
-      Set an array of band energies of dimension (nkpoints x nbands).
-      Kpoints must be set in advance. Can contain floats or None.
-      :param bands: a list of nkpoints lists of nbands bands, or a 2D array
-      of shape (nkpoints x nbands), with band energies for each kpoint
-      :param units: optional, energy units
-      :param occupations: optional, a 2D list or array of floats of same
-      shape as bands, with the occupation associated to each band
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData.set_bands
+         :renderer: rst
 
    .. py:property:: array_labels
       :canonical: aiida.orm.nodes.data.array.bands.BandsData.array_labels
 
-      Get the labels associated with the band arrays
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData.array_labels
+         :renderer: rst
 
    .. py:property:: units
       :canonical: aiida.orm.nodes.data.array.bands.BandsData.units
 
-      Units in which the data in bands were stored. A string
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData.units
+         :renderer: rst
 
    .. py:method:: _set_pbc(value)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._set_pbc
 
-      validate the pbc, then store them
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._set_pbc
+         :renderer: rst
 
    .. py:method:: get_bands(also_occupations=False, also_labels=False)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData.get_bands
 
-      Returns an array (nkpoints x num_bands or nspins x nkpoints x num_bands)
-      of energies.
-      :param also_occupations: if True, returns also the occupations array.
-      Default = False
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData.get_bands
+         :renderer: rst
 
    .. py:method:: _get_bandplot_data(cartesian, prettify_format=None, join_symbol=None, get_segments=False, y_origin=0.0)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._get_bandplot_data
 
-      Get data to plot a band structure
-
-      :param cartesian: if True, distances (for the x-axis) are computed in
-              cartesian coordinates, otherwise they are computed in reciprocal
-              coordinates. cartesian=True will fail if no cell has been set.
-      :param prettify_format: by default, strings are not prettified. If you want
-           to prettify them, pass a valid prettify_format string (see valid options
-           in the docstring of :py:func:prettify_labels).
-      :param join_symbols: by default, strings are not joined. If you pass a string,
-           this is used to join strings that are much closer than a given threshold.
-           The most typical string is the pipe symbol: ``|``.
-      :param get_segments: if True, also computes the band split into segments
-      :param y_origin: if present, shift bands so to set the value specified at ``y=0``
-      :return: a plot_info dictiorary, whose keys are ``x`` (array of distances
-         for the x axis of the plot); ``y`` (array of bands), ``labels`` (list
-         of tuples in the format (float x value of the label, label string),
-         ``band_type_idx`` (array containing an index for each band: if there is only
-         one spin, then it's an array of zeros, of length equal to the number of bands
-         at each point; if there are two spins, then it's an array of zeros or ones
-         depending on the type of spin; the length is always equalt to the total
-         number of bands per kpoint).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._get_bandplot_data
+         :renderer: rst
 
    .. py:method:: _prepare_agr_batch(main_file_name='', comments=True, prettify_format=None)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_agr_batch
 
-      Prepare two files, data and batch, to be plot with xmgrace as:
-      xmgrace -batch file.dat
-
-      :param main_file_name: if the user asks to write the main content on a
-           file, this contains the filename. This should be used to infer a
-           good filename for the additional files.
-           In this case, we remove the extension, and add '_data.dat'
-      :param comments: if True, print comments (if it makes sense for the given
-          format)
-      :param prettify_format: if None, use the default prettify format. Otherwise
-          specify a string with the prettifier to use.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_agr_batch
+         :renderer: rst
 
    .. py:method:: _prepare_dat_multicolumn(main_file_name='', comments=True)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_dat_multicolumn
 
-      Write an N x M matrix. First column is the distance between kpoints,
-      The other columns are the bands. Header contains number of kpoints and
-      the number of bands (commented).
-
-      :param comments: if True, print comments (if it makes sense for the given
-          format)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_dat_multicolumn
+         :renderer: rst
 
    .. py:method:: _prepare_dat_blocks(main_file_name='', comments=True)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_dat_blocks
 
-      Format suitable for gnuplot using blocks.
-      Columns with x and y (path and band energy). Several blocks, separated
-      by two empty lines, one per energy band.
-
-      :param comments: if True, print comments (if it makes sense for the given
-          format)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_dat_blocks
+         :renderer: rst
 
    .. py:method:: _matplotlib_get_dict(main_file_name='', comments=True, title='', legend=None, legend2=None, y_max_lim=None, y_min_lim=None, y_origin=0.0, prettify_format=None, **kwargs)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._matplotlib_get_dict
 
-      Prepare the data to send to the python-matplotlib plotting script.
-
-      :param comments: if True, print comments (if it makes sense for the given
-          format)
-      :param plot_info: a dictionary
-      :param setnumber_offset: an offset to be applied to all set numbers
-          (i.e. s0 is replaced by s[offset], s1 by s[offset+1], etc.)
-      :param color_number: the color number for lines, symbols, error bars
-          and filling (should be less than the parameter MAX_NUM_AGR_COLORS
-          defined below)
-      :param title: the title
-      :param legend: the legend (applied only to the first of the set)
-      :param legend2: the legend for second-type spins
-          (applied only to the first of the set)
-      :param y_max_lim: the maximum on the y axis (if None, put the
-          maximum of the bands)
-      :param y_min_lim: the minimum on the y axis (if None, put the
-          minimum of the bands)
-      :param y_origin: the new origin of the y axis -> all bands are replaced
-          by bands-y_origin
-      :param prettify_format: if None, use the default prettify format. Otherwise
-          specify a string with the prettifier to use.
-      :param kwargs: additional customization variables; only a subset is
-          accepted, see internal variable 'valid_additional_keywords
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._matplotlib_get_dict
+         :renderer: rst
 
    .. py:method:: _prepare_mpl_singlefile(*args, **kwargs)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_mpl_singlefile
 
-      Prepare a python script using matplotlib to plot the bands
-
-      For the possible parameters, see documentation of
-      :py:meth:`~aiida.orm.nodes.data.array.bands.BandsData._matplotlib_get_dict`
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_mpl_singlefile
+         :renderer: rst
 
    .. py:method:: _prepare_mpl_withjson(main_file_name='', *args, **kwargs)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_mpl_withjson
 
-      Prepare a python script using matplotlib to plot the bands, with the JSON
-      returned as an independent file.
-
-      For the possible parameters, see documentation of
-      :py:meth:`~aiida.orm.nodes.data.array.bands.BandsData._matplotlib_get_dict`
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_mpl_withjson
+         :renderer: rst
 
    .. py:method:: _prepare_mpl_pdf(main_file_name='', *args, **kwargs)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_mpl_pdf
 
-      Prepare a python script using matplotlib to plot the bands, with the JSON
-      returned as an independent file.
-
-      For the possible parameters, see documentation of
-      :py:meth:`~aiida.orm.nodes.data.array.bands.BandsData._matplotlib_get_dict`
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_mpl_pdf
+         :renderer: rst
 
    .. py:method:: _prepare_mpl_png(main_file_name='', *args, **kwargs)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_mpl_png
 
-      Prepare a python script using matplotlib to plot the bands, with the JSON
-      returned as an independent file.
-
-      For the possible parameters, see documentation of
-      :py:meth:`~aiida.orm.nodes.data.array.bands.BandsData._matplotlib_get_dict`
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_mpl_png
+         :renderer: rst
 
    .. py:method:: _get_mpl_body_template(paths)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._get_mpl_body_template
       :staticmethod:
 
-      :param paths: paths of k-points
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._get_mpl_body_template
+         :renderer: rst
 
    .. py:method:: show_mpl(**kwargs)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData.show_mpl
 
-      Call a show() command for the band structure using matplotlib.
-      This uses internally the 'mpl_singlefile' format, with empty
-      main_file_name.
-
-      Other kwargs are passed to self._exportcontent.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData.show_mpl
+         :renderer: rst
 
    .. py:method:: _prepare_gnuplot(main_file_name=None, title='', comments=True, prettify_format=None, y_max_lim=None, y_min_lim=None, y_origin=0.0)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_gnuplot
 
-      Prepare an gnuplot script to plot the bands, with the .dat file
-      returned as an independent file.
-
-      :param main_file_name: if the user asks to write the main content on a
-           file, this contains the filename. This should be used to infer a
-           good filename for the additional files.
-           In this case, we remove the extension, and add '_data.dat'
-      :param title: if specified, add a title to the plot
-      :param comments: if True, print comments (if it makes sense for the given
-          format)
-      :param prettify_format: if None, use the default prettify format. Otherwise
-          specify a string with the prettifier to use.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_gnuplot
+         :renderer: rst
 
    .. py:method:: _prepare_agr(main_file_name='', comments=True, setnumber_offset=0, color_number=1, color_number2=2, legend='', title='', y_max_lim=None, y_min_lim=None, y_origin=0.0, prettify_format=None)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_agr
 
-      Prepare an xmgrace agr file.
-
-      :param comments: if True, print comments
-          (if it makes sense for the given format)
-      :param plot_info: a dictionary
-      :param setnumber_offset: an offset to be applied to all set numbers
-          (i.e. s0 is replaced by s[offset], s1 by s[offset+1], etc.)
-      :param color_number: the color number for lines, symbols, error bars
-          and filling (should be less than the parameter MAX_NUM_AGR_COLORS
-          defined below)
-      :param color_number2: the color number for lines, symbols, error bars
-          and filling for the second-type spins (should be less than the
-          parameter MAX_NUM_AGR_COLORS defined below)
-      :param legend: the legend (applied only to the first set)
-      :param title: the title
-      :param y_max_lim: the maximum on the y axis (if None, put the
-          maximum of the bands); applied *after* shifting the origin
-          by ``y_origin``
-      :param y_min_lim: the minimum on the y axis (if None, put the
-          minimum of the bands); applied *after* shifting the origin
-          by ``y_origin``
-      :param y_origin: the new origin of the y axis -> all bands are replaced
-          by bands-y_origin
-      :param prettify_format: if None, use the default prettify format. Otherwise
-          specify a string with the prettifier to use.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_agr
+         :renderer: rst
 
    .. py:method:: _get_band_segments(cartesian)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._get_band_segments
 
-      Return the band segments.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._get_band_segments
+         :renderer: rst
 
    .. py:method:: _prepare_json(main_file_name='', comments=True)
       :canonical: aiida.orm.nodes.data.array.bands.BandsData._prepare_json
 
-      Prepare a json file in a format compatible with the AiiDA band visualizer
-
-      :param comments: if True, print comments (if it makes sense for the given
-          format)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.BandsData._prepare_json
+         :renderer: rst
 
 .. py:class:: BaseType(value=None, **kwargs)
    :canonical: aiida.orm.nodes.data.base.BaseType
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   `Data` sub class to be used as a base for data containers that represent base python data types.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.base.BaseType
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.orm.nodes.data.base.BaseType.__init__
+      :renderer: rst
 
    .. py:property:: value
       :canonical: aiida.orm.nodes.data.base.BaseType.value
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.base.BaseType.value
+         :renderer: rst
+
    .. py:method:: __str__()
       :canonical: aiida.orm.nodes.data.base.BaseType.__str__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.base.BaseType.__str__
+         :renderer: rst
 
    .. py:method:: __eq__(other)
       :canonical: aiida.orm.nodes.data.base.BaseType.__eq__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.base.BaseType.__eq__
+         :renderer: rst
+
    .. py:method:: new(value=None)
       :canonical: aiida.orm.nodes.data.base.BaseType.new
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.base.BaseType.new
+         :renderer: rst
 
 .. py:class:: Bool
    :canonical: aiida.orm.nodes.data.bool.Bool
 
    Bases: :py:obj:`aiida.orm.nodes.data.base.BaseType`
 
-   `Data` sub class to represent a boolean value.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.bool.Bool
+      :renderer: rst
 
    .. py:attribute:: _type
       :canonical: aiida.orm.nodes.data.bool.Bool._type
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.bool.Bool._type
+         :renderer: rst
+
    .. py:method:: __int__()
       :canonical: aiida.orm.nodes.data.bool.Bool.__int__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.bool.Bool.__int__
+         :renderer: rst
+
    .. py:method:: __bool__()
       :canonical: aiida.orm.nodes.data.bool.Bool.__bool__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.bool.Bool.__bool__
+         :renderer: rst
 
 .. py:class:: CalcFunctionNode
    :canonical: aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode
 
    Bases: :py:obj:`aiida.orm.utils.mixins.FunctionCalculationMixin`, :py:obj:`aiida.orm.nodes.process.calculation.calculation.CalculationNode`
 
-   ORM class for all nodes representing the execution of a calcfunction.
+   .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode
+      :renderer: rst
 
    .. py:attribute:: _CLS_NODE_LINKS
       :canonical: aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode._CLS_NODE_LINKS
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcfunction.CalcFunctionNode._CLS_NODE_LINKS
+         :renderer: rst
 
 .. py:class:: CalcJobNode
    :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode
 
    Bases: :py:obj:`aiida.orm.nodes.process.calculation.calculation.CalculationNode`
 
-   ORM class for all nodes representing the execution of a CalcJob.
+   .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode
+      :renderer: rst
 
    .. py:attribute:: CALC_JOB_STATE_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.CALC_JOB_STATE_KEY
       :value: 'state'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.CALC_JOB_STATE_KEY
+         :renderer: rst
+
    .. py:attribute:: IMMIGRATED_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.IMMIGRATED_KEY
       :value: 'imported'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.IMMIGRATED_KEY
+         :renderer: rst
 
    .. py:attribute:: REMOTE_WORKDIR_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.REMOTE_WORKDIR_KEY
       :value: 'remote_workdir'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.REMOTE_WORKDIR_KEY
+         :renderer: rst
+
    .. py:attribute:: RETRIEVE_LIST_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.RETRIEVE_LIST_KEY
       :value: 'retrieve_list'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.RETRIEVE_LIST_KEY
+         :renderer: rst
 
    .. py:attribute:: RETRIEVE_TEMPORARY_LIST_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.RETRIEVE_TEMPORARY_LIST_KEY
       :value: 'retrieve_temporary_list'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.RETRIEVE_TEMPORARY_LIST_KEY
+         :renderer: rst
+
    .. py:attribute:: SCHEDULER_JOB_ID_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_JOB_ID_KEY
       :value: 'job_id'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_JOB_ID_KEY
+         :renderer: rst
 
    .. py:attribute:: SCHEDULER_STATE_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_STATE_KEY
       :value: 'scheduler_state'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_STATE_KEY
+         :renderer: rst
+
    .. py:attribute:: SCHEDULER_LAST_CHECK_TIME_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_LAST_CHECK_TIME_KEY
       :value: 'scheduler_lastchecktime'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_LAST_CHECK_TIME_KEY
+         :renderer: rst
 
    .. py:attribute:: SCHEDULER_LAST_JOB_INFO_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_LAST_JOB_INFO_KEY
       :value: 'last_job_info'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_LAST_JOB_INFO_KEY
+         :renderer: rst
+
    .. py:attribute:: SCHEDULER_DETAILED_JOB_INFO_KEY
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_DETAILED_JOB_INFO_KEY
       :value: 'detailed_job_info'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.SCHEDULER_DETAILED_JOB_INFO_KEY
+         :renderer: rst
 
    .. py:attribute:: _tools
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode._tools
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode._tools
+         :renderer: rst
+
    .. py:property:: tools
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.tools
       :type: aiida.tools.calculations.CalculationTools
 
-      Return the calculation tools that are registered for the process type associated with this calculation.
-
-      If the entry point name stored in the `process_type` of the CalcJobNode has an accompanying entry point in the
-      `aiida.tools.calculations` entry point category, it will attempt to load the entry point and instantiate it
-      passing the node to the constructor. If the entry point does not exist, cannot be resolved or loaded, a warning
-      will be logged and the base CalculationTools class will be instantiated and returned.
-
-      :return: CalculationTools instance
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.tools
+         :renderer: rst
 
    .. py:method:: _updatable_attributes() -> typing.Tuple[str, ...]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode._updatable_attributes
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode._updatable_attributes
+         :renderer: rst
+
    .. py:method:: _hash_ignored_attributes() -> typing.Tuple[str, ...]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode._hash_ignored_attributes
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode._hash_ignored_attributes
+         :renderer: rst
 
    .. py:method:: get_builder_restart() -> aiida.engine.processes.builder.ProcessBuilder
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_builder_restart
 
-      Return a `ProcessBuilder` that is ready to relaunch the same `CalcJob` that created this node.
-
-      The process class will be set based on the `process_type` of this node and the inputs of the builder will be
-      prepopulated with the inputs registered for this node. This functionality is very useful if a process has
-      completed and you want to relaunch it with slightly different inputs.
-
-      In addition to prepopulating the input nodes, which is implemented by the base `ProcessNode` class, here we
-      also add the `options` that were passed in the `metadata` input of the `CalcJob` process.
-
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_builder_restart
+         :renderer: rst
 
    .. py:property:: is_imported
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.is_imported
       :type: bool
 
-      Return whether the calculation job was imported instead of being an actual run.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.is_imported
+         :renderer: rst
 
    .. py:method:: get_option(name: str) -> typing.Optional[typing.Any]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_option
 
-      Retun the value of an option that was set for this CalcJobNode
-
-      :param name: the option name
-      :return: the option value or None
-      :raises: ValueError for unknown option
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_option
+         :renderer: rst
 
    .. py:method:: set_option(name: str, value: typing.Any) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_option
 
-      Set an option to the given value
-
-      :param name: the option name
-      :param value: the value to set
-      :raises: ValueError for unknown option
-      :raises: TypeError for values with invalid type
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_option
+         :renderer: rst
 
    .. py:method:: get_options() -> typing.Dict[str, typing.Any]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_options
 
-      Return the dictionary of options set for this CalcJobNode
-
-      :return: dictionary of the options and their values
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_options
+         :renderer: rst
 
    .. py:method:: set_options(options: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_options
 
-      Set the options for this CalcJobNode
-
-      :param options: dictionary of option and their values to set
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_options
+         :renderer: rst
 
    .. py:method:: get_state() -> typing.Optional[aiida.common.datastructures.CalcJobState]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_state
 
-      Return the calculation job active sub state.
-
-      The calculation job state serves to give more granular state information to `CalcJobs`, in addition to the
-      generic process state, while the calculation job is active. The state can take values from the enumeration
-      defined in `aiida.common.datastructures.CalcJobState` and can be used to query for calculation jobs in specific
-      active states.
-
-      :return: instance of `aiida.common.datastructures.CalcJobState` or `None` if invalid value, or not set
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_state
+         :renderer: rst
 
    .. py:method:: set_state(state: aiida.common.datastructures.CalcJobState) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_state
 
-      Set the calculation active job state.
-
-      :raise: ValueError if state is invalid
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_state
+         :renderer: rst
 
    .. py:method:: delete_state() -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.delete_state
 
-      Delete the calculation job state attribute if it exists.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.delete_state
+         :renderer: rst
 
    .. py:method:: set_remote_workdir(remote_workdir: str) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_remote_workdir
 
-      Set the absolute path to the working directory on the remote computer where the calculation is run.
-
-      :param remote_workdir: absolute filepath to the remote working directory
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_remote_workdir
+         :renderer: rst
 
    .. py:method:: get_remote_workdir() -> typing.Optional[str]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_remote_workdir
 
-      Return the path to the remote (on cluster) scratch folder of the calculation.
-
-      :return: a string with the remote path
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_remote_workdir
+         :renderer: rst
 
    .. py:method:: _validate_retrieval_directive(directives: typing.Sequence[typing.Union[str, typing.Tuple[str, str, str]]]) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode._validate_retrieval_directive
       :staticmethod:
 
-      Validate a list or tuple of file retrieval directives.
-
-      :param directives: a list or tuple of file retrieval directives
-      :raise ValueError: if the format of the directives is invalid
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode._validate_retrieval_directive
+         :renderer: rst
 
    .. py:method:: set_retrieve_list(retrieve_list: typing.Sequence[typing.Union[str, typing.Tuple[str, str, str]]]) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_retrieve_list
 
-      Set the retrieve list.
-
-      This list of directives will instruct the daemon what files to retrieve after the calculation has completed.
-      list or tuple of files or paths that should be retrieved by the daemon.
-
-      :param retrieve_list: list or tuple of with filepath directives
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_retrieve_list
+         :renderer: rst
 
    .. py:method:: get_retrieve_list() -> typing.Optional[typing.Sequence[typing.Union[str, typing.Tuple[str, str, str]]]]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_retrieve_list
 
-      Return the list of files/directories to be retrieved on the cluster after the calculation has completed.
-
-      :return: a list of file directives
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_retrieve_list
+         :renderer: rst
 
    .. py:method:: set_retrieve_temporary_list(retrieve_temporary_list: typing.Sequence[typing.Union[str, typing.Tuple[str, str, str]]]) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_retrieve_temporary_list
 
-      Set the retrieve temporary list.
-
-      The retrieve temporary list stores files that are retrieved after completion and made available during parsing
-      and are deleted as soon as the parsing has been completed.
-
-      :param retrieve_temporary_list: list or tuple of with filepath directives
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_retrieve_temporary_list
+         :renderer: rst
 
    .. py:method:: get_retrieve_temporary_list() -> typing.Optional[typing.Sequence[typing.Union[str, typing.Tuple[str, str, str]]]]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_retrieve_temporary_list
 
-      Return list of files to be retrieved from the cluster which will be available during parsing.
-
-      :return: a list of file directives
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_retrieve_temporary_list
+         :renderer: rst
 
    .. py:method:: set_job_id(job_id: typing.Union[int, str]) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_job_id
 
-      Set the job id that was assigned to the calculation by the scheduler.
-
-      .. note:: the id will always be stored as a string
-
-      :param job_id: the id assigned by the scheduler after submission
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_job_id
+         :renderer: rst
 
    .. py:method:: get_job_id() -> typing.Optional[str]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_job_id
 
-      Return job id that was assigned to the calculation by the scheduler.
-
-      :return: the string representation of the scheduler job id
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_job_id
+         :renderer: rst
 
    .. py:method:: set_scheduler_state(state: aiida.schedulers.datastructures.JobState) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_scheduler_state
 
-      Set the scheduler state.
-
-      :param state: an instance of `JobState`
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_scheduler_state
+         :renderer: rst
 
    .. py:method:: get_scheduler_state() -> typing.Optional[aiida.schedulers.datastructures.JobState]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_scheduler_state
 
-      Return the status of the calculation according to the cluster scheduler.
-
-      :return: a JobState enum instance.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_scheduler_state
+         :renderer: rst
 
    .. py:method:: get_scheduler_lastchecktime() -> typing.Optional[datetime.datetime]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_scheduler_lastchecktime
 
-      Return the time of the last update of the scheduler state by the daemon or None if it was never set.
-
-      :return: a datetime object or None
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_scheduler_lastchecktime
+         :renderer: rst
 
    .. py:method:: set_detailed_job_info(detailed_job_info: typing.Optional[dict]) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_detailed_job_info
 
-      Set the detailed job info dictionary.
-
-      :param detailed_job_info: a dictionary with metadata with the accounting of a completed job
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_detailed_job_info
+         :renderer: rst
 
    .. py:method:: get_detailed_job_info() -> typing.Optional[dict]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_detailed_job_info
 
-      Return the detailed job info dictionary.
-
-      The scheduler is polled for the detailed job info after the job is completed and ready to be retrieved.
-
-      :return: the dictionary with detailed job info if defined or None
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_detailed_job_info
+         :renderer: rst
 
    .. py:method:: set_last_job_info(last_job_info: aiida.schedulers.datastructures.JobInfo) -> None
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_last_job_info
 
-      Set the last job info.
-
-      :param last_job_info: a `JobInfo` object
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.set_last_job_info
+         :renderer: rst
 
    .. py:method:: get_last_job_info() -> typing.Optional[aiida.schedulers.datastructures.JobInfo]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_last_job_info
 
-      Return the last information asked to the scheduler about the status of the job.
-
-      The last job info is updated on every poll of the scheduler, except for the final poll when the job drops from
-      the scheduler's job queue.
-      For completed jobs, the last job info therefore contains the "second-to-last" job info that still shows the job
-      as running. Please use :meth:`~aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_detailed_job_info`
-      instead.
-
-      :return: a `JobInfo` object (that closely resembles a dictionary) or None.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_last_job_info
+         :renderer: rst
 
    .. py:method:: get_authinfo() -> aiida.orm.authinfos.AuthInfo
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_authinfo
 
-      Return the `AuthInfo` that is configured for the `Computer` set for this node.
-
-      :return: `AuthInfo`
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_authinfo
+         :renderer: rst
 
    .. py:method:: get_transport() -> aiida.transports.Transport
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_transport
 
-      Return the transport for this calculation.
-
-      :return: `Transport` configured with the `AuthInfo` associated to the computer of this node
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_transport
+         :renderer: rst
 
    .. py:method:: get_parser_class() -> typing.Optional[typing.Type[aiida.parsers.Parser]]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_parser_class
 
-      Return the output parser object for this calculation or None if no parser is set.
-
-      :return: a `Parser` class.
-      :raises `aiida.common.exceptions.EntryPointError`: if the parser entry point can not be resolved.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_parser_class
+         :renderer: rst
 
    .. py:property:: link_label_retrieved
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.link_label_retrieved
       :type: str
 
-      Return the link label used for the retrieved FolderData node.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.link_label_retrieved
+         :renderer: rst
 
    .. py:method:: get_retrieved_node() -> typing.Optional[aiida.orm.FolderData]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_retrieved_node
 
-      Return the retrieved data folder.
-
-      :return: the retrieved FolderData node or None if not found
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_retrieved_node
+         :renderer: rst
 
    .. py:property:: res
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.res
       :type: aiida.orm.utils.calcjob.CalcJobResultManager
 
-      To be used to get direct access to the parsed parameters.
-
-      :return: an instance of the CalcJobResultManager.
-
-      :note: a practical example on how it is meant to be used: let's say that there is a key 'energy'
-          in the dictionary of the parsed results which contains a list of floats.
-          The command `calc.res.energy` will return such a list.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.res
+         :renderer: rst
 
    .. py:method:: get_scheduler_stdout() -> typing.Optional[typing.AnyStr]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_scheduler_stdout
 
-      Return the scheduler stderr output if the calculation has finished and been retrieved, None otherwise.
-
-      :return: scheduler stderr output or None
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_scheduler_stdout
+         :renderer: rst
 
    .. py:method:: get_scheduler_stderr() -> typing.Optional[typing.AnyStr]
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_scheduler_stderr
 
-      Return the scheduler stdout output if the calculation has finished and been retrieved, None otherwise.
-
-      :return: scheduler stdout output or None
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_scheduler_stderr
+         :renderer: rst
 
    .. py:method:: get_description() -> str
       :canonical: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_description
 
-      Return a description of the node based on its properties.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_description
+         :renderer: rst
 
 .. py:class:: CalcJobResultManager(node)
    :canonical: aiida.orm.utils.calcjob.CalcJobResultManager
 
-   Utility class to easily access the contents of the 'default output' node of a `CalcJobNode`.
-
-   A `CalcJob` process can mark one of its outputs as the 'default output'. The default output node will always be
-   returned by the `CalcJob` and will always be a `Dict` node.
-
-   If a `CalcJob` defines such a default output node, this utility class will simplify retrieving the result of said
-   node through the `CalcJobNode` instance produced by the execution of the `CalcJob`.
-
-   The default results are only defined if the `CalcJobNode` has a `process_type` that can be successfully used
-   to load the corresponding `CalcJob` process class *and* if its process spec defines a `default_output_node`.
-   If both these conditions are met, the results are defined as the dictionary contained within the default
-   output node.
+   .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct an instance of the `CalcJobResultManager`.
-
-   :param calc: the `CalcJobNode` instance.
+   .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager.__init__
+      :renderer: rst
 
    .. py:property:: node
       :canonical: aiida.orm.utils.calcjob.CalcJobResultManager.node
 
-      Return the `CalcJobNode` associated with this result manager instance.
+      .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager.node
+         :renderer: rst
 
    .. py:method:: _load_results()
       :canonical: aiida.orm.utils.calcjob.CalcJobResultManager._load_results
 
-      Try to load the results for the `CalcJobNode` of this result manager.
-
-      :raises ValueError: if no default output node could be loaded
+      .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager._load_results
+         :renderer: rst
 
    .. py:method:: get_results()
       :canonical: aiida.orm.utils.calcjob.CalcJobResultManager.get_results
 
-      Return the results dictionary of the default results node of the calculation node.
-
-      This property will lazily load the dictionary.
-
-      :return: the dictionary of the default result node
+      .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager.get_results
+         :renderer: rst
 
    .. py:method:: __dir__()
       :canonical: aiida.orm.utils.calcjob.CalcJobResultManager.__dir__
 
-      Add the keys of the results dictionary such that they can be autocompleted.
+      .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager.__dir__
+         :renderer: rst
 
    .. py:method:: __iter__()
       :canonical: aiida.orm.utils.calcjob.CalcJobResultManager.__iter__
 
-      Return an iterator over the keys of the result dictionary.
+      .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager.__iter__
+         :renderer: rst
 
    .. py:method:: __getattr__(name)
       :canonical: aiida.orm.utils.calcjob.CalcJobResultManager.__getattr__
 
-      Return an attribute from the results dictionary.
-
-      :param name: name of the result return
-      :return: value of the attribute
-      :raises AttributeError: if the results node cannot be retrieved or it does not contain the `name` attribute
+      .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager.__getattr__
+         :renderer: rst
 
    .. py:method:: __getitem__(name)
       :canonical: aiida.orm.utils.calcjob.CalcJobResultManager.__getitem__
 
-      Return an attribute from the results dictionary.
-
-      :param name: name of the result return
-      :return: value of the attribute
-      :raises KeyError: if the results node cannot be retrieved or it does not contain the `name` attribute
+      .. autodoc2-docstring:: aiida.orm.utils.calcjob.CalcJobResultManager.__getitem__
+         :renderer: rst
 
 .. py:class:: CalculationEntityLoader
    :canonical: aiida.orm.utils.loaders.CalculationEntityLoader
 
    Bases: :py:obj:`aiida.orm.utils.loaders.OrmEntityLoader`
 
-   Loader for the `Calculation` entity and sub classes.
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.CalculationEntityLoader
+      :renderer: rst
 
    .. py:method:: orm_base_class()
       :canonical: aiida.orm.utils.loaders.CalculationEntityLoader.orm_base_class
 
-      Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
-      may further narrow the query set by defining a more specific set of orm classes, as long as each of
-      those is a strict sub class of the orm base class.
-
-      :returns: the orm base class
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.CalculationEntityLoader.orm_base_class
+         :renderer: rst
 
    .. py:method:: _get_query_builder_label_identifier(identifier, classes, operator='==', project='*')
       :canonical: aiida.orm.utils.loaders.CalculationEntityLoader._get_query_builder_label_identifier
       :classmethod:
 
-      Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
-      defined for this loader class, interpreting the identifier as a LABEL like identifier
-
-      :param identifier: the LABEL identifier
-      :param classes: a tuple of orm classes to which the identifier should be mapped
-      :param operator: the operator to use in the query
-      :param project: the property or properties to project for entities matching the query
-      :returns: the query builder instance that should retrieve the entity corresponding to the identifier
-      :raises ValueError: if the identifier is invalid
-      :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.CalculationEntityLoader._get_query_builder_label_identifier
+         :renderer: rst
 
 .. py:class:: CalculationNode(backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None, user: typing.Optional[aiida.orm.users.User] = None, computer: typing.Optional[aiida.orm.computers.Computer] = None, **kwargs: typing.Any)
    :canonical: aiida.orm.nodes.process.calculation.calculation.CalculationNode
 
    Bases: :py:obj:`aiida.orm.nodes.process.process.ProcessNode`
 
-   Base class for all nodes representing the execution of a calculation process.
+   .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calculation.CalculationNode
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   :param backend_entity: the backend model supporting this entity
+   .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calculation.CalculationNode.__init__
+      :renderer: rst
 
    .. py:attribute:: _storable
       :canonical: aiida.orm.nodes.process.calculation.calculation.CalculationNode._storable
       :value: True
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calculation.CalculationNode._storable
+         :renderer: rst
+
    .. py:attribute:: _cachable
       :canonical: aiida.orm.nodes.process.calculation.calculation.CalculationNode._cachable
       :value: True
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calculation.CalculationNode._cachable
+         :renderer: rst
 
    .. py:attribute:: _unstorable_message
       :canonical: aiida.orm.nodes.process.calculation.calculation.CalculationNode._unstorable_message
       :value: 'storing for this node has been disabled'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calculation.CalculationNode._unstorable_message
+         :renderer: rst
+
    .. py:property:: inputs
       :canonical: aiida.orm.nodes.process.calculation.calculation.CalculationNode.inputs
       :type: aiida.orm.utils.managers.NodeLinksManager
 
-      Return an instance of `NodeLinksManager` to manage incoming INPUT_CALC links
-
-      The returned Manager allows you to easily explore the nodes connected to this node
-      via an incoming INPUT_CALC link.
-      The incoming nodes are reachable by their link labels which are attributes of the manager.
-
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calculation.CalculationNode.inputs
+         :renderer: rst
 
    .. py:property:: outputs
       :canonical: aiida.orm.nodes.process.calculation.calculation.CalculationNode.outputs
       :type: aiida.orm.utils.managers.NodeLinksManager
 
-      Return an instance of `NodeLinksManager` to manage outgoing CREATE links
-
-      The returned Manager allows you to easily explore the nodes connected to this node
-      via an outgoing CREATE link.
-      The outgoing nodes are reachable by their link labels which are attributes of the manager.
-
+      .. autodoc2-docstring:: aiida.orm.nodes.process.calculation.calculation.CalculationNode.outputs
+         :renderer: rst
 
 .. py:class:: CifData(ase=None, file=None, filename=None, values=None, scan_type=None, parse_policy=None, **kwargs)
    :canonical: aiida.orm.nodes.data.cif.CifData
 
    Bases: :py:obj:`aiida.orm.nodes.data.singlefile.SinglefileData`
 
-   Wrapper for Crystallographic Interchange File (CIF)
-
-   .. note:: the file (physical) is held as the authoritative source of
-       information, so all conversions are done through the physical file:
-       when setting ``ase`` or ``values``, a physical CIF file is generated
-       first, the values are updated from the physical CIF file.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance and set the contents to that of the file.
-
-   :param file: an absolute filepath or filelike object for CIF.
-       Hint: Pass io.BytesIO(b"my string") to construct the SinglefileData directly from a string.
-   :param filename: specify filename to use (defaults to name of provided file).
-   :param ase: ASE Atoms object to construct the CifData instance from.
-   :param values: PyCifRW CifFile object to construct the CifData instance from.
-   :param scan_type: scan type string for parsing with PyCIFRW ('standard' or 'flex'). See CifFile.ReadCif
-   :param parse_policy: 'eager' (parse CIF file on set_file) or 'lazy' (defer parsing until needed)
+   .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.__init__
+      :renderer: rst
 
    .. py:attribute:: _SET_INCOMPATIBILITIES
       :canonical: aiida.orm.nodes.data.cif.CifData._SET_INCOMPATIBILITIES
       :value: [('ase', 'file'), ('ase', 'values'), ('file', 'values')]
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._SET_INCOMPATIBILITIES
+         :renderer: rst
+
    .. py:attribute:: _SCAN_TYPES
       :canonical: aiida.orm.nodes.data.cif.CifData._SCAN_TYPES
       :value: ('standard', 'flex')
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._SCAN_TYPES
+         :renderer: rst
 
    .. py:attribute:: _SCAN_TYPE_DEFAULT
       :canonical: aiida.orm.nodes.data.cif.CifData._SCAN_TYPE_DEFAULT
       :value: 'standard'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._SCAN_TYPE_DEFAULT
+         :renderer: rst
+
    .. py:attribute:: _PARSE_POLICIES
       :canonical: aiida.orm.nodes.data.cif.CifData._PARSE_POLICIES
       :value: ('eager', 'lazy')
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._PARSE_POLICIES
+         :renderer: rst
 
    .. py:attribute:: _PARSE_POLICY_DEFAULT
       :canonical: aiida.orm.nodes.data.cif.CifData._PARSE_POLICY_DEFAULT
       :value: 'eager'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._PARSE_POLICY_DEFAULT
+         :renderer: rst
+
    .. py:attribute:: _values
       :canonical: aiida.orm.nodes.data.cif.CifData._values
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._values
+         :renderer: rst
 
    .. py:attribute:: _ase
       :canonical: aiida.orm.nodes.data.cif.CifData._ase
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._ase
+         :renderer: rst
+
    .. py:method:: read_cif(fileobj, index=-1, **kwargs)
       :canonical: aiida.orm.nodes.data.cif.CifData.read_cif
       :staticmethod:
 
-      A wrapper method that simulates the behavior of the old
-      function ase.io.cif.read_cif by using the new generic ase.io.read
-      function.
-
-      Somewhere from 3.12 to 3.17 the tag concept was bundled with each Atom object. When
-      reading a CIF file, this is incremented and signifies the atomic species, even though
-      the CIF file do not have specific tags embedded. On reading CIF files we thus force the
-      ASE tag to zero for all Atom elements.
-
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.read_cif
+         :renderer: rst
 
    .. py:method:: from_md5(md5, backend=None)
       :canonical: aiida.orm.nodes.data.cif.CifData.from_md5
       :classmethod:
 
-      Return a list of all CIF files that match a given MD5 hash.
-
-      .. note:: the hash has to be stored in a ``_md5`` attribute,
-          otherwise the CIF file will not be found.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.from_md5
+         :renderer: rst
 
    .. py:method:: get_or_create(filename, use_first=False, store_cif=True)
       :canonical: aiida.orm.nodes.data.cif.CifData.get_or_create
       :classmethod:
 
-      Pass the same parameter of the init; if a file with the same md5
-      is found, that CifData is returned.
-
-      :param filename: an absolute filename on disk
-      :param use_first: if False (default), raise an exception if more than                 one CIF file is found.                If it is True, instead, use the first available CIF file.
-      :param bool store_cif: If false, the CifData objects are not stored in
-              the database. default=True.
-      :return (cif, created): where cif is the CifData object, and create is either            True if the object was created, or False if the object was retrieved            from the DB.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.get_or_create
+         :renderer: rst
 
    .. py:property:: ase
       :canonical: aiida.orm.nodes.data.cif.CifData.ase
 
-      ASE object, representing the CIF.
-
-      .. note:: requires ASE module.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.ase
+         :renderer: rst
 
    .. py:method:: get_ase(**kwargs)
       :canonical: aiida.orm.nodes.data.cif.CifData.get_ase
 
-      Returns ASE object, representing the CIF. This function differs
-      from the property ``ase`` by the possibility to pass the keyworded
-      arguments (kwargs) to ase.io.cif.read_cif().
-
-      .. note:: requires ASE module.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.get_ase
+         :renderer: rst
 
    .. py:method:: set_ase(aseatoms)
       :canonical: aiida.orm.nodes.data.cif.CifData.set_ase
 
-      Set the contents of the CifData starting from an ASE atoms object
-
-      :param aseatoms: the ASE atoms object
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.set_ase
+         :renderer: rst
 
    .. py:property:: values
       :canonical: aiida.orm.nodes.data.cif.CifData.values
 
-      PyCifRW structure, representing the CIF datablocks.
-
-      .. note:: requires PyCifRW module.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.values
+         :renderer: rst
 
    .. py:method:: set_values(values)
       :canonical: aiida.orm.nodes.data.cif.CifData.set_values
 
-      Set internal representation to `values`.
-
-      Warning: This also writes a new CIF file.
-
-      :param values: PyCifRW CifFile object
-
-      .. note:: requires PyCifRW module.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.set_values
+         :renderer: rst
 
    .. py:method:: parse(scan_type=None)
       :canonical: aiida.orm.nodes.data.cif.CifData.parse
 
-      Parses CIF file and sets attributes.
-
-      :param scan_type:  See set_scan_type
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.parse
+         :renderer: rst
 
    .. py:method:: store(*args, **kwargs)
       :canonical: aiida.orm.nodes.data.cif.CifData.store
 
-      Store the node.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.store
+         :renderer: rst
 
    .. py:method:: set_file(file, filename=None)
       :canonical: aiida.orm.nodes.data.cif.CifData.set_file
 
-      Set the file.
-
-      If the source is set and the MD5 checksum of new file
-      is different from the source, the source has to be deleted.
-
-      :param file: filepath or filelike object of the CIF file to store.
-          Hint: Pass io.BytesIO(b"my string") to construct the file directly from a string.
-      :param filename: specify filename to use (defaults to name of provided file).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.set_file
+         :renderer: rst
 
    .. py:method:: set_scan_type(scan_type)
       :canonical: aiida.orm.nodes.data.cif.CifData.set_scan_type
 
-      Set the scan_type for PyCifRW.
-
-      The 'flex' scan_type of PyCifRW is faster for large CIF files but
-      does not yet support the CIF2 format as of 02/2018.
-      See the CifFile.ReadCif function
-
-      :param scan_type: Either 'standard' or 'flex' (see _scan_types)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.set_scan_type
+         :renderer: rst
 
    .. py:method:: set_parse_policy(parse_policy)
       :canonical: aiida.orm.nodes.data.cif.CifData.set_parse_policy
 
-      Set the parse policy.
-
-      :param parse_policy: Either 'eager' (parse CIF file on set_file)
-          or 'lazy' (defer parsing until needed)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.set_parse_policy
+         :renderer: rst
 
    .. py:method:: get_formulae(mode='sum', custom_tags=None)
       :canonical: aiida.orm.nodes.data.cif.CifData.get_formulae
 
-      Return chemical formulae specified in CIF file.
-
-      Note: This does not compute the formula, it only reads it from the
-      appropriate tag. Use refine_inline to compute formulae.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.get_formulae
+         :renderer: rst
 
    .. py:method:: get_spacegroup_numbers()
       :canonical: aiida.orm.nodes.data.cif.CifData.get_spacegroup_numbers
 
-      Get the spacegroup international number.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.get_spacegroup_numbers
+         :renderer: rst
 
    .. py:property:: has_partial_occupancies
       :canonical: aiida.orm.nodes.data.cif.CifData.has_partial_occupancies
 
-      Return if the cif data contains partial occupancies
-
-      A partial occupancy is defined as site with an occupancy that differs from unity, within a precision of 1E-6
-
-      .. note: occupancies that cannot be parsed into a float are ignored
-
-      :return: True if there are partial occupancies, False otherwise
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.has_partial_occupancies
+         :renderer: rst
 
    .. py:property:: has_attached_hydrogens
       :canonical: aiida.orm.nodes.data.cif.CifData.has_attached_hydrogens
 
-      Check if there are hydrogens without coordinates, specified as attached
-      to the atoms of the structure.
-
-      :returns: True if there are attached hydrogens, False otherwise.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.has_attached_hydrogens
+         :renderer: rst
 
    .. py:property:: has_undefined_atomic_sites
       :canonical: aiida.orm.nodes.data.cif.CifData.has_undefined_atomic_sites
 
-      Return whether the cif data contains any undefined atomic sites.
-
-      An undefined atomic site is defined as a site where at least one of the fractional coordinates specified in the
-      `_atom_site_fract_*` tags, cannot be successfully interpreted as a float. If the cif data contains any site that
-      matches this description, or it does not contain any atomic site tags at all, the cif data is said to have
-      undefined atomic sites.
-
-      :return: boolean, True if no atomic sites are defined or if any of the defined sites contain undefined positions
-          and False otherwise
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.has_undefined_atomic_sites
+         :renderer: rst
 
    .. py:property:: has_atomic_sites
       :canonical: aiida.orm.nodes.data.cif.CifData.has_atomic_sites
 
-      Returns whether there are any atomic sites defined in the cif data. That
-      is to say, it will check all the values for the `_atom_site_fract_*` tags
-      and if they are all equal to `?` that means there are no relevant atomic
-      sites defined and the function will return False. In all other cases the
-      function will return True
-
-      :returns: False when at least one atomic site fractional coordinate is not
-          equal to `?` and True otherwise
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.has_atomic_sites
+         :renderer: rst
 
    .. py:property:: has_unknown_species
       :canonical: aiida.orm.nodes.data.cif.CifData.has_unknown_species
 
-      Returns whether the cif contains atomic species that are not recognized by AiiDA.
-
-      The known species are taken from the elements dictionary in `aiida.common.constants`, with the exception of
-      the "unknown" placeholder element with symbol 'X', as this could not be used to construct a real structure.
-      If any of the formula of the cif data contain species that are not in that elements dictionary, the function
-      will return True and False in all other cases. If there is no formulae to be found, it will return None
-
-      :returns: True when there are unknown species in any of the formulae, False if not, None if no formula found
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.has_unknown_species
+         :renderer: rst
 
    .. py:method:: generate_md5()
       :canonical: aiida.orm.nodes.data.cif.CifData.generate_md5
 
-      Computes and returns MD5 hash of the CIF file.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.generate_md5
+         :renderer: rst
 
    .. py:method:: get_structure(converter='pymatgen', store=False, **kwargs)
       :canonical: aiida.orm.nodes.data.cif.CifData.get_structure
 
-      Creates :py:class:`aiida.orm.nodes.data.structure.StructureData`.
-
-      .. versionadded:: 1.0
-         Renamed from _get_aiida_structure
-
-      :param converter: specify the converter. Default 'pymatgen'.
-      :param store: if True, intermediate calculation gets stored in the
-          AiiDA database for record. Default False.
-      :param primitive_cell: if True, primitive cell is returned,
-          conventional cell if False. Default False.
-      :param occupancy_tolerance: If total occupancy of a site is between 1 and occupancy_tolerance,
-          the occupancies will be scaled down to 1. (pymatgen only)
-      :param site_tolerance: This tolerance is used to determine if two sites are sitting in the same position,
-          in which case they will be combined to a single disordered site. Defaults to 1e-4. (pymatgen only)
-      :return: :py:class:`aiida.orm.nodes.data.structure.StructureData` node.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData.get_structure
+         :renderer: rst
 
    .. py:method:: _prepare_cif(**kwargs)
       :canonical: aiida.orm.nodes.data.cif.CifData._prepare_cif
 
-      Return CIF string of CifData object.
-
-      If parsed values are present, a CIF string is created and written to file. If no parsed values are present, the
-      CIF string is read from file.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._prepare_cif
+         :renderer: rst
 
    .. py:method:: _get_object_ase()
       :canonical: aiida.orm.nodes.data.cif.CifData._get_object_ase
 
-      Converts CifData to ase.Atoms
-
-      :return: an ase.Atoms object
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._get_object_ase
+         :renderer: rst
 
    .. py:method:: _get_object_pycifrw()
       :canonical: aiida.orm.nodes.data.cif.CifData._get_object_pycifrw
 
-      Converts CifData to PyCIFRW.CifFile
-
-      :return: a PyCIFRW.CifFile object
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._get_object_pycifrw
+         :renderer: rst
 
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.cif.CifData._validate
 
-      Validates MD5 hash of CIF file.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.cif.CifData._validate
+         :renderer: rst
 
 .. py:class:: Code(remote_computer_exec=None, local_executable=None, input_plugin_name=None, files=None, **kwargs)
    :canonical: aiida.orm.nodes.data.code.legacy.Code
 
    Bases: :py:obj:`aiida.orm.nodes.data.code.abstract.AbstractCode`
 
-   A code entity.
-   It can either be 'local', or 'remote'.
-
-   * Local code: it is a collection of files/dirs (added using the add_path() method), where one     file is flagged as executable (using the set_local_executable() method).
-
-   * Remote code: it is a pair (remotecomputer, remotepath_of_executable) set using the     set_remote_computer_exec() method.
-
-   For both codes, one can set some code to be executed right before or right after
-   the execution of the code, using the set_preexec_code() and set_postexec_code()
-   methods (e.g., the set_preexec_code() can be used to load specific modules required
-   for the code to be run).
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance.
-
-   :param default_calc_job_plugin: The entry point name of the default ``CalcJob`` plugin to use.
-   :param append_text: The text that should be appended to the run line in the job script.
-   :param prepend_text: The text that should be prepended to the run line in the job script.
-   :param use_double_quotes: Whether the command line invocation of this code should be escaped with double quotes.
-   :param is_hidden: Whether the code is hidden.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.__init__
+      :renderer: rst
 
    .. py:attribute:: HIDDEN_KEY
       :canonical: aiida.orm.nodes.data.code.legacy.Code.HIDDEN_KEY
       :value: 'hidden'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.HIDDEN_KEY
+         :renderer: rst
+
    .. py:method:: can_run_on_computer(computer: aiida.orm.Computer) -> bool
       :canonical: aiida.orm.nodes.data.code.legacy.Code.can_run_on_computer
 
-      Return whether the code can run on a given computer.
-
-      :param computer: The computer.
-      :return: ``True`` if the code can run on ``computer``, ``False`` otherwise.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.can_run_on_computer
+         :renderer: rst
 
    .. py:method:: get_executable() -> pathlib.PurePosixPath
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_executable
 
-      Return the executable that the submission script should execute to run the code.
-
-      :return: The executable to be called in the submission script.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_executable
+         :renderer: rst
 
    .. py:method:: hide()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.hide
 
-      Hide the code (prevents from showing it in the verdi code list)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.hide
+         :renderer: rst
 
    .. py:method:: reveal()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.reveal
 
-      Reveal the code (allows to show it in the verdi code list)
-      By default, it is revealed
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.reveal
+         :renderer: rst
 
    .. py:property:: hidden
       :canonical: aiida.orm.nodes.data.code.legacy.Code.hidden
 
-      Determines whether the Code is hidden or not
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.hidden
+         :renderer: rst
 
    .. py:method:: set_files(files)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.set_files
 
-      Given a list of filenames (or a single filename string),
-      add it to the path (all at level zero, i.e. without folders).
-      Therefore, be careful for files with the same name!
-
-      :todo: decide whether to check if the Code must be a local executable
-           to be able to call this function.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.set_files
+         :renderer: rst
 
    .. py:method:: __str__()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.__str__
+         :renderer: rst
 
    .. py:method:: get_computer_label()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_computer_label
 
-      Get label of this code's computer.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_computer_label
+         :renderer: rst
 
    .. py:property:: full_label
       :canonical: aiida.orm.nodes.data.code.legacy.Code.full_label
 
-      Get full label of this code.
-
-      Returns label of the form <code-label>@<computer-name>.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.full_label
+         :renderer: rst
 
    .. py:method:: relabel(new_label)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.relabel
 
-      Relabel this code.
-
-      :param new_label: new code label
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.relabel
+         :renderer: rst
 
    .. py:method:: get_description()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_description
 
-      Return a string description of this Code instance.
-
-      :return: string description of this Code instance
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_description
+         :renderer: rst
 
    .. py:method:: get_code_helper(label, machinename=None, backend=None)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_code_helper
       :classmethod:
 
-      :param label: the code label identifying the code to load
-      :param machinename: the machine name where code is setup
-
-      :raise aiida.common.NotExistent: if no code identified by the given string is found
-      :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely
-          a code
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_code_helper
+         :renderer: rst
 
    .. py:method:: get(pk=None, label=None, machinename=None)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get
       :classmethod:
 
-      Get a Computer object with given identifier string, that can either be
-      the numeric ID (pk), or the label (and computername) (if unique).
-
-      :param pk: the numeric ID (pk) for code
-      :param label: the code label identifying the code to load
-      :param machinename: the machine name where code is setup
-
-      :raise aiida.common.NotExistent: if no code identified by the given string is found
-      :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely a code
-      :raise ValueError: if neither a pk nor a label was passed in
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get
+         :renderer: rst
 
    .. py:method:: get_from_string(code_string)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_from_string
       :classmethod:
 
-      Get a Computer object with given identifier string in the format
-      label@machinename. See the note below for details on the string
-      detection algorithm.
-
-      .. note:: the (leftmost) '@' symbol is always used to split code
-          and computername. Therefore do not use
-          '@' in the code name if you want to use this function
-          ('@' in the computer name are instead valid).
-
-      :param code_string: the code string identifying the code to load
-
-      :raise aiida.common.NotExistent: if no code identified by the given string is found
-      :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely
-          a code
-      :raise TypeError: if code_string is not of string type
-
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_from_string
+         :renderer: rst
 
    .. py:method:: list_for_plugin(plugin, labels=True, backend=None)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.list_for_plugin
       :classmethod:
 
-      Return a list of valid code strings for a given plugin.
-
-      :param plugin: The string of the plugin.
-      :param labels: if True, return a list of code names, otherwise
-        return the code PKs (integers).
-      :return: a list of string, with the code names if labels is True,
-        otherwise a list of integers with the code PKs.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.list_for_plugin
+         :renderer: rst
 
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.code.legacy.Code._validate
 
-      Validate information stored in Node object.
-
-      For the :py:class:`~aiida.orm.Node` base class, this check is always valid.
-      Subclasses can override this method to perform additional checks
-      and should usually call ``super()._validate()`` first!
-
-      This method is called automatically before storing the node in the DB.
-      Therefore, use :py:meth:`~aiida.orm.nodes.attributes.NodeAttributes.get()` and similar methods that
-      automatically read either from the DB or from the internal attribute cache.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code._validate
+         :renderer: rst
 
    .. py:method:: validate_remote_exec_path()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.validate_remote_exec_path
 
-      Validate the ``remote_exec_path`` attribute.
-
-      Checks whether the executable exists on the remote computer if a transport can be opened to it. This method
-      is intentionally not called in ``_validate`` as to allow the creation of ``Code`` instances whose computers can
-      not yet be connected to and as to not require the overhead of opening transports in storing a new code.
-
-      :raises `~aiida.common.exceptions.ValidationError`: if no transport could be opened or if the defined executable
-          does not exist on the remote computer.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.validate_remote_exec_path
+         :renderer: rst
 
    .. py:method:: set_prepend_text(code)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.set_prepend_text
 
-      Pass a string of code that will be put in the scheduler script before the
-      execution of the code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.set_prepend_text
+         :renderer: rst
 
    .. py:method:: get_prepend_text()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_prepend_text
 
-      Return the code that will be put in the scheduler script before the
-      execution, or an empty string if no pre-exec code was defined.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_prepend_text
+         :renderer: rst
 
    .. py:method:: set_input_plugin_name(input_plugin)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.set_input_plugin_name
 
-      Set the name of the default input plugin, to be used for the automatic
-      generation of a new calculation.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.set_input_plugin_name
+         :renderer: rst
 
    .. py:method:: get_input_plugin_name()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_input_plugin_name
 
-      Return the name of the default input plugin (or None if no input plugin
-      was set.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_input_plugin_name
+         :renderer: rst
 
    .. py:method:: set_use_double_quotes(use_double_quotes: bool)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.set_use_double_quotes
 
-      Set whether the command line invocation of this code should be escaped with double quotes.
-
-      :param use_double_quotes: True if to escape with double quotes, False otherwise.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.set_use_double_quotes
+         :renderer: rst
 
    .. py:method:: get_use_double_quotes() -> bool
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_use_double_quotes
 
-      Return whether the command line invocation of this code should be escaped with double quotes.
-
-      :returns: True if to escape with double quotes, False otherwise which is also the default.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_use_double_quotes
+         :renderer: rst
 
    .. py:method:: set_append_text(code)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.set_append_text
 
-      Pass a string of code that will be put in the scheduler script after the
-      execution of the code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.set_append_text
+         :renderer: rst
 
    .. py:method:: get_append_text()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_append_text
 
-      Return the postexec_code, or an empty string if no post-exec code was defined.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_append_text
+         :renderer: rst
 
    .. py:method:: set_local_executable(exec_name)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.set_local_executable
 
-      Set the filename of the local executable.
-      Implicitly set the code as local.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.set_local_executable
+         :renderer: rst
 
    .. py:method:: get_local_executable()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_local_executable
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_local_executable
+         :renderer: rst
+
    .. py:method:: set_remote_computer_exec(remote_computer_exec)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.set_remote_computer_exec
 
-      Set the code as remote, and pass the computer on which it resides
-      and the absolute path on that computer.
-
-      :param remote_computer_exec: a tuple (computer, remote_exec_path), where computer is a aiida.orm.Computer and
-          remote_exec_path is the absolute path of the main executable on remote computer.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.set_remote_computer_exec
+         :renderer: rst
 
    .. py:method:: get_remote_exec_path()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_remote_exec_path
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_remote_exec_path
+         :renderer: rst
+
    .. py:method:: get_remote_computer()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_remote_computer
 
-      Return the remote computer associated with this code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_remote_computer
+         :renderer: rst
 
    .. py:method:: _set_local()
       :canonical: aiida.orm.nodes.data.code.legacy.Code._set_local
 
-      Set the code as a 'local' code, meaning that all the files belonging to the code
-      will be copied to the cluster, and the file set with set_exec_filename will be
-      run.
-
-      It also deletes the flags related to the local case (if any)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code._set_local
+         :renderer: rst
 
    .. py:method:: _set_remote()
       :canonical: aiida.orm.nodes.data.code.legacy.Code._set_remote
 
-      Set the code as a 'remote' code, meaning that the code itself has no files attached,
-      but only a location on a remote computer (with an absolute path of the executable on
-      the remote computer).
-
-      It also deletes the flags related to the local case (if any)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code._set_remote
+         :renderer: rst
 
    .. py:method:: is_local()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.is_local
 
-      Return True if the code is 'local', False if it is 'remote' (see also documentation
-      of the set_local and set_remote functions).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.is_local
+         :renderer: rst
 
    .. py:method:: can_run_on(computer)
       :canonical: aiida.orm.nodes.data.code.legacy.Code.can_run_on
 
-      Return True if this code can run on the given computer, False otherwise.
-
-      Local codes can run on any machine; remote codes can run only on the machine
-      on which they reside.
-
-      TODO: add filters to mask the remote machines on which a local code can run.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.can_run_on
+         :renderer: rst
 
    .. py:method:: get_execname()
       :canonical: aiida.orm.nodes.data.code.legacy.Code.get_execname
 
-      Return the executable string to be put in the script.
-      For local codes, it is ./LOCAL_EXECUTABLE_NAME
-      For remote codes, it is the absolute path to the executable.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.legacy.Code.get_execname
+         :renderer: rst
 
 .. py:class:: CodeEntityLoader
    :canonical: aiida.orm.utils.loaders.CodeEntityLoader
 
    Bases: :py:obj:`aiida.orm.utils.loaders.OrmEntityLoader`
 
-   Loader for the `Code` entity and sub classes.
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.CodeEntityLoader
+      :renderer: rst
 
    .. py:method:: orm_base_class()
       :canonical: aiida.orm.utils.loaders.CodeEntityLoader.orm_base_class
 
-      Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
-      may further narrow the query set by defining a more specific set of orm classes, as long as each of
-      those is a strict sub class of the orm base class.
-
-      :returns: the orm base class
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.CodeEntityLoader.orm_base_class
+         :renderer: rst
 
    .. py:method:: _get_query_builder_label_identifier(identifier, classes, operator='==', project='*')
       :canonical: aiida.orm.utils.loaders.CodeEntityLoader._get_query_builder_label_identifier
       :classmethod:
 
-      Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
-      defined for this loader class, interpreting the identifier as a LABEL like identifier
-
-      :param identifier: the LABEL identifier
-      :param classes: a tuple of orm classes to which the identifier should be mapped
-      :param operator: the operator to use in the query
-      :param project: the property or properties to project for entities matching the query
-      :returns: the query builder instance that should retrieve the entity corresponding to the identifier
-      :raises ValueError: if the identifier is invalid
-      :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.CodeEntityLoader._get_query_builder_label_identifier
+         :renderer: rst
 
 .. py:class:: Collection(entity_class: typing.Type[aiida.orm.entities.EntityType], backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.entities.Collection
 
    Bases: :py:obj:`abc.ABC`, :py:obj:`typing.Generic`\ [\ :py:obj:`aiida.orm.entities.EntityType`\ ]
 
-   Container class that represents the collection of objects of a particular entity type.
+   .. autodoc2-docstring:: aiida.orm.entities.Collection
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new entity collection.
-
-   :param entity_class: the entity type e.g. User, Computer, etc
-   :param backend: the backend instance to get the collection for, or use the default
+   .. autodoc2-docstring:: aiida.orm.entities.Collection.__init__
+      :renderer: rst
 
    .. py:method:: _entity_base_cls() -> typing.Type[aiida.orm.entities.EntityType]
       :canonical: aiida.orm.entities.Collection._entity_base_cls
       :abstractmethod:
       :staticmethod:
 
-      The allowed entity class or subclasses thereof.
+      .. autodoc2-docstring:: aiida.orm.entities.Collection._entity_base_cls
+         :renderer: rst
 
    .. py:method:: get_cached(entity_class: typing.Type[aiida.orm.entities.EntityType], backend: aiida.orm.implementation.StorageBackend)
       :canonical: aiida.orm.entities.Collection.get_cached
       :classmethod:
 
-      Get the cached collection instance for the given entity class and backend.
-
-      :param backend: the backend instance to get the collection for
+      .. autodoc2-docstring:: aiida.orm.entities.Collection.get_cached
+         :renderer: rst
 
    .. py:method:: __call__(backend: aiida.orm.implementation.StorageBackend) -> aiida.orm.entities.CollectionType
       :canonical: aiida.orm.entities.Collection.__call__
 
-      Get or create a cached collection using a new backend.
+      .. autodoc2-docstring:: aiida.orm.entities.Collection.__call__
+         :renderer: rst
 
    .. py:property:: entity_type
       :canonical: aiida.orm.entities.Collection.entity_type
       :type: typing.Type[aiida.orm.entities.EntityType]
 
-      The entity type for this instance.
+      .. autodoc2-docstring:: aiida.orm.entities.Collection.entity_type
+         :renderer: rst
 
    .. py:property:: backend
       :canonical: aiida.orm.entities.Collection.backend
       :type: aiida.orm.implementation.StorageBackend
 
-      Return the backend.
+      .. autodoc2-docstring:: aiida.orm.entities.Collection.backend
+         :renderer: rst
 
    .. py:method:: query(filters: typing.Optional[aiida.orm.querybuilder.FilterType] = None, order_by: typing.Optional[aiida.orm.querybuilder.OrderByType] = None, limit: typing.Optional[int] = None, offset: typing.Optional[int] = None) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.entities.Collection.query
 
-      Get a query builder for the objects of this collection.
-
-      :param filters: the keyword value pair filters to match
-      :param order_by: a list of (key, direction) pairs specifying the sort order
-      :param limit: the maximum number of results to return
-      :param offset: number of initial results to be skipped
+      .. autodoc2-docstring:: aiida.orm.entities.Collection.query
+         :renderer: rst
 
    .. py:method:: get(**filters: typing.Any) -> aiida.orm.entities.EntityType
       :canonical: aiida.orm.entities.Collection.get
 
-      Get a single collection entry that matches the filter criteria.
-
-      :param filters: the filters identifying the object to get
-
-      :return: the entry
+      .. autodoc2-docstring:: aiida.orm.entities.Collection.get
+         :renderer: rst
 
    .. py:method:: find(filters: typing.Optional[aiida.orm.querybuilder.FilterType] = None, order_by: typing.Optional[aiida.orm.querybuilder.OrderByType] = None, limit: typing.Optional[int] = None) -> typing.List[aiida.orm.entities.EntityType]
       :canonical: aiida.orm.entities.Collection.find
 
-      Find collection entries matching the filter criteria.
-
-      :param filters: the keyword value pair filters to match
-      :param order_by: a list of (key, direction) pairs specifying the sort order
-      :param limit: the maximum number of results to return
-
-      :return: a list of resulting matches
+      .. autodoc2-docstring:: aiida.orm.entities.Collection.find
+         :renderer: rst
 
    .. py:method:: all() -> typing.List[aiida.orm.entities.EntityType]
       :canonical: aiida.orm.entities.Collection.all
 
-      Get all entities in this collection.
-
-      :return: A list of all entities
+      .. autodoc2-docstring:: aiida.orm.entities.Collection.all
+         :renderer: rst
 
    .. py:method:: count(filters: typing.Optional[aiida.orm.querybuilder.FilterType] = None) -> int
       :canonical: aiida.orm.entities.Collection.count
 
-      Count entities in this collection according to criteria.
-
-      :param filters: the keyword value pair filters to match
-
-      :return: The number of entities found using the supplied criteria
+      .. autodoc2-docstring:: aiida.orm.entities.Collection.count
+         :renderer: rst
 
 .. py:class:: Comment(node: aiida.orm.Node, user: aiida.orm.User, content: typing.Optional[str] = None, backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.comments.Comment
 
    Bases: :py:obj:`aiida.orm.entities.Entity`\ [\ :py:obj:`aiida.orm.implementation.BackendComment`\ , :py:obj:`aiida.orm.comments.CommentCollection`\ ]
 
-   Base class to map a DbComment that represents a comment attached to a certain Node.
+   .. autodoc2-docstring:: aiida.orm.comments.Comment
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Create a Comment for a given node and user
-
-   :param node: a Node instance
-   :param user: a User instance
-   :param content: the comment content
-   :param backend: the backend to use for the instance, or use the default backend if None
-
-   :return: a Comment object associated to the given node and user
+   .. autodoc2-docstring:: aiida.orm.comments.Comment.__init__
+      :renderer: rst
 
    .. py:attribute:: _CLS_COLLECTION
       :canonical: aiida.orm.comments.Comment._CLS_COLLECTION
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.comments.Comment._CLS_COLLECTION
+         :renderer: rst
+
    .. py:method:: __str__() -> str
       :canonical: aiida.orm.comments.Comment.__str__
+
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.__str__
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.orm.comments.Comment.uuid
       :type: str
 
-      Return the UUID for this comment.
-
-      This identifier is unique across all entities types and backend instances.
-
-      :return: the entity uuid
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.uuid
+         :renderer: rst
 
    .. py:property:: ctime
       :canonical: aiida.orm.comments.Comment.ctime
       :type: datetime.datetime
 
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.ctime
+         :renderer: rst
+
    .. py:property:: mtime
       :canonical: aiida.orm.comments.Comment.mtime
       :type: datetime.datetime
 
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.mtime
+         :renderer: rst
+
    .. py:method:: set_mtime(value: datetime.datetime) -> None
       :canonical: aiida.orm.comments.Comment.set_mtime
+
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.set_mtime
+         :renderer: rst
 
    .. py:property:: node
       :canonical: aiida.orm.comments.Comment.node
       :type: aiida.orm.Node
 
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.node
+         :renderer: rst
+
    .. py:property:: user
       :canonical: aiida.orm.comments.Comment.user
       :type: aiida.orm.User
 
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.user
+         :renderer: rst
+
    .. py:method:: set_user(value: aiida.orm.User) -> None
       :canonical: aiida.orm.comments.Comment.set_user
+
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.set_user
+         :renderer: rst
 
    .. py:property:: content
       :canonical: aiida.orm.comments.Comment.content
       :type: str
 
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.content
+         :renderer: rst
+
    .. py:method:: set_content(value: str) -> None
       :canonical: aiida.orm.comments.Comment.set_content
+
+      .. autodoc2-docstring:: aiida.orm.comments.Comment.set_content
+         :renderer: rst
 
 .. py:class:: Computer(label: typing.Optional[str] = None, hostname: str = '', description: str = '', transport_type: str = '', scheduler_type: str = '', workdir: typing.Optional[str] = None, backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.computers.Computer
 
    Bases: :py:obj:`aiida.orm.entities.Entity`\ [\ :py:obj:`aiida.orm.implementation.BackendComputer`\ , :py:obj:`aiida.orm.computers.ComputerCollection`\ ]
 
-   Computer entity.
+   .. autodoc2-docstring:: aiida.orm.computers.Computer
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new computer.
+   .. autodoc2-docstring:: aiida.orm.computers.Computer.__init__
+      :renderer: rst
 
    .. py:attribute:: _logger
       :canonical: aiida.orm.computers.Computer._logger
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._logger
+         :renderer: rst
+
    .. py:attribute:: PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL
       :canonical: aiida.orm.computers.Computer.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL
       :value: 'minimum_scheduler_poll_interval'
+
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL
+         :renderer: rst
 
    .. py:attribute:: PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT
       :canonical: aiida.orm.computers.Computer.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT
       :value: 10.0
 
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT
+         :renderer: rst
+
    .. py:attribute:: PROPERTY_WORKDIR
       :canonical: aiida.orm.computers.Computer.PROPERTY_WORKDIR
       :value: 'workdir'
+
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.PROPERTY_WORKDIR
+         :renderer: rst
 
    .. py:attribute:: PROPERTY_SHEBANG
       :canonical: aiida.orm.computers.Computer.PROPERTY_SHEBANG
       :value: 'shebang'
 
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.PROPERTY_SHEBANG
+         :renderer: rst
+
    .. py:attribute:: _CLS_COLLECTION
       :canonical: aiida.orm.computers.Computer._CLS_COLLECTION
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._CLS_COLLECTION
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.orm.computers.Computer.__repr__
 
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.__repr__
+         :renderer: rst
+
    .. py:method:: __str__()
       :canonical: aiida.orm.computers.Computer.__str__
+
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.__str__
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.orm.computers.Computer.uuid
       :type: str
 
-      Return the UUID for this computer.
-
-      This identifier is unique across all entities types and backend instances.
-
-      :return: the entity uuid
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.uuid
+         :renderer: rst
 
    .. py:property:: logger
       :canonical: aiida.orm.computers.Computer.logger
       :type: logging.Logger
 
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.logger
+         :renderer: rst
+
    .. py:method:: _label_validator(label: str) -> None
       :canonical: aiida.orm.computers.Computer._label_validator
       :classmethod:
 
-      Validates the label.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._label_validator
+         :renderer: rst
 
    .. py:method:: _hostname_validator(hostname: str) -> None
       :canonical: aiida.orm.computers.Computer._hostname_validator
       :classmethod:
 
-      Validates the hostname.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._hostname_validator
+         :renderer: rst
 
    .. py:method:: _description_validator(description: str) -> None
       :canonical: aiida.orm.computers.Computer._description_validator
       :classmethod:
 
-      Validates the description.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._description_validator
+         :renderer: rst
 
    .. py:method:: _transport_type_validator(transport_type: str) -> None
       :canonical: aiida.orm.computers.Computer._transport_type_validator
       :classmethod:
 
-      Validates the transport string.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._transport_type_validator
+         :renderer: rst
 
    .. py:method:: _scheduler_type_validator(scheduler_type: str) -> None
       :canonical: aiida.orm.computers.Computer._scheduler_type_validator
       :classmethod:
 
-      Validates the transport string.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._scheduler_type_validator
+         :renderer: rst
 
    .. py:method:: _prepend_text_validator(prepend_text: str) -> None
       :canonical: aiida.orm.computers.Computer._prepend_text_validator
       :classmethod:
 
-      Validates the prepend text string.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._prepend_text_validator
+         :renderer: rst
 
    .. py:method:: _append_text_validator(append_text: str) -> None
       :canonical: aiida.orm.computers.Computer._append_text_validator
       :classmethod:
 
-      Validates the append text string.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._append_text_validator
+         :renderer: rst
 
    .. py:method:: _workdir_validator(workdir: str) -> None
       :canonical: aiida.orm.computers.Computer._workdir_validator
       :classmethod:
 
-      Validates the transport string.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._workdir_validator
+         :renderer: rst
 
    .. py:method:: _mpirun_command_validator(mpirun_cmd: typing.Union[typing.List[str], typing.Tuple[str, ...]]) -> None
       :canonical: aiida.orm.computers.Computer._mpirun_command_validator
 
-      Validates the mpirun_command variable. MUST be called after properly
-      checking for a valid scheduler.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._mpirun_command_validator
+         :renderer: rst
 
    .. py:method:: validate() -> None
       :canonical: aiida.orm.computers.Computer.validate
 
-      Check if the attributes and files retrieved from the DB are valid.
-      Raise a ValidationError if something is wrong.
-
-      Must be able to work even before storing: therefore, use the get_attr and similar methods
-      that automatically read either from the DB or from the internal attribute cache.
-
-      For the base class, this is always valid. Subclasses will reimplement this.
-      In the subclass, always call the super().validate() method first!
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.validate
+         :renderer: rst
 
    .. py:method:: _default_mpiprocs_per_machine_validator(def_cpus_per_machine: typing.Optional[int]) -> None
       :canonical: aiida.orm.computers.Computer._default_mpiprocs_per_machine_validator
       :classmethod:
 
-      Validates the default number of CPUs per machine (node)
+      .. autodoc2-docstring:: aiida.orm.computers.Computer._default_mpiprocs_per_machine_validator
+         :renderer: rst
 
    .. py:method:: default_memory_per_machine_validator(def_memory_per_machine: typing.Optional[int]) -> None
       :canonical: aiida.orm.computers.Computer.default_memory_per_machine_validator
       :classmethod:
 
-      Validates the default amount of memory (kB) per machine (node)
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.default_memory_per_machine_validator
+         :renderer: rst
 
    .. py:method:: copy() -> aiida.orm.computers.Computer
       :canonical: aiida.orm.computers.Computer.copy
 
-      Return a copy of the current object to work with, not stored yet.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.copy
+         :renderer: rst
 
    .. py:method:: store() -> aiida.orm.computers.Computer
       :canonical: aiida.orm.computers.Computer.store
 
-      Store the computer in the DB.
-
-      Differently from Nodes, a computer can be re-stored if its properties
-      are to be changed (e.g. a new mpirun command, etc.)
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.store
+         :renderer: rst
 
    .. py:property:: label
       :canonical: aiida.orm.computers.Computer.label
       :type: str
 
-      Return the computer label.
-
-      :return: the label.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.label
+         :renderer: rst
 
    .. py:property:: description
       :canonical: aiida.orm.computers.Computer.description
       :type: str
 
-      Return the computer computer.
-
-      :return: the description.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.description
+         :renderer: rst
 
    .. py:property:: hostname
       :canonical: aiida.orm.computers.Computer.hostname
       :type: str
 
-      Return the computer hostname.
-
-      :return: the hostname.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.hostname
+         :renderer: rst
 
    .. py:property:: scheduler_type
       :canonical: aiida.orm.computers.Computer.scheduler_type
       :type: str
 
-      Return the computer scheduler type.
-
-      :return: the scheduler type.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.scheduler_type
+         :renderer: rst
 
    .. py:property:: transport_type
       :canonical: aiida.orm.computers.Computer.transport_type
       :type: str
 
-      Return the computer transport type.
-
-      :return: the transport_type.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.transport_type
+         :renderer: rst
 
    .. py:property:: metadata
       :canonical: aiida.orm.computers.Computer.metadata
       :type: typing.Dict[str, typing.Any]
 
-      Return the computer metadata.
-
-      :return: the metadata.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.metadata
+         :renderer: rst
 
    .. py:method:: delete_property(name: str, raise_exception: bool = True) -> None
       :canonical: aiida.orm.computers.Computer.delete_property
 
-      Delete a property from this computer
-
-      :param name: the name of the property
-      :param raise_exception: if True raise if the property does not exist, otherwise return None
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.delete_property
+         :renderer: rst
 
    .. py:method:: set_property(name: str, value: typing.Any) -> None
       :canonical: aiida.orm.computers.Computer.set_property
 
-      Set a property on this computer
-
-      :param name: the property name
-      :param value: the new value
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_property
+         :renderer: rst
 
    .. py:method:: get_property(name: str, *args: typing.Any) -> typing.Any
       :canonical: aiida.orm.computers.Computer.get_property
 
-      Get a property of this computer
-
-      :param name: the property name
-      :param args: additional arguments
-
-      :return: the property value
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_property
+         :renderer: rst
 
    .. py:method:: get_prepend_text() -> str
       :canonical: aiida.orm.computers.Computer.get_prepend_text
 
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_prepend_text
+         :renderer: rst
+
    .. py:method:: set_prepend_text(val: str) -> None
       :canonical: aiida.orm.computers.Computer.set_prepend_text
+
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_prepend_text
+         :renderer: rst
 
    .. py:method:: get_append_text() -> str
       :canonical: aiida.orm.computers.Computer.get_append_text
 
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_append_text
+         :renderer: rst
+
    .. py:method:: set_append_text(val: str) -> None
       :canonical: aiida.orm.computers.Computer.set_append_text
+
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_append_text
+         :renderer: rst
 
    .. py:method:: get_use_double_quotes() -> bool
       :canonical: aiida.orm.computers.Computer.get_use_double_quotes
 
-      Return whether the command line parameters of this computer should be escaped with double quotes.
-
-      :returns: True if to escape with double quotes, False otherwise which is also the default.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_use_double_quotes
+         :renderer: rst
 
    .. py:method:: set_use_double_quotes(val: bool) -> None
       :canonical: aiida.orm.computers.Computer.set_use_double_quotes
 
-      Set whether the command line parameters of this computer should be escaped with double quotes.
-
-      :param use_double_quotes: True if to escape with double quotes, False otherwise.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_use_double_quotes
+         :renderer: rst
 
    .. py:method:: get_mpirun_command() -> typing.List[str]
       :canonical: aiida.orm.computers.Computer.get_mpirun_command
 
-      Return the mpirun command. Must be a list of strings, that will be
-      then joined with spaces when submitting.
-
-      I also provide a sensible default that may be ok in many cases.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_mpirun_command
+         :renderer: rst
 
    .. py:method:: set_mpirun_command(val: typing.Union[typing.List[str], typing.Tuple[str, ...]]) -> None
       :canonical: aiida.orm.computers.Computer.set_mpirun_command
 
-      Set the mpirun command. It must be a list of strings (you can use
-      string.split() if you have a single, space-separated string).
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_mpirun_command
+         :renderer: rst
 
    .. py:method:: get_default_mpiprocs_per_machine() -> typing.Optional[int]
       :canonical: aiida.orm.computers.Computer.get_default_mpiprocs_per_machine
 
-      Return the default number of CPUs per machine (node) for this computer,
-      or None if it was not set.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_default_mpiprocs_per_machine
+         :renderer: rst
 
    .. py:method:: set_default_mpiprocs_per_machine(def_cpus_per_machine: typing.Optional[int]) -> None
       :canonical: aiida.orm.computers.Computer.set_default_mpiprocs_per_machine
 
-      Set the default number of CPUs per machine (node) for this computer.
-      Accepts None if you do not want to set this value.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_default_mpiprocs_per_machine
+         :renderer: rst
 
    .. py:method:: get_default_memory_per_machine() -> typing.Optional[int]
       :canonical: aiida.orm.computers.Computer.get_default_memory_per_machine
 
-      Return the default amount of memory (kB) per machine (node) for this computer,
-      or None if it was not set.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_default_memory_per_machine
+         :renderer: rst
 
    .. py:method:: set_default_memory_per_machine(def_memory_per_machine: typing.Optional[int]) -> None
       :canonical: aiida.orm.computers.Computer.set_default_memory_per_machine
 
-      Set the default amount of memory (kB) per machine (node) for this computer.
-      Accepts None if you do not want to set this value.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_default_memory_per_machine
+         :renderer: rst
 
    .. py:method:: get_minimum_job_poll_interval() -> float
       :canonical: aiida.orm.computers.Computer.get_minimum_job_poll_interval
 
-      Get the minimum interval between subsequent requests to poll the scheduler for job status.
-
-      .. note:: If no value was ever set for this computer it will fall back on the default provided by the associated
-          transport class in the ``DEFAULT_MINIMUM_JOB_POLL_INTERVAL`` attribute. If the computer doesn't have a
-          transport class, or it cannot be loaded, or it doesn't provide a job poll interval default, then this will
-          fall back on the ``PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT`` attribute of this class.
-
-      :return: The minimum interval (in seconds).
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_minimum_job_poll_interval
+         :renderer: rst
 
    .. py:method:: set_minimum_job_poll_interval(interval: float) -> None
       :canonical: aiida.orm.computers.Computer.set_minimum_job_poll_interval
 
-      Set the minimum interval between subsequent requests to update the list
-      of jobs currently running on this computer.
-
-      :param interval: The minimum interval in seconds
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_minimum_job_poll_interval
+         :renderer: rst
 
    .. py:method:: get_workdir() -> str
       :canonical: aiida.orm.computers.Computer.get_workdir
 
-      Get the working directory for this computer
-      :return: The currently configured working directory
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_workdir
+         :renderer: rst
 
    .. py:method:: set_workdir(val: str) -> None
       :canonical: aiida.orm.computers.Computer.set_workdir
 
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_workdir
+         :renderer: rst
+
    .. py:method:: get_shebang() -> str
       :canonical: aiida.orm.computers.Computer.get_shebang
+
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_shebang
+         :renderer: rst
 
    .. py:method:: set_shebang(val: str) -> None
       :canonical: aiida.orm.computers.Computer.set_shebang
 
-      :param str val: A valid shebang line
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.set_shebang
+         :renderer: rst
 
    .. py:method:: get_authinfo(user: aiida.orm.User) -> aiida.orm.AuthInfo
       :canonical: aiida.orm.computers.Computer.get_authinfo
 
-      Return the aiida.orm.authinfo.AuthInfo instance for the
-      given user on this computer, if the computer
-      is configured for the given user.
-
-      :param user: a User instance.
-      :return: a AuthInfo instance
-      :raise aiida.common.NotExistent: if the computer is not configured for the given
-          user.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_authinfo
+         :renderer: rst
 
    .. py:property:: is_configured
       :canonical: aiida.orm.computers.Computer.is_configured
       :type: bool
 
-      Return whether the computer is configured for the current default user.
-
-      :return: Boolean, ``True`` if the computer is configured for the current default user, ``False`` otherwise.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.is_configured
+         :renderer: rst
 
    .. py:method:: is_user_configured(user: aiida.orm.User) -> bool
       :canonical: aiida.orm.computers.Computer.is_user_configured
 
-      Is the user configured on this computer?
-
-      :param user: the user to check
-      :return: True if configured, False otherwise
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.is_user_configured
+         :renderer: rst
 
    .. py:method:: is_user_enabled(user: aiida.orm.User) -> bool
       :canonical: aiida.orm.computers.Computer.is_user_enabled
 
-      Is the given user enabled to run on this computer?
-
-      :param user: the user to check
-      :return: True if enabled, False otherwise
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.is_user_enabled
+         :renderer: rst
 
    .. py:method:: get_transport(user: typing.Optional[aiida.orm.User] = None) -> aiida.transports.Transport
       :canonical: aiida.orm.computers.Computer.get_transport
 
-      Return a Transport class, configured with all correct parameters.
-      The Transport is closed (meaning that if you want to run any operation with
-      it, you have to open it first (i.e., e.g. for a SSH transport, you have
-      to open a connection). To do this you can call ``transports.open()``, or simply
-      run within a ``with`` statement::
-
-         transport = Computer.get_transport()
-         with transport:
-             print(transports.whoami())
-
-      :param user: if None, try to obtain a transport for the default user.
-          Otherwise, pass a valid User.
-
-      :return: a (closed) Transport, already configured with the connection
-          parameters to the supercomputer, as configured with ``verdi computer configure``
-          for the user specified as a parameter ``user``.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_transport
+         :renderer: rst
 
    .. py:method:: get_transport_class() -> typing.Type[aiida.transports.Transport]
       :canonical: aiida.orm.computers.Computer.get_transport_class
 
-      Get the transport class for this computer.  Can be used to instantiate a transport instance.
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_transport_class
+         :renderer: rst
 
    .. py:method:: get_scheduler() -> aiida.schedulers.Scheduler
       :canonical: aiida.orm.computers.Computer.get_scheduler
 
-      Get a scheduler instance for this computer
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_scheduler
+         :renderer: rst
 
    .. py:method:: configure(user: typing.Optional[aiida.orm.User] = None, **kwargs: typing.Any) -> aiida.orm.AuthInfo
       :canonical: aiida.orm.computers.Computer.configure
 
-      Configure a computer for a user with valid auth params passed via kwargs
-
-      :param user: the user to configure the computer for
-      :kwargs: the configuration keywords with corresponding values
-      :return: the authinfo object for the configured user
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.configure
+         :renderer: rst
 
    .. py:method:: get_configuration(user: typing.Optional[aiida.orm.User] = None) -> typing.Dict[str, typing.Any]
       :canonical: aiida.orm.computers.Computer.get_configuration
 
-      Get the configuration of computer for the given user as a dictionary
-
-      :param user: the user to to get the configuration for, otherwise default user
+      .. autodoc2-docstring:: aiida.orm.computers.Computer.get_configuration
+         :renderer: rst
 
 .. py:class:: ComputerEntityLoader
    :canonical: aiida.orm.utils.loaders.ComputerEntityLoader
 
    Bases: :py:obj:`aiida.orm.utils.loaders.OrmEntityLoader`
 
-   Loader for the `Computer` entity and sub classes.
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.ComputerEntityLoader
+      :renderer: rst
 
    .. py:method:: orm_base_class()
       :canonical: aiida.orm.utils.loaders.ComputerEntityLoader.orm_base_class
 
-      Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
-      may further narrow the query set by defining a more specific set of orm classes, as long as each of
-      those is a strict sub class of the orm base class.
-
-      :returns: the orm base class
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.ComputerEntityLoader.orm_base_class
+         :renderer: rst
 
    .. py:method:: _get_query_builder_label_identifier(identifier, classes, operator='==', project='*')
       :canonical: aiida.orm.utils.loaders.ComputerEntityLoader._get_query_builder_label_identifier
       :classmethod:
 
-      Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
-      defined for this loader class, interpreting the identifier as a LABEL like identifier
-
-      :param identifier: the LABEL identifier
-      :param classes: a tuple of orm classes to which the identifier should be mapped
-      :param operator: the operator to use in the query
-      :param project: the property or properties to project for entities matching the query
-      :returns: the query builder instance that should retrieve the entity corresponding to the identifier
-      :raises ValueError: if the identifier is invalid
-      :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.ComputerEntityLoader._get_query_builder_label_identifier
+         :renderer: rst
 
 .. py:class:: ContainerizedCode(engine_command: str, image_name: str, **kwargs)
    :canonical: aiida.orm.nodes.data.code.containerized.ContainerizedCode
 
    Bases: :py:obj:`aiida.orm.nodes.data.code.installed.InstalledCode`
 
-   Data plugin representing an executable code in container on a remote computer.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode.__init__
+      :renderer: rst
 
    .. py:attribute:: _KEY_ATTRIBUTE_ENGINE_COMMAND
       :canonical: aiida.orm.nodes.data.code.containerized.ContainerizedCode._KEY_ATTRIBUTE_ENGINE_COMMAND
       :type: str
       :value: 'engine_command'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode._KEY_ATTRIBUTE_ENGINE_COMMAND
+         :renderer: rst
+
    .. py:attribute:: _KEY_ATTRIBUTE_IMAGE_NAME
       :canonical: aiida.orm.nodes.data.code.containerized.ContainerizedCode._KEY_ATTRIBUTE_IMAGE_NAME
       :type: str
       :value: 'image_name'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode._KEY_ATTRIBUTE_IMAGE_NAME
+         :renderer: rst
+
    .. py:property:: filepath_executable
       :canonical: aiida.orm.nodes.data.code.containerized.ContainerizedCode.filepath_executable
       :type: pathlib.PurePosixPath
 
-      Return the filepath of the executable that this code represents.
-
-      .. note:: This is overridden from the base class since the path does not have to be absolute.
-
-      :return: The filepath of the executable.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode.filepath_executable
+         :renderer: rst
 
    .. py:property:: engine_command
       :canonical: aiida.orm.nodes.data.code.containerized.ContainerizedCode.engine_command
       :type: str
 
-      Return the engine command with image as template field of the containerized code
-
-      :return: The engine command of the containerized code
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode.engine_command
+         :renderer: rst
 
    .. py:property:: image_name
       :canonical: aiida.orm.nodes.data.code.containerized.ContainerizedCode.image_name
       :type: str
 
-      The image name of container
-
-      :return: The image name of container.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode.image_name
+         :renderer: rst
 
    .. py:method:: get_prepend_cmdline_params(mpi_args: list[str] | None = None, extra_mpirun_params: list[str] | None = None) -> list[str]
       :canonical: aiida.orm.nodes.data.code.containerized.ContainerizedCode.get_prepend_cmdline_params
 
-      Return the list of prepend cmdline params for mpi seeting
-
-      :return: list of prepend cmdline parameters.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode.get_prepend_cmdline_params
+         :renderer: rst
 
    .. py:method:: _get_cli_options() -> dict
       :canonical: aiida.orm.nodes.data.code.containerized.ContainerizedCode._get_cli_options
       :classmethod:
 
-      Return the CLI options that would allow to create an instance of this class.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.containerized.ContainerizedCode._get_cli_options
+         :renderer: rst
 
 .. py:data:: DESCENDING
    :canonical: aiida.orm.logs.DESCENDING
    :value: 'desc'
+
+   .. autodoc2-docstring:: aiida.orm.logs.DESCENDING
+      :renderer: rst
 
 .. py:class:: Data(*args, source=None, **kwargs)
    :canonical: aiida.orm.nodes.data.data.Data
 
    Bases: :py:obj:`aiida.orm.nodes.node.Node`
 
-   The base class for all Data nodes.
-
-   AiiDA Data classes are subclasses of Node and must support multiple inheritance.
-
-   Architecture note:
-   Calculation plugins are responsible for converting raw output data from simulation codes to Data nodes.
-   Nodes are responsible for validating their content (see _validate method).
+   .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance, setting the ``source`` attribute if provided as a keyword argument.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.__init__
+      :renderer: rst
 
    .. py:attribute:: _source_attributes
       :canonical: aiida.orm.nodes.data.data.Data._source_attributes
       :value: ['db_name', 'db_uri', 'uri', 'id', 'version', 'extras', 'source_md5', 'description', 'license']
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data._source_attributes
+         :renderer: rst
 
    .. py:attribute:: _export_format_replacements
       :canonical: aiida.orm.nodes.data.data.Data._export_format_replacements
       :type: typing.Dict[str, str]
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data._export_format_replacements
+         :renderer: rst
+
    .. py:attribute:: _storable
       :canonical: aiida.orm.nodes.data.data.Data._storable
       :value: True
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data._storable
+         :renderer: rst
 
    .. py:attribute:: _unstorable_message
       :canonical: aiida.orm.nodes.data.data.Data._unstorable_message
       :value: 'storing for this node has been disabled'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data._unstorable_message
+         :renderer: rst
+
    .. py:method:: __copy__()
       :canonical: aiida.orm.nodes.data.data.Data.__copy__
 
-      Copying a Data node is not supported, use copy.deepcopy or call Data.clone().
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.__copy__
+         :renderer: rst
 
    .. py:method:: __deepcopy__(memo)
       :canonical: aiida.orm.nodes.data.data.Data.__deepcopy__
 
-      Create a clone of the Data node by piping through to the clone method and return the result.
-
-      :returns: an unstored clone of this Data node
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.__deepcopy__
+         :renderer: rst
 
    .. py:method:: clone()
       :canonical: aiida.orm.nodes.data.data.Data.clone
 
-      Create a clone of the Data node.
-
-      :returns: an unstored clone of this Data node
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.clone
+         :renderer: rst
 
    .. py:property:: source
       :canonical: aiida.orm.nodes.data.data.Data.source
 
-      Gets the dictionary describing the source of Data object. Possible fields:
-
-      * **db_name**: name of the source database.
-      * **db_uri**: URI of the source database.
-      * **uri**: URI of the object's source. Should be a permanent link.
-      * **id**: object's source identifier in the source database.
-      * **version**: version of the object's source.
-      * **extras**: a dictionary with other fields for source description.
-      * **source_md5**: MD5 checksum of object's source.
-      * **description**: human-readable free form description of the object's source.
-      * **license**: a string with a type of license.
-
-      .. note:: some limitations for setting the data source exist, see ``_validate`` method.
-
-      :return: dictionary describing the source of Data object.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.source
+         :renderer: rst
 
    .. py:method:: set_source(source)
       :canonical: aiida.orm.nodes.data.data.Data.set_source
 
-      Sets the dictionary describing the source of Data object.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.set_source
+         :renderer: rst
 
    .. py:property:: creator
       :canonical: aiida.orm.nodes.data.data.Data.creator
 
-      Return the creator of this node or None if it does not exist.
-
-      :return: the creating node or None
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.creator
+         :renderer: rst
 
    .. py:method:: _exportcontent(fileformat, main_file_name='', **kwargs)
       :canonical: aiida.orm.nodes.data.data.Data._exportcontent
 
-      Converts a Data node to one (or multiple) files.
-
-      Note: Export plugins should return utf8-encoded **bytes**, which can be
-      directly dumped to file.
-
-      :param fileformat: the extension, uniquely specifying the file format.
-      :type fileformat: str
-      :param main_file_name: (empty by default) Can be used by plugin to
-          infer sensible names for additional files, if necessary.  E.g. if the
-          main file is '../myplot.gnu', the plugin may decide to store the dat
-          file under '../myplot_data.dat'.
-      :type main_file_name: str
-      :param kwargs: other parameters are passed down to the plugin
-      :returns: a tuple of length 2. The first element is the content of the
-          otuput file. The second is a dictionary (possibly empty) in the format
-          {filename: filecontent} for any additional file that should be produced.
-      :rtype: (bytes, dict)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data._exportcontent
+         :renderer: rst
 
    .. py:method:: export(path, fileformat=None, overwrite=False, **kwargs)
       :canonical: aiida.orm.nodes.data.data.Data.export
 
-      Save a Data object to a file.
-
-      :param fname: string with file name. Can be an absolute or relative path.
-      :param fileformat: kind of format to use for the export. If not present,
-          it will try to use the extension of the file name.
-      :param overwrite: if set to True, overwrites file found at path. Default=False
-      :param kwargs: additional parameters to be passed to the
-          _exportcontent method
-      :return: the list of files created
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.export
+         :renderer: rst
 
    .. py:method:: _get_exporters()
       :canonical: aiida.orm.nodes.data.data.Data._get_exporters
 
-      Get all implemented export formats.
-      The convention is to find all _prepare_... methods.
-      Returns a dictionary of method_name: method_function
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data._get_exporters
+         :renderer: rst
 
    .. py:method:: get_export_formats()
       :canonical: aiida.orm.nodes.data.data.Data.get_export_formats
       :classmethod:
 
-      Get the list of valid export format strings
-
-      :return: a list of valid formats
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.get_export_formats
+         :renderer: rst
 
    .. py:method:: importstring(inputstring, fileformat, **kwargs)
       :canonical: aiida.orm.nodes.data.data.Data.importstring
 
-      Converts a Data object to other text format.
-
-      :param fileformat: a string (the extension) to describe the file format.
-      :returns: a string with the structure description.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.importstring
+         :renderer: rst
 
    .. py:method:: importfile(fname, fileformat=None)
       :canonical: aiida.orm.nodes.data.data.Data.importfile
 
-      Populate a Data object from a file.
-
-      :param fname: string with file name. Can be an absolute or relative path.
-      :param fileformat: kind of format to use for the export. If not present,
-          it will try to use the extension of the file name.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.importfile
+         :renderer: rst
 
    .. py:method:: _get_importers()
       :canonical: aiida.orm.nodes.data.data.Data._get_importers
 
-      Get all implemented import formats.
-      The convention is to find all _parse_... methods.
-      Returns a list of strings.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data._get_importers
+         :renderer: rst
 
    .. py:method:: convert(object_format=None, *args)
       :canonical: aiida.orm.nodes.data.data.Data.convert
 
-      Convert the AiiDA StructureData into another python object
-
-      :param object_format: Specify the output format
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data.convert
+         :renderer: rst
 
    .. py:method:: _get_converters()
       :canonical: aiida.orm.nodes.data.data.Data._get_converters
 
-      Get all implemented converter formats.
-      The convention is to find all _get_object_... methods.
-      Returns a list of strings.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.data.Data._get_converters
+         :renderer: rst
 
 .. py:class:: Dict(value=None, **kwargs)
    :canonical: aiida.orm.nodes.data.dict.Dict
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   `Data` sub class to represent a dictionary.
-
-   The dictionary contents of a `Dict` node are stored in the database as attributes. The dictionary
-   can be initialized through the `dict` argument in the constructor. After construction, values can
-   be retrieved and updated through the item getters and setters, respectively:
-
-       node['key'] = 'value'
-
-   Alternatively, the `dict` property returns an instance of the `AttributeManager` that can be used
-   to get and set values through attribute notation:
-
-       node.dict.key = 'value'
-
-   Note that trying to set dictionary values directly on the node, e.g. `node.key = value`, will not
-   work as intended. It will merely set the `key` attribute on the node instance, but will not be
-   stored in the database. As soon as the node goes out of scope, the value will be lost.
-
-   It is also relevant to note here the difference in something being an "attribute of a node" (in
-   the sense that it is stored in the "attribute" column of the database when the node is stored)
-   and something being an "attribute of a python object" (in the sense of being able to modify and
-   access it as if it was a property of the variable, e.g. `node.key = value`). This is true of all
-   types of nodes, but it becomes more relevant for `Dict` nodes where one is constantly manipulating
-   these attributes.
-
-   Finally, all dictionary mutations will be forbidden once the node is stored.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialise a ``Dict`` node instance.
-
-   Usual rules for attribute names apply, in particular, keys cannot start with an underscore, or a ``ValueError``
-   will be raised.
-
-   Initial attributes can be changed, deleted or added as long as the node is not stored.
-
-   :param value: dictionary to initialise the ``Dict`` node from
+   .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.__init__
+      :renderer: rst
 
    .. py:method:: __getitem__(key)
       :canonical: aiida.orm.nodes.data.dict.Dict.__getitem__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.__getitem__
+         :renderer: rst
+
    .. py:method:: __setitem__(key, value)
       :canonical: aiida.orm.nodes.data.dict.Dict.__setitem__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.__setitem__
+         :renderer: rst
 
    .. py:method:: __eq__(other)
       :canonical: aiida.orm.nodes.data.dict.Dict.__eq__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.__eq__
+         :renderer: rst
+
    .. py:method:: __contains__(key: str) -> bool
       :canonical: aiida.orm.nodes.data.dict.Dict.__contains__
 
-      Return whether the node contains a key.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.__contains__
+         :renderer: rst
 
    .. py:method:: set_dict(dictionary)
       :canonical: aiida.orm.nodes.data.dict.Dict.set_dict
 
-      Replace the current dictionary with another one.
-
-      :param dictionary: dictionary to set
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.set_dict
+         :renderer: rst
 
    .. py:method:: update_dict(dictionary)
       :canonical: aiida.orm.nodes.data.dict.Dict.update_dict
 
-      Update the current dictionary with the keys provided in the dictionary.
-
-      .. note:: works exactly as `dict.update()` where new keys are simply added and existing keys are overwritten.
-
-      :param dictionary: a dictionary with the keys to substitute
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.update_dict
+         :renderer: rst
 
    .. py:method:: get_dict()
       :canonical: aiida.orm.nodes.data.dict.Dict.get_dict
 
-      Return a dictionary with the parameters currently set.
-
-      :return: dictionary
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.get_dict
+         :renderer: rst
 
    .. py:method:: keys()
       :canonical: aiida.orm.nodes.data.dict.Dict.keys
 
-      Iterator of valid keys stored in the Dict object.
-
-      :return: iterator over the keys of the current dictionary
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.keys
+         :renderer: rst
 
    .. py:method:: items()
       :canonical: aiida.orm.nodes.data.dict.Dict.items
 
-      Iterator of all items stored in the Dict node.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.items
+         :renderer: rst
 
    .. py:property:: dict
       :canonical: aiida.orm.nodes.data.dict.Dict.dict
 
-      Return an instance of `AttributeManager` that transforms the dictionary into an attribute dict.
-
-      .. note:: this will allow one to do `node.dict.key` as well as `node.dict[key]`.
-
-      :return: an instance of the `AttributeResultManager`.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.dict.Dict.dict
+         :renderer: rst
 
 .. py:class:: Entity(backend_entity: aiida.orm.entities.BackendEntityType)
    :canonical: aiida.orm.entities.Entity
 
    Bases: :py:obj:`abc.ABC`, :py:obj:`typing.Generic`\ [\ :py:obj:`aiida.orm.entities.BackendEntityType`\ , :py:obj:`aiida.orm.entities.CollectionType`\ ]
 
-   An AiiDA entity
+   .. autodoc2-docstring:: aiida.orm.entities.Entity
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   :param backend_entity: the backend model supporting this entity
+   .. autodoc2-docstring:: aiida.orm.entities.Entity.__init__
+      :renderer: rst
 
    .. py:attribute:: _CLS_COLLECTION
       :canonical: aiida.orm.entities.Entity._CLS_COLLECTION
       :type: typing.Type[aiida.orm.entities.CollectionType]
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.entities.Entity._CLS_COLLECTION
+         :renderer: rst
+
    .. py:method:: objects() -> aiida.orm.entities.CollectionType
       :canonical: aiida.orm.entities.Entity.objects
 
-      Get a collection for objects of this type, with the default backend.
-
-      .. deprecated:: This will be removed in v3, use ``collection`` instead.
-
-      :return: an object that can be used to access entities of this type
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.objects
+         :renderer: rst
 
    .. py:method:: collection() -> aiida.orm.entities.CollectionType
       :canonical: aiida.orm.entities.Entity.collection
 
-      Get a collection for objects of this type, with the default backend.
-
-      :return: an object that can be used to access entities of this type
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.collection
+         :renderer: rst
 
    .. py:method:: get(**kwargs)
       :canonical: aiida.orm.entities.Entity.get
       :classmethod:
 
-      Get an entity of the collection matching the given filters.
-
-      .. deprecated: Will be removed in v3, use `Entity.collection.get` instead.
-
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.get
+         :renderer: rst
 
    .. py:method:: from_backend_entity(backend_entity: aiida.orm.entities.BackendEntityType) -> aiida.orm.entities.EntityType
       :canonical: aiida.orm.entities.Entity.from_backend_entity
       :classmethod:
 
-      Construct an entity from a backend entity instance
-
-      :param backend_entity: the backend entity
-
-      :return: an AiiDA entity instance
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.from_backend_entity
+         :renderer: rst
 
    .. py:method:: __getstate__()
       :canonical: aiida.orm.entities.Entity.__getstate__
 
-      Prevent an ORM entity instance from being pickled.
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.__getstate__
+         :renderer: rst
 
    .. py:method:: initialize() -> None
       :canonical: aiida.orm.entities.Entity.initialize
 
-      Initialize instance attributes.
-
-      This will be called after the constructor is called or an entity is created from an existing backend entity.
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.initialize
+         :renderer: rst
 
    .. py:property:: id
       :canonical: aiida.orm.entities.Entity.id
       :type: int
 
-      Return the id for this entity.
-
-      This identifier is guaranteed to be unique amongst entities of the same type for a single backend instance.
-
-      .. deprecated: Will be removed in v3, use `pk` instead.
-
-      :return: the entity's id
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.id
+         :renderer: rst
 
    .. py:property:: pk
       :canonical: aiida.orm.entities.Entity.pk
       :type: int
 
-      Return the primary key for this entity.
-
-      This identifier is guaranteed to be unique amongst entities of the same type for a single backend instance.
-
-      :return: the entity's principal key
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.pk
+         :renderer: rst
 
    .. py:method:: store() -> aiida.orm.entities.EntityType
       :canonical: aiida.orm.entities.Entity.store
 
-      Store the entity.
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.store
+         :renderer: rst
 
    .. py:property:: is_stored
       :canonical: aiida.orm.entities.Entity.is_stored
       :type: bool
 
-      Return whether the entity is stored.
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.is_stored
+         :renderer: rst
 
    .. py:property:: backend
       :canonical: aiida.orm.entities.Entity.backend
       :type: aiida.orm.implementation.StorageBackend
 
-      Get the backend for this entity
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.backend
+         :renderer: rst
 
    .. py:property:: backend_entity
       :canonical: aiida.orm.entities.Entity.backend_entity
       :type: aiida.orm.entities.BackendEntityType
 
-      Get the implementing class for this object
+      .. autodoc2-docstring:: aiida.orm.entities.Entity.backend_entity
+         :renderer: rst
 
 .. py:class:: EntityExtras(entity: typing.Union[aiida.orm.nodes.node.Node, aiida.orm.groups.Group])
    :canonical: aiida.orm.extras.EntityExtras
 
-   Interface to the extras of a node or group instance.
-
-   Extras are a JSONable dictionary, stored on each entity,
-   allowing for arbitrary data to be stored by users.
-
-   Extras are mutable, even after storing the entity,
-   and as such are not deemed a core part of the provenance graph.
+   .. autodoc2-docstring:: aiida.orm.extras.EntityExtras
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize the interface.
+   .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.__init__
+      :renderer: rst
 
    .. py:method:: __contains__(key: str) -> bool
       :canonical: aiida.orm.extras.EntityExtras.__contains__
 
-      Check if the extras contain the given key.
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.__contains__
+         :renderer: rst
 
    .. py:property:: all
       :canonical: aiida.orm.extras.EntityExtras.all
       :type: typing.Dict[str, typing.Any]
 
-      Return the complete extras dictionary.
-
-      .. warning:: While the entity is unstored, this will return references of the extras on the database model,
-          meaning that changes on the returned values (if they are mutable themselves, e.g. a list or dictionary) will
-          automatically be reflected on the database model as well. As soon as the entity is stored, the returned
-          extras will be a deep copy and mutations of the database extras will have to go through the appropriate set
-          methods. Therefore, once stored, retrieving a deep copy can be a heavy operation. If you only need the keys
-          or some values, use the iterators `extras_keys` and `extras_items`, or the getters `get_extra` and
-          `get_extra_many` instead.
-
-      :return: the extras as a dictionary
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.all
+         :renderer: rst
 
    .. py:method:: get(key: str, default: typing.Any = _NO_DEFAULT) -> typing.Any
       :canonical: aiida.orm.extras.EntityExtras.get
 
-      Return the value of an extra.
-
-      .. warning:: While the entity is unstored, this will return a reference of the extra on the database model,
-          meaning that changes on the returned value (if they are mutable themselves, e.g. a list or dictionary) will
-          automatically be reflected on the database model as well. As soon as the entity is stored, the returned
-          extra will be a deep copy and mutations of the database extras will have to go through the appropriate set
-          methods.
-
-      :param key: name of the extra
-      :param default: return this value instead of raising if the attribute does not exist
-      :return: the value of the extra
-      :raises AttributeError: if the extra does not exist and no default is specified
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.get
+         :renderer: rst
 
    .. py:method:: get_many(keys: typing.List[str]) -> typing.List[typing.Any]
       :canonical: aiida.orm.extras.EntityExtras.get_many
 
-      Return the values of multiple extras.
-
-      .. warning:: While the entity is unstored, this will return references of the extras on the database model,
-          meaning that changes on the returned values (if they are mutable themselves, e.g. a list or dictionary) will
-          automatically be reflected on the database model as well. As soon as the entity is stored, the returned
-          extras will be a deep copy and mutations of the database extras will have to go through the appropriate set
-          methods. Therefore, once stored, retrieving a deep copy can be a heavy operation. If you only need the keys
-          or some values, use the iterators `extras_keys` and `extras_items`, or the getters `get_extra` and
-          `get_extra_many` instead.
-
-      :param keys: a list of extra names
-      :return: a list of extra values
-      :raises AttributeError: if at least one extra does not exist
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.get_many
+         :renderer: rst
 
    .. py:method:: set(key: str, value: typing.Any) -> None
       :canonical: aiida.orm.extras.EntityExtras.set
 
-      Set an extra to the given value.
-
-      :param key: name of the extra
-      :param value: value of the extra
-      :raise aiida.common.ValidationError: if the key is invalid, i.e. contains periods
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.set
+         :renderer: rst
 
    .. py:method:: set_many(extras: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.orm.extras.EntityExtras.set_many
 
-      Set multiple extras.
-
-      .. note:: This will override any existing extras that are present in the new dictionary.
-
-      :param extras: a dictionary with the extras to set
-      :raise aiida.common.ValidationError: if any of the keys are invalid, i.e. contain periods
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.set_many
+         :renderer: rst
 
    .. py:method:: reset(extras: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.orm.extras.EntityExtras.reset
 
-      Reset the extras.
-
-      .. note:: This will completely clear any existing extras and replace them with the new dictionary.
-
-      :param extras: a dictionary with the extras to set
-      :raise aiida.common.ValidationError: if any of the keys are invalid, i.e. contain periods
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.reset
+         :renderer: rst
 
    .. py:method:: delete(key: str) -> None
       :canonical: aiida.orm.extras.EntityExtras.delete
 
-      Delete an extra.
-
-      :param key: name of the extra
-      :raises AttributeError: if the extra does not exist
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.delete
+         :renderer: rst
 
    .. py:method:: delete_many(keys: typing.List[str]) -> None
       :canonical: aiida.orm.extras.EntityExtras.delete_many
 
-      Delete multiple extras.
-
-      :param keys: names of the extras to delete
-      :raises AttributeError: if at least one of the extra does not exist
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.delete_many
+         :renderer: rst
 
    .. py:method:: clear() -> None
       :canonical: aiida.orm.extras.EntityExtras.clear
 
-      Delete all extras.
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.clear
+         :renderer: rst
 
    .. py:method:: items() -> typing.Iterable[typing.Tuple[str, typing.Any]]
       :canonical: aiida.orm.extras.EntityExtras.items
 
-      Return an iterator over the extras.
-
-      :return: an iterator with extra key value pairs
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.items
+         :renderer: rst
 
    .. py:method:: keys() -> typing.Iterable[str]
       :canonical: aiida.orm.extras.EntityExtras.keys
 
-      Return an iterator over the extra keys.
-
-      :return: an iterator with extra keys
+      .. autodoc2-docstring:: aiida.orm.extras.EntityExtras.keys
+         :renderer: rst
 
 .. py:class:: EntityTypes
    :canonical: aiida.orm.entities.EntityTypes
 
    Bases: :py:obj:`enum.Enum`
 
-   Enum for referring to ORM entities in a backend-agnostic manner.
+   .. autodoc2-docstring:: aiida.orm.entities.EntityTypes
+      :renderer: rst
 
    .. py:attribute:: AUTHINFO
       :canonical: aiida.orm.entities.EntityTypes.AUTHINFO
       :value: 'authinfo'
 
+      .. autodoc2-docstring:: aiida.orm.entities.EntityTypes.AUTHINFO
+         :renderer: rst
+
    .. py:attribute:: COMMENT
       :canonical: aiida.orm.entities.EntityTypes.COMMENT
       :value: 'comment'
+
+      .. autodoc2-docstring:: aiida.orm.entities.EntityTypes.COMMENT
+         :renderer: rst
 
    .. py:attribute:: COMPUTER
       :canonical: aiida.orm.entities.EntityTypes.COMPUTER
       :value: 'computer'
 
+      .. autodoc2-docstring:: aiida.orm.entities.EntityTypes.COMPUTER
+         :renderer: rst
+
    .. py:attribute:: GROUP
       :canonical: aiida.orm.entities.EntityTypes.GROUP
       :value: 'group'
+
+      .. autodoc2-docstring:: aiida.orm.entities.EntityTypes.GROUP
+         :renderer: rst
 
    .. py:attribute:: LOG
       :canonical: aiida.orm.entities.EntityTypes.LOG
       :value: 'log'
 
+      .. autodoc2-docstring:: aiida.orm.entities.EntityTypes.LOG
+         :renderer: rst
+
    .. py:attribute:: NODE
       :canonical: aiida.orm.entities.EntityTypes.NODE
       :value: 'node'
+
+      .. autodoc2-docstring:: aiida.orm.entities.EntityTypes.NODE
+         :renderer: rst
 
    .. py:attribute:: USER
       :canonical: aiida.orm.entities.EntityTypes.USER
       :value: 'user'
 
+      .. autodoc2-docstring:: aiida.orm.entities.EntityTypes.USER
+         :renderer: rst
+
    .. py:attribute:: LINK
       :canonical: aiida.orm.entities.EntityTypes.LINK
       :value: 'link'
 
+      .. autodoc2-docstring:: aiida.orm.entities.EntityTypes.LINK
+         :renderer: rst
+
    .. py:attribute:: GROUP_NODE
       :canonical: aiida.orm.entities.EntityTypes.GROUP_NODE
       :value: 'group_node'
+
+      .. autodoc2-docstring:: aiida.orm.entities.EntityTypes.GROUP_NODE
+         :renderer: rst
 
 .. py:class:: EnumData(member: enum.Enum, *args, **kwargs)
    :canonical: aiida.orm.nodes.data.enum.EnumData
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   Data plugin that allows to easily wrap an :class:`enum.Enum` member.
-
-   The enum member is stored in the database by storing the value, name and the identifier (string that represents the
-   class of the enumeration) in the ``KEY_NAME``, ``KEY_VALUE`` and ``KEY_IDENTIFIER`` attribute, respectively. The
-   original enum member can be reconstructured from the (loaded) node through the ``get_member`` method. The enum
-   itself can be retrieved from the ``get_enum`` method. Like a normal enum member, the ``EnumData`` plugin provides
-   the ``name`` and ``value`` properties which return the name and value of the enum member, respectively.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct the node for the to enum member that is to be wrapped.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData.__init__
+      :renderer: rst
 
    .. py:attribute:: KEY_NAME
       :canonical: aiida.orm.nodes.data.enum.EnumData.KEY_NAME
       :value: 'name'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData.KEY_NAME
+         :renderer: rst
+
    .. py:attribute:: KEY_VALUE
       :canonical: aiida.orm.nodes.data.enum.EnumData.KEY_VALUE
       :value: 'value'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData.KEY_VALUE
+         :renderer: rst
 
    .. py:attribute:: KEY_IDENTIFIER
       :canonical: aiida.orm.nodes.data.enum.EnumData.KEY_IDENTIFIER
       :value: 'identifier'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData.KEY_IDENTIFIER
+         :renderer: rst
+
    .. py:property:: name
       :canonical: aiida.orm.nodes.data.enum.EnumData.name
       :type: str
 
-      Return the name of the enum member.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData.name
+         :renderer: rst
 
    .. py:property:: value
       :canonical: aiida.orm.nodes.data.enum.EnumData.value
       :type: typing.Any
 
-      Return the value of the enum member.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData.value
+         :renderer: rst
 
    .. py:method:: get_enum() -> typing.Type[aiida.orm.nodes.data.enum.EnumType]
       :canonical: aiida.orm.nodes.data.enum.EnumData.get_enum
 
-      Return the enum class reconstructed from the serialized identifier stored in the database.
-
-      :raises `ImportError`: if the enum class represented by the stored identifier cannot be imported.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData.get_enum
+         :renderer: rst
 
    .. py:method:: get_member() -> aiida.orm.nodes.data.enum.EnumType
       :canonical: aiida.orm.nodes.data.enum.EnumData.get_member
 
-      Return the enum member reconstructed from the serialized data stored in the database.
-
-      For the enum member to be successfully reconstructed, the class of course has to still be importable and its
-      implementation should not have changed since the node was stored. That is to say, the value of the member when
-      it was stored, should still be a valid value for the enum class now.
-
-      :raises `ImportError`: if the enum class represented by the stored identifier cannot be imported.
-      :raises `ValueError`: if the stored enum member value is no longer valid for the imported enum class.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData.get_member
+         :renderer: rst
 
    .. py:method:: __eq__(other: typing.Any) -> bool
       :canonical: aiida.orm.nodes.data.enum.EnumData.__eq__
 
-      Return whether the other object is equivalent to ourselves.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.enum.EnumData.__eq__
+         :renderer: rst
 
 .. py:class:: Float
    :canonical: aiida.orm.nodes.data.float.Float
 
    Bases: :py:obj:`aiida.orm.nodes.data.numeric.NumericType`
 
-   `Data` sub class to represent a float value.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.float.Float
+      :renderer: rst
 
    .. py:attribute:: _type
       :canonical: aiida.orm.nodes.data.float.Float._type
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.float.Float._type
+         :renderer: rst
 
 .. py:class:: FolderData(**kwargs)
    :canonical: aiida.orm.nodes.data.folder.FolderData
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   `Data` sub class to represent a folder on a file system.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.folder.FolderData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new `FolderData` to which any files and folders can be added.
-
-   Use the `tree` keyword to simply wrap a directory:
-
-       folder = FolderData(tree='/absolute/path/to/directory')
-
-   Alternatively, one can construct the node first and then use the various repository methods to add objects:
-
-       folder = FolderData()
-       folder.put_object_from_tree('/absolute/path/to/directory')
-       folder.put_object_from_filepath('/absolute/path/to/file.txt')
-       folder.put_object_from_filelike(filelike_object)
-
-   :param tree: absolute path to a folder to wrap
-   :type tree: str
+   .. autodoc2-docstring:: aiida.orm.nodes.data.folder.FolderData.__init__
+      :renderer: rst
 
 .. py:class:: Group(label: typing.Optional[str] = None, user: typing.Optional[aiida.orm.User] = None, description: str = '', type_string: typing.Optional[str] = None, backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.groups.Group
 
    Bases: :py:obj:`aiida.orm.entities.Entity`\ [\ :py:obj:`aiida.orm.implementation.BackendGroup`\ , :py:obj:`aiida.orm.groups.GroupCollection`\ ]
 
-   An AiiDA ORM implementation of group of nodes.
+   .. autodoc2-docstring:: aiida.orm.groups.Group
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Create a new group. Either pass a dbgroup parameter, to reload
-   a group from the DB (and then, no further parameters are allowed),
-   or pass the parameters for the Group creation.
-
-   :param label: The group label, required on creation
-   :param description: The group description (by default, an empty string)
-   :param user: The owner of the group (by default, the automatic user)
-   :param type_string: a string identifying the type of group (by default,
-       an empty string, indicating an user-defined group.
+   .. autodoc2-docstring:: aiida.orm.groups.Group.__init__
+      :renderer: rst
 
    .. py:attribute:: _type_string
       :canonical: aiida.orm.groups.Group._type_string
       :type: typing.ClassVar[typing.Optional[str]]
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.groups.Group._type_string
+         :renderer: rst
+
    .. py:attribute:: _CLS_COLLECTION
       :canonical: aiida.orm.groups.Group._CLS_COLLECTION
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.groups.Group._CLS_COLLECTION
+         :renderer: rst
+
    .. py:method:: base() -> aiida.orm.groups.GroupBase
       :canonical: aiida.orm.groups.Group.base
 
-      Return the group base namespace.
+      .. autodoc2-docstring:: aiida.orm.groups.Group.base
+         :renderer: rst
 
    .. py:method:: __repr__() -> str
       :canonical: aiida.orm.groups.Group.__repr__
 
+      .. autodoc2-docstring:: aiida.orm.groups.Group.__repr__
+         :renderer: rst
+
    .. py:method:: __str__() -> str
       :canonical: aiida.orm.groups.Group.__str__
+
+      .. autodoc2-docstring:: aiida.orm.groups.Group.__str__
+         :renderer: rst
 
    .. py:method:: store() -> aiida.orm.groups.SelfType
       :canonical: aiida.orm.groups.Group.store
 
-      Verify that the group is allowed to be stored, which is the case along as `type_string` is set.
+      .. autodoc2-docstring:: aiida.orm.groups.Group.store
+         :renderer: rst
 
    .. py:method:: entry_point() -> typing.Optional[aiida.plugins.entry_point.EntryPoint]
       :canonical: aiida.orm.groups.Group.entry_point
 
-      Return the entry point associated this group type.
-
-      :return: the associated entry point or ``None`` if it isn't known.
+      .. autodoc2-docstring:: aiida.orm.groups.Group.entry_point
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.orm.groups.Group.uuid
       :type: str
 
-      Return the UUID for this group.
-
-      This identifier is unique across all entities types and backend instances.
-
-      :return: the entity uuid
+      .. autodoc2-docstring:: aiida.orm.groups.Group.uuid
+         :renderer: rst
 
    .. py:property:: label
       :canonical: aiida.orm.groups.Group.label
       :type: str
 
-      :return: the label of the group as a string
+      .. autodoc2-docstring:: aiida.orm.groups.Group.label
+         :renderer: rst
 
    .. py:property:: description
       :canonical: aiida.orm.groups.Group.description
       :type: str
 
-      :return: the description of the group as a string
+      .. autodoc2-docstring:: aiida.orm.groups.Group.description
+         :renderer: rst
 
    .. py:property:: type_string
       :canonical: aiida.orm.groups.Group.type_string
       :type: str
 
-      :return: the string defining the type of the group
+      .. autodoc2-docstring:: aiida.orm.groups.Group.type_string
+         :renderer: rst
 
    .. py:property:: user
       :canonical: aiida.orm.groups.Group.user
       :type: aiida.orm.User
 
-      :return: the user associated with this group
+      .. autodoc2-docstring:: aiida.orm.groups.Group.user
+         :renderer: rst
 
    .. py:method:: count() -> int
       :canonical: aiida.orm.groups.Group.count
 
-      Return the number of entities in this group.
-
-      :return: integer number of entities contained within the group
+      .. autodoc2-docstring:: aiida.orm.groups.Group.count
+         :renderer: rst
 
    .. py:property:: nodes
       :canonical: aiida.orm.groups.Group.nodes
       :type: aiida.orm.convert.ConvertIterator
 
-      Return a generator/iterator that iterates over all nodes and returns
-      the respective AiiDA subclasses of Node, and also allows to ask for
-      the number of nodes in the group using len().
+      .. autodoc2-docstring:: aiida.orm.groups.Group.nodes
+         :renderer: rst
 
    .. py:property:: is_empty
       :canonical: aiida.orm.groups.Group.is_empty
       :type: bool
 
-      Return whether the group is empty, i.e. it does not contain any nodes.
-
-      :return: True if it contains no nodes, False otherwise
+      .. autodoc2-docstring:: aiida.orm.groups.Group.is_empty
+         :renderer: rst
 
    .. py:method:: clear() -> None
       :canonical: aiida.orm.groups.Group.clear
 
-      Remove all the nodes from this group.
+      .. autodoc2-docstring:: aiida.orm.groups.Group.clear
+         :renderer: rst
 
    .. py:method:: add_nodes(nodes: typing.Union[aiida.orm.nodes.Node, typing.Sequence[aiida.orm.nodes.Node]]) -> None
       :canonical: aiida.orm.groups.Group.add_nodes
 
-      Add a node or a set of nodes to the group.
-
-      :note: all the nodes *and* the group itself have to be stored.
-
-      :param nodes: a single `Node` or a list of `Nodes`
+      .. autodoc2-docstring:: aiida.orm.groups.Group.add_nodes
+         :renderer: rst
 
    .. py:method:: remove_nodes(nodes: typing.Union[aiida.orm.nodes.Node, typing.Sequence[aiida.orm.nodes.Node]]) -> None
       :canonical: aiida.orm.groups.Group.remove_nodes
 
-      Remove a node or a set of nodes to the group.
-
-      :note: all the nodes *and* the group itself have to be stored.
-
-      :param nodes: a single `Node` or a list of `Nodes`
+      .. autodoc2-docstring:: aiida.orm.groups.Group.remove_nodes
+         :renderer: rst
 
    .. py:method:: is_user_defined() -> bool
       :canonical: aiida.orm.groups.Group.is_user_defined
 
-      :return: True if the group is user defined, False otherwise
+      .. autodoc2-docstring:: aiida.orm.groups.Group.is_user_defined
+         :renderer: rst
 
    .. py:attribute:: _deprecated_extra_methods
       :canonical: aiida.orm.groups.Group._deprecated_extra_methods
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.groups.Group._deprecated_extra_methods
+         :renderer: rst
+
    .. py:method:: __getattr__(name: str) -> typing.Any
       :canonical: aiida.orm.groups.Group.__getattr__
 
-      This method is called when an extras is not found in the instance.
-
-      It allows for the handling of deprecated mixin methods.
+      .. autodoc2-docstring:: aiida.orm.groups.Group.__getattr__
+         :renderer: rst
 
 .. py:class:: GroupEntityLoader
    :canonical: aiida.orm.utils.loaders.GroupEntityLoader
 
    Bases: :py:obj:`aiida.orm.utils.loaders.OrmEntityLoader`
 
-   Loader for the `Group` entity and sub classes.
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.GroupEntityLoader
+      :renderer: rst
 
    .. py:method:: orm_base_class()
       :canonical: aiida.orm.utils.loaders.GroupEntityLoader.orm_base_class
 
-      Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
-      may further narrow the query set by defining a more specific set of orm classes, as long as each of
-      those is a strict sub class of the orm base class.
-
-      :returns: the orm base class
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.GroupEntityLoader.orm_base_class
+         :renderer: rst
 
    .. py:method:: _get_query_builder_label_identifier(identifier, classes, operator='==', project='*')
       :canonical: aiida.orm.utils.loaders.GroupEntityLoader._get_query_builder_label_identifier
       :classmethod:
 
-      Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
-      defined for this loader class, interpreting the identifier as a LABEL like identifier
-
-      :param identifier: the LABEL identifier
-      :param classes: a tuple of orm classes to which the identifier should be mapped
-      :param operator: the operator to use in the query
-      :param project: the property or properties to project for entities matching the query
-      :returns: the query builder instance that should retrieve the entity corresponding to the identifier
-      :raises ValueError: if the identifier is invalid
-      :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.GroupEntityLoader._get_query_builder_label_identifier
+         :renderer: rst
 
 .. py:class:: ImportGroup(label: typing.Optional[str] = None, user: typing.Optional[aiida.orm.User] = None, description: str = '', type_string: typing.Optional[str] = None, backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.groups.ImportGroup
 
    Bases: :py:obj:`aiida.orm.groups.Group`
 
-   Group to be used to contain all nodes from an export archive that has been imported.
+   .. autodoc2-docstring:: aiida.orm.groups.ImportGroup
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Create a new group. Either pass a dbgroup parameter, to reload
-   a group from the DB (and then, no further parameters are allowed),
-   or pass the parameters for the Group creation.
-
-   :param label: The group label, required on creation
-   :param description: The group description (by default, an empty string)
-   :param user: The owner of the group (by default, the automatic user)
-   :param type_string: a string identifying the type of group (by default,
-       an empty string, indicating an user-defined group.
+   .. autodoc2-docstring:: aiida.orm.groups.ImportGroup.__init__
+      :renderer: rst
 
 .. py:class:: InstalledCode(computer: aiida.orm.Computer, filepath_executable: str, **kwargs)
    :canonical: aiida.orm.nodes.data.code.installed.InstalledCode
 
    Bases: :py:obj:`aiida.orm.nodes.data.code.legacy.Code`
 
-   Data plugin representing an executable code on a remote computer.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance.
-
-   :param computer: The remote computer on which the executable is located.
-   :param filepath_executable: The absolute filepath of the executable on the remote computer.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode.__init__
+      :renderer: rst
 
    .. py:attribute:: _KEY_ATTRIBUTE_FILEPATH_EXECUTABLE
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode._KEY_ATTRIBUTE_FILEPATH_EXECUTABLE
       :type: str
       :value: 'filepath_executable'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode._KEY_ATTRIBUTE_FILEPATH_EXECUTABLE
+         :renderer: rst
+
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode._validate
 
-      Validate the instance by checking that a computer has been defined.
-
-      :raises :class:`aiida.common.exceptions.ValidationError`: If the state of the node is invalid.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode._validate
+         :renderer: rst
 
    .. py:method:: validate_filepath_executable()
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode.validate_filepath_executable
 
-      Validate the ``filepath_executable`` attribute.
-
-      Checks whether the executable exists on the remote computer if a transport can be opened to it. This method
-      is intentionally not called in ``_validate`` as to allow the creation of ``Code`` instances whose computers can
-      not yet be connected to and as to not require the overhead of opening transports in storing a new code.
-
-      :raises `~aiida.common.exceptions.ValidationError`: if no transport could be opened or if the defined executable
-          does not exist on the remote computer.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode.validate_filepath_executable
+         :renderer: rst
 
    .. py:method:: can_run_on_computer(computer: aiida.orm.Computer) -> bool
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode.can_run_on_computer
 
-      Return whether the code can run on a given computer.
-
-      :param computer: The computer.
-      :return: ``True`` if the provided computer is the same as the one configured for this code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode.can_run_on_computer
+         :renderer: rst
 
    .. py:method:: get_executable() -> pathlib.PurePosixPath
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode.get_executable
 
-      Return the executable that the submission script should execute to run the code.
-
-      :return: The executable to be called in the submission script.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode.get_executable
+         :renderer: rst
 
    .. py:property:: computer
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode.computer
       :type: aiida.orm.Computer
 
-      Return the computer of this code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode.computer
+         :renderer: rst
 
    .. py:property:: full_label
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode.full_label
       :type: str
 
-      Return the full label of this code.
-
-      The full label can be just the label itself but it can be something else. However, it at the very least has to
-      include the label of the code.
-
-      :return: The full label of the code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode.full_label
+         :renderer: rst
 
    .. py:property:: filepath_executable
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode.filepath_executable
       :type: pathlib.PurePosixPath
 
-      Return the absolute filepath of the executable that this code represents.
-
-      :return: The absolute filepath of the executable.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode.filepath_executable
+         :renderer: rst
 
    .. py:method:: cli_validate_label_uniqueness(ctx, _, value)
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode.cli_validate_label_uniqueness
       :staticmethod:
 
-      Validate the uniqueness of the label of the code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode.cli_validate_label_uniqueness
+         :renderer: rst
 
    .. py:method:: _get_cli_options() -> dict
       :canonical: aiida.orm.nodes.data.code.installed.InstalledCode._get_cli_options
       :classmethod:
 
-      Return the CLI options that would allow to create an instance of this class.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.installed.InstalledCode._get_cli_options
+         :renderer: rst
 
 .. py:class:: Int
    :canonical: aiida.orm.nodes.data.int.Int
 
    Bases: :py:obj:`aiida.orm.nodes.data.numeric.NumericType`
 
-   `Data` sub class to represent an integer value.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.int.Int
+      :renderer: rst
 
    .. py:attribute:: _type
       :canonical: aiida.orm.nodes.data.int.Int._type
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.int.Int._type
+         :renderer: rst
 
 .. py:class:: JsonableData(obj: aiida.orm.nodes.data.jsonable.JsonSerializableProtocol, *args, **kwargs)
    :canonical: aiida.orm.nodes.data.jsonable.JsonableData
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   Data plugin that allows to easily wrap objects that are JSON-able.
-
-   Any class that implements the ``as_dict`` method, returning a dictionary that is a JSON serializable representation
-   of the object, can be wrapped and stored by this data plugin.
-
-   As an example, take the ``Molecule`` class of the ``pymatgen`` library, which respects the spec described above. To
-   store an instance as a ``JsonableData`` simply pass an instance as an argument to the constructor as follows::
-
-       from pymatgen.core import Molecule
-       molecule = Molecule(['H']. [0, 0, 0])
-       node = JsonableData(molecule)
-       node.store()
-
-   Since ``Molecule.as_dict`` returns a dictionary that is JSON-serializable, the data plugin will call it and store
-   the dictionary as the attributes of the ``JsonableData`` node in the database.
-
-   .. note:: A JSON-serializable dictionary means a dictionary that when passed to ``json.dumps`` does not except but
-       produces a valid JSON string representation of the dictionary.
-
-   If the wrapped class implements a class-method ``from_dict``, the wrapped instance can easily be recovered from a
-   previously stored node that was optionally loaded from the database. The ``from_dict`` method should simply accept
-   a single argument which is the dictionary that is returned by the ``as_dict`` method. If this criteria is satisfied,
-   an instance wrapped and stored in a ``JsonableData`` node can be recovered through the ``obj`` property::
-
-       loaded = load_node(node.pk)
-       molecule = loaded.obj
-
-   Of course, this requires that the class of the originally wrapped instance can be imported in the current
-   environment, or an ``ImportError`` will be raised.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.jsonable.JsonableData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct the node for the to be wrapped object.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.jsonable.JsonableData.__init__
+      :renderer: rst
 
    .. py:method:: _deserialize_float_constants(data: typing.Any)
       :canonical: aiida.orm.nodes.data.jsonable.JsonableData._deserialize_float_constants
       :classmethod:
 
-      Deserialize the contents of a dictionary ``data`` deserializing infinity and NaN string constants.
-
-      The ``data`` dictionary is recursively checked for the ``Infinity``, ``-Infinity`` and ``NaN`` strings, which
-      are the Javascript string equivalents to the Python ``float('inf')``, ``-float('inf')`` and ``float('nan')``
-      float constants. If one of the strings is encountered, the Python float constant is returned and otherwise the
-      original value is returned.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.jsonable.JsonableData._deserialize_float_constants
+         :renderer: rst
 
    .. py:method:: _get_object() -> aiida.orm.nodes.data.jsonable.JsonSerializableProtocol
       :canonical: aiida.orm.nodes.data.jsonable.JsonableData._get_object
 
-      Return the cached wrapped object.
-
-      .. note:: If the object is not yet present in memory, for example if the node was loaded from the database,
-          the object will first be reconstructed from the state stored in the node attributes.
-
+      .. autodoc2-docstring:: aiida.orm.nodes.data.jsonable.JsonableData._get_object
+         :renderer: rst
 
    .. py:property:: obj
       :canonical: aiida.orm.nodes.data.jsonable.JsonableData.obj
       :type: aiida.orm.nodes.data.jsonable.JsonSerializableProtocol
 
-      Return the wrapped object.
-
-      .. note:: This property caches the deserialized object, this means that when the node is loaded from the
-          database, the object is deserialized only once and stored in memory as an attribute. Subsequent calls will
-          simply return this cached object and not reload it from the database. This is fine, since nodes that are
-          loaded from the database are by definition stored and therefore immutable, making it safe to assume that the
-          object that is represented can not change. Note, however, that the caching also applies to unstored nodes.
-          That means that manually changing the attributes of an unstored ``JsonableData`` can lead to inconsistencies
-          with the object returned by this property.
-
+      .. autodoc2-docstring:: aiida.orm.nodes.data.jsonable.JsonableData.obj
+         :renderer: rst
 
 .. py:class:: Kind(**kwargs)
    :canonical: aiida.orm.nodes.data.structure.Kind
 
-   This class contains the information about the species (kinds) of the system.
-
-   It can be a single atom, or an alloy, or even contain vacancies.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Create a site.
-   One can either pass:
-
-   :param raw: the raw python dictionary that will be converted to a
-          Kind object.
-   :param ase: an ase Atom object
-   :param kind: a Kind object (to get a copy)
-
-   Or alternatively the following parameters:
-
-   :param symbols: a single string for the symbol of this site, or a list
-              of symbol strings
-   :param weights: (optional) the weights for each atomic species of
-              this site.
-              If only a single symbol is provided, then this value is
-              optional and the weight is set to 1.
-   :param mass: (optional) the mass for this site in atomic mass units.
-              If not provided, the mass is set by the
-              self.reset_mass() function.
-   :param name: a string that uniquely identifies the kind, and that
-              is used to identify the sites.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.__init__
+      :renderer: rst
 
    .. py:method:: get_raw()
       :canonical: aiida.orm.nodes.data.structure.Kind.get_raw
 
-      Return the raw version of the site, mapped to a suitable dictionary.
-      This is the format that is actually used to store each kind of the
-      structure in the DB.
-
-      :return: a python dictionary with the kind.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.get_raw
+         :renderer: rst
 
    .. py:method:: reset_mass()
       :canonical: aiida.orm.nodes.data.structure.Kind.reset_mass
 
-      Reset the mass to the automatic calculated value.
-
-      The mass can be set manually; by default, if not provided,
-      it is the mass of the constituent atoms, weighted with their
-      weight (after the weight has been normalized to one to take
-      correctly into account vacancies).
-
-      This function uses the internal _symbols and _weights values and
-      thus assumes that the values are validated.
-
-      It sets the mass to None if the sum of weights is zero.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.reset_mass
+         :renderer: rst
 
    .. py:property:: name
       :canonical: aiida.orm.nodes.data.structure.Kind.name
 
-      Return the name of this kind.
-      The name of a kind is used to identify the species of a site.
-
-      :return: a string
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.name
+         :renderer: rst
 
    .. py:method:: set_automatic_kind_name(tag=None)
       :canonical: aiida.orm.nodes.data.structure.Kind.set_automatic_kind_name
 
-      Set the type to a string obtained with the symbols appended one
-      after the other, without spaces, in alphabetical order;
-      if the site has a vacancy, a X is appended at the end too.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.set_automatic_kind_name
+         :renderer: rst
 
    .. py:method:: compare_with(other_kind)
       :canonical: aiida.orm.nodes.data.structure.Kind.compare_with
 
-      Compare with another Kind object to check if they are different.
-
-      .. note:: This does NOT check the 'type' attribute. Instead, it compares
-          (with reasonable thresholds, where applicable): the mass, and the list
-          of symbols and of weights. Moreover, it compares the
-          ``_internal_tag``, if defined (at the moment, defined automatically
-          only when importing the Kind from ASE, if the atom has a non-zero tag).
-          Note that the _internal_tag is only used while the class is loaded,
-          but is not persisted on the database.
-
-      :return: A tuple with two elements. The first one is True if the two sites
-          are 'equivalent' (same mass, symbols and weights), False otherwise.
-          The second element of the tuple is a string,
-          which is either None (if the first element was True), or contains
-          a 'human-readable' description of the first difference encountered
-          between the two sites.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.compare_with
+         :renderer: rst
 
    .. py:property:: mass
       :canonical: aiida.orm.nodes.data.structure.Kind.mass
 
-      The mass of this species kind.
-
-      :return: a float
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.mass
+         :renderer: rst
 
    .. py:property:: weights
       :canonical: aiida.orm.nodes.data.structure.Kind.weights
 
-      Weights for this species kind. Refer also to
-      :func:validate_symbols_tuple for the validation rules on the weights.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.weights
+         :renderer: rst
 
    .. py:method:: get_symbols_string()
       :canonical: aiida.orm.nodes.data.structure.Kind.get_symbols_string
 
-      Return a string that tries to match as good as possible the symbols
-      of this kind. If there is only one symbol (no alloy) with 100%
-      occupancy, just returns the symbol name. Otherwise, groups the full
-      string in curly brackets, and try to write also the composition
-      (with 2 precision only).
-
-      .. note:: If there is a vacancy (sum of weights<1), we indicate it
-          with the X symbol followed by 1-sum(weights) (still with 2
-          digits precision, so it can be 0.00)
-
-      .. note:: Note the difference with respect to the symbols and the
-          symbol properties!
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.get_symbols_string
+         :renderer: rst
 
    .. py:property:: symbol
       :canonical: aiida.orm.nodes.data.structure.Kind.symbol
 
-      If the kind has only one symbol, return it; otherwise, raise a
-      ValueError.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.symbol
+         :renderer: rst
 
    .. py:property:: symbols
       :canonical: aiida.orm.nodes.data.structure.Kind.symbols
 
-      List of symbols for this site. If the site is a single atom,
-      pass a list of one element only, or simply the string for that atom.
-      For alloys, a list of elements.
-
-      .. note:: Note that if you change the list of symbols, the kind
-          name remains unchanged.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.symbols
+         :renderer: rst
 
    .. py:method:: set_symbols_and_weights(symbols, weights)
       :canonical: aiida.orm.nodes.data.structure.Kind.set_symbols_and_weights
 
-      Set the chemical symbols and the weights for the site.
-
-      .. note:: Note that the kind name remains unchanged.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.set_symbols_and_weights
+         :renderer: rst
 
    .. py:property:: is_alloy
       :canonical: aiida.orm.nodes.data.structure.Kind.is_alloy
 
-      Return whether the Kind is an alloy, i.e. contains more than one element
-
-      :return: boolean, True if the kind has more than one element, False otherwise.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.is_alloy
+         :renderer: rst
 
    .. py:property:: has_vacancies
       :canonical: aiida.orm.nodes.data.structure.Kind.has_vacancies
 
-      Return whether the Kind contains vacancies, i.e. when the sum of the weights is less than one.
-
-      .. note:: the property uses the internal variable `_SUM_THRESHOLD` as a threshold.
-
-      :return: boolean, True if the sum of the weights is less than one, False otherwise
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.has_vacancies
+         :renderer: rst
 
    .. py:method:: __repr__()
       :canonical: aiida.orm.nodes.data.structure.Kind.__repr__
 
-      Return repr(self).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.__repr__
+         :renderer: rst
 
    .. py:method:: __str__()
       :canonical: aiida.orm.nodes.data.structure.Kind.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Kind.__str__
+         :renderer: rst
 
 .. py:class:: KpointsData
    :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData
 
    Bases: :py:obj:`aiida.orm.nodes.data.array.array.ArrayData`
 
-   Class to handle array of kpoints in the Brillouin zone. Provide methods to
-   generate either user-defined k-points or path of k-points along symmetry
-   lines.
-   Internally, all k-points are defined in terms of crystal (fractional)
-   coordinates.
-   Cell and lattice vector coordinates are in Angstroms, reciprocal lattice
-   vectors in Angstrom^-1 .
-   :note: The methods setting and using the Bravais lattice info assume the
-   PRIMITIVE unit cell is provided in input to the set_cell or
-   set_cell_from_structure methods.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData
+      :renderer: rst
 
    .. py:method:: get_description()
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.get_description
 
-      Returns a string with infos retrieved from  kpoints node's properties.
-      :param node:
-      :return: retstr
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.get_description
+         :renderer: rst
 
    .. py:property:: cell
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.cell
 
-      The crystal unit cell. Rows are the crystal vectors in Angstroms.
-      :return: a 3x3 numpy.array
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.cell
+         :renderer: rst
 
    .. py:method:: _set_cell(value)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData._set_cell
 
-      Validate if 'value' is a allowed crystal unit cell
-      :param value: something compatible with a 3x3 tuple of floats
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData._set_cell
+         :renderer: rst
 
    .. py:property:: pbc
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.pbc
 
-      The periodic boundary conditions along the vectors a1,a2,a3.
-
-      :return: a tuple of three booleans, each one tells if there are periodic
-          boundary conditions for the i-th real-space direction (i=1,2,3)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.pbc
+         :renderer: rst
 
    .. py:method:: _set_pbc(value)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData._set_pbc
 
-      validate the pbc, then store them
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData._set_pbc
+         :renderer: rst
 
    .. py:property:: labels
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.labels
 
-      Labels associated with the list of kpoints.
-      List of tuples with kpoint index and kpoint name: ``[(0,'G'),(13,'M'),...]``
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.labels
+         :renderer: rst
 
    .. py:method:: _set_labels(value)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData._set_labels
 
-      set label names. Must pass in input a list like: ``[[0,'X'],[34,'L'],... ]``
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData._set_labels
+         :renderer: rst
 
    .. py:method:: _change_reference(kpoints, to_cartesian=True)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData._change_reference
 
-      Change reference system, from cartesian to crystal coordinates (units of b1,b2,b3) or viceversa.
-      :param kpoints: a list of (3) point coordinates
-      :return kpoints: a list of (3) point coordinates in the new reference
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData._change_reference
+         :renderer: rst
 
    .. py:method:: set_cell_from_structure(structuredata)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.set_cell_from_structure
 
-      Set a cell to be used for symmetry analysis from an AiiDA structure.
-      Inherits both the cell and the pbc's.
-      To set manually a cell, use "set_cell"
-
-      :param structuredata: an instance of StructureData
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.set_cell_from_structure
+         :renderer: rst
 
    .. py:method:: set_cell(cell, pbc=None)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.set_cell
 
-      Set a cell to be used for symmetry analysis.
-      To set a cell from an AiiDA structure, use "set_cell_from_structure".
-
-      :param cell: 3x3 matrix of cell vectors. Orientation: each row
-                   represent a lattice vector. Units are Angstroms.
-      :param pbc: list of 3 booleans, True if in the nth crystal direction the
-                  structure is periodic. Default = [True,True,True]
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.set_cell
+         :renderer: rst
 
    .. py:property:: reciprocal_cell
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.reciprocal_cell
 
-      Compute reciprocal cell from the internally set cell.
-
-      :returns: reciprocal cell in units of 1/Angstrom with cell vectors stored as rows.
-          Use e.g. reciprocal_cell[0] to access the first reciprocal cell vector.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.reciprocal_cell
+         :renderer: rst
 
    .. py:method:: set_kpoints_mesh(mesh, offset=None)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.set_kpoints_mesh
 
-      Set KpointsData to represent a uniformily spaced mesh of kpoints in the
-      Brillouin zone. This excludes the possibility of set/get kpoints
-
-      :param mesh: a list of three integers, representing the size of the
-          kpoint mesh along b1,b2,b3.
-      :param offset: (optional) a list of three floats between 0 and 1.
-          [0.,0.,0.] is Gamma centered mesh
-          [0.5,0.5,0.5] is half shifted
-          [1.,1.,1.] by periodicity should be equivalent to [0.,0.,0.]
-          Default = [0.,0.,0.].
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.set_kpoints_mesh
+         :renderer: rst
 
    .. py:method:: get_kpoints_mesh(print_list=False)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.get_kpoints_mesh
 
-      Get the mesh of kpoints.
-
-      :param print_list: default=False. If True, prints the mesh of kpoints as a list
-
-      :raise AttributeError: if no mesh has been set
-      :return mesh,offset: (if print_list=False) a list of 3 integers and a list of three
-              floats 0<x<1, representing the mesh and the offset of kpoints
-      :return kpoints: (if print_list = True) an explicit list of kpoints coordinates,
-              similar to what returned by get_kpoints()
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.get_kpoints_mesh
+         :renderer: rst
 
    .. py:method:: set_kpoints_mesh_from_density(distance, offset=None, force_parity=False)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.set_kpoints_mesh_from_density
 
-      Set a kpoints mesh using a kpoints density, expressed as the maximum
-      distance between adjacent points along a reciprocal axis
-
-      :param distance: distance (in 1/Angstrom) between adjacent
-          kpoints, i.e. the number of kpoints along each reciprocal
-          axis i is :math:`|b_i|/distance`
-          where :math:`|b_i|` is the norm of the reciprocal cell vector.
-      :param offset: (optional) a list of three floats between 0 and 1.
-          [0.,0.,0.] is Gamma centered mesh
-          [0.5,0.5,0.5] is half shifted
-          Default = [0.,0.,0.].
-      :param force_parity: (optional) if True, force each integer in the mesh
-          to be even (except for the non-periodic directions).
-
-      :note: a cell should be defined first.
-      :note: the number of kpoints along non-periodic axes is always 1.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.set_kpoints_mesh_from_density
+         :renderer: rst
 
    .. py:property:: _dimension
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData._dimension
 
-      Dimensionality of the structure, found from its pbc (i.e. 1 if it's a 1D
-      structure, 2 if its 2D, 3 if it's 3D ...).
-      :return dimensionality: 0, 1, 2 or 3
-      :note: will return 3 if pbc has not been set beforehand
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData._dimension
+         :renderer: rst
 
    .. py:method:: _validate_kpoints_weights(kpoints, weights)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData._validate_kpoints_weights
 
-      Validate the list of kpoints and of weights before storage.
-      Kpoints and weights must be convertible respectively to an array of
-      N x dimension and N floats
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData._validate_kpoints_weights
+         :renderer: rst
 
    .. py:method:: set_kpoints(kpoints, cartesian=False, labels=None, weights=None, fill_values=0)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.set_kpoints
 
-      Set the list of kpoints. If a mesh has already been stored, raise a
-      ModificationNotAllowed
-
-      :param kpoints: a list of kpoints, each kpoint being a list of one, two
-          or three coordinates, depending on self.pbc: if structure is 1D
-          (only one True in self.pbc) one allows singletons or scalars for
-          each k-point, if it's 2D it can be a length-2 list, and in all
-          cases it can be a length-3 list.
-          Examples:
-
-              * [[0.,0.,0.],[0.1,0.1,0.1],...] for 1D, 2D or 3D
-              * [[0.,0.],[0.1,0.1,],...] for 1D or 2D
-              * [[0.],[0.1],...] for 1D
-              * [0., 0.1, ...] for 1D (list of scalars)
-
-          For 0D (all pbc are False), the list can be any of the above
-          or empty - then only Gamma point is set.
-          The value of k for the non-periodic dimension(s) is set by
-          fill_values
-      :param cartesian: if True, the coordinates given in input are treated
-          as in cartesian units. If False, the coordinates are crystal,
-          i.e. in units of b1,b2,b3. Default = False
-      :param labels: optional, the list of labels to be set for some of the
-          kpoints. See labels for more info
-      :param weights: optional, a list of floats with the weight associated
-          to the kpoint list
-      :param fill_values: scalar to be set to all
-          non-periodic dimensions (indicated by False in self.pbc), or list of
-          values for each of the non-periodic dimensions.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.set_kpoints
+         :renderer: rst
 
    .. py:method:: get_kpoints(also_weights=False, cartesian=False)
       :canonical: aiida.orm.nodes.data.array.kpoints.KpointsData.get_kpoints
 
-      Return the list of kpoints
-
-      :param also_weights: if True, returns also the list of weights.
-          Default = False
-      :param cartesian: if True, returns points in cartesian coordinates,
-          otherwise, returns in crystal coordinates. Default = False.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.kpoints.KpointsData.get_kpoints
+         :renderer: rst
 
 .. py:class:: LinkManager(link_triples: typing.List[aiida.orm.utils.links.LinkTriple])
    :canonical: aiida.orm.utils.links.LinkManager
 
-   Class to convert a list of LinkTriple tuples into an iterator.
-
-   It defines convenience methods to retrieve certain subsets of LinkTriple while checking for consistency.
-   For example::
-
-       LinkManager.one(): returns the only entry in the list or it raises an exception
-       LinkManager.first(): returns the first entry from the list
-       LinkManager.all(): returns all entries from list
-
-   The methods `all_nodes` and `all_link_labels` are syntactic sugar wrappers around `all` to get a list of only the
-   incoming nodes or link labels, respectively.
+   .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialise the collection.
+   .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.__init__
+      :renderer: rst
 
    .. py:method:: __iter__() -> typing.Iterator[aiida.orm.utils.links.LinkTriple]
       :canonical: aiida.orm.utils.links.LinkManager.__iter__
 
-      Return an iterator of LinkTriple instances.
-
-      :return: iterator of LinkTriple instances
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.__iter__
+         :renderer: rst
 
    .. py:method:: __next__() -> typing.Generator[aiida.orm.utils.links.LinkTriple, None, None]
       :canonical: aiida.orm.utils.links.LinkManager.__next__
 
-      Return the next element in the iterator.
-
-      :return: LinkTriple
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.__next__
+         :renderer: rst
 
    .. py:method:: __bool__()
       :canonical: aiida.orm.utils.links.LinkManager.__bool__
 
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.__bool__
+         :renderer: rst
+
    .. py:method:: next() -> typing.Generator[aiida.orm.utils.links.LinkTriple, None, None]
       :canonical: aiida.orm.utils.links.LinkManager.next
 
-      Return the next element in the iterator.
-
-      :return: LinkTriple
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.next
+         :renderer: rst
 
    .. py:method:: one() -> aiida.orm.utils.links.LinkTriple
       :canonical: aiida.orm.utils.links.LinkManager.one
 
-      Return a single entry from the iterator.
-
-      If the iterator contains no or more than one entry, an exception will be raised
-      :return: LinkTriple instance
-      :raises ValueError: if the iterator contains anything but one entry
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.one
+         :renderer: rst
 
    .. py:method:: first() -> typing.Optional[aiida.orm.utils.links.LinkTriple]
       :canonical: aiida.orm.utils.links.LinkManager.first
 
-      Return the first entry from the iterator.
-
-      :return: LinkTriple instance or None if no entries were matched
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.first
+         :renderer: rst
 
    .. py:method:: all() -> typing.List[aiida.orm.utils.links.LinkTriple]
       :canonical: aiida.orm.utils.links.LinkManager.all
 
-      Return all entries from the list.
-
-      :return: list of LinkTriple instances
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.all
+         :renderer: rst
 
    .. py:method:: all_nodes() -> typing.List[aiida.orm.Node]
       :canonical: aiida.orm.utils.links.LinkManager.all_nodes
 
-      Return a list of all nodes.
-
-      :return: list of nodes
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.all_nodes
+         :renderer: rst
 
    .. py:method:: all_link_pairs() -> typing.List[aiida.orm.utils.links.LinkPair]
       :canonical: aiida.orm.utils.links.LinkManager.all_link_pairs
 
-      Return a list of all link pairs.
-
-      :return: list of LinkPair instances
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.all_link_pairs
+         :renderer: rst
 
    .. py:method:: all_link_labels() -> typing.List[str]
       :canonical: aiida.orm.utils.links.LinkManager.all_link_labels
 
-      Return a list of all link labels.
-
-      :return: list of link labels
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.all_link_labels
+         :renderer: rst
 
    .. py:method:: get_node_by_label(label: str) -> aiida.orm.Node
       :canonical: aiida.orm.utils.links.LinkManager.get_node_by_label
 
-      Return the node from list for given label.
-
-      :return: node that corresponds to the given label
-      :raises aiida.common.NotExistent: if the label is not present among the link_triples
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.get_node_by_label
+         :renderer: rst
 
    .. py:method:: nested(sort=True)
       :canonical: aiida.orm.utils.links.LinkManager.nested
 
-      Construct (nested) dictionary of matched nodes that mirrors the original nesting of link namespaces.
-
-      Process input and output namespaces can be nested, however the link labels that represent them in the database
-      have a flat hierarchy, and so the link labels are flattened representations of the nested namespaces.
-      This function reconstructs the original node nesting based on the flattened links.
-
-      :return: dictionary of nested namespaces
-      :raises KeyError: if there are duplicate link labels in a namespace
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkManager.nested
+         :renderer: rst
 
 .. py:class:: LinkPair
    :canonical: aiida.orm.utils.links.LinkPair
 
    Bases: :py:obj:`typing.NamedTuple`
 
+   .. autodoc2-docstring:: aiida.orm.utils.links.LinkPair
+      :renderer: rst
+
    .. py:attribute:: link_type
       :canonical: aiida.orm.utils.links.LinkPair.link_type
       :type: aiida.common.links.LinkType
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkPair.link_type
+         :renderer: rst
 
    .. py:attribute:: link_label
       :canonical: aiida.orm.utils.links.LinkPair.link_label
       :type: str
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkPair.link_label
+         :renderer: rst
+
 .. py:class:: LinkTriple
    :canonical: aiida.orm.utils.links.LinkTriple
 
    Bases: :py:obj:`typing.NamedTuple`
+
+   .. autodoc2-docstring:: aiida.orm.utils.links.LinkTriple
+      :renderer: rst
 
    .. py:attribute:: node
       :canonical: aiida.orm.utils.links.LinkTriple.node
       :type: aiida.orm.Node
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkTriple.node
+         :renderer: rst
+
    .. py:attribute:: link_type
       :canonical: aiida.orm.utils.links.LinkTriple.link_type
       :type: aiida.common.links.LinkType
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkTriple.link_type
+         :renderer: rst
 
    .. py:attribute:: link_label
       :canonical: aiida.orm.utils.links.LinkTriple.link_label
       :type: str
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.utils.links.LinkTriple.link_label
+         :renderer: rst
+
 .. py:class:: List(value=None, **kwargs)
    :canonical: aiida.orm.nodes.data.list.List
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`, :py:obj:`collections.abc.MutableSequence`
 
-   `Data` sub class to represent a list.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.list.List
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialise a ``List`` node instance.
-
-   :param value: list to initialise the ``List`` node from
+   .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.__init__
+      :renderer: rst
 
    .. py:attribute:: _LIST_KEY
       :canonical: aiida.orm.nodes.data.list.List._LIST_KEY
       :value: 'list'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List._LIST_KEY
+         :renderer: rst
+
    .. py:method:: __getitem__(item)
       :canonical: aiida.orm.nodes.data.list.List.__getitem__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.__getitem__
+         :renderer: rst
 
    .. py:method:: __setitem__(key, value)
       :canonical: aiida.orm.nodes.data.list.List.__setitem__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.__setitem__
+         :renderer: rst
+
    .. py:method:: __delitem__(key)
       :canonical: aiida.orm.nodes.data.list.List.__delitem__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.__delitem__
+         :renderer: rst
 
    .. py:method:: __len__()
       :canonical: aiida.orm.nodes.data.list.List.__len__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.__len__
+         :renderer: rst
+
    .. py:method:: __str__()
       :canonical: aiida.orm.nodes.data.list.List.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.__str__
+         :renderer: rst
 
    .. py:method:: __eq__(other)
       :canonical: aiida.orm.nodes.data.list.List.__eq__
 
-      Return self==value.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.__eq__
+         :renderer: rst
 
    .. py:method:: append(value)
       :canonical: aiida.orm.nodes.data.list.List.append
 
-      S.append(value) -- append value to the end of the sequence
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.append
+         :renderer: rst
 
    .. py:method:: extend(value)
       :canonical: aiida.orm.nodes.data.list.List.extend
 
-      S.extend(iterable) -- extend sequence by appending elements from the iterable
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.extend
+         :renderer: rst
 
    .. py:method:: insert(i, value)
       :canonical: aiida.orm.nodes.data.list.List.insert
 
-      S.insert(index, value) -- insert value before index
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.insert
+         :renderer: rst
 
    .. py:method:: remove(value)
       :canonical: aiida.orm.nodes.data.list.List.remove
 
-      S.remove(value) -- remove first occurrence of value.
-      Raise ValueError if the value is not present.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.remove
+         :renderer: rst
 
    .. py:method:: pop(**kwargs)
       :canonical: aiida.orm.nodes.data.list.List.pop
 
-      Remove and return item at index (default last).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.pop
+         :renderer: rst
 
    .. py:method:: index(value)
       :canonical: aiida.orm.nodes.data.list.List.index
 
-      Return first index of value..
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.index
+         :renderer: rst
 
    .. py:method:: count(value)
       :canonical: aiida.orm.nodes.data.list.List.count
 
-      Return number of occurrences of value.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.count
+         :renderer: rst
 
    .. py:method:: sort(key=None, reverse=False)
       :canonical: aiida.orm.nodes.data.list.List.sort
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.sort
+         :renderer: rst
+
    .. py:method:: reverse()
       :canonical: aiida.orm.nodes.data.list.List.reverse
 
-      S.reverse() -- reverse *IN PLACE*
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.reverse
+         :renderer: rst
 
    .. py:method:: get_list()
       :canonical: aiida.orm.nodes.data.list.List.get_list
 
-      Return the contents of this node.
-
-      :return: a list
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.get_list
+         :renderer: rst
 
    .. py:method:: set_list(data)
       :canonical: aiida.orm.nodes.data.list.List.set_list
 
-      Set the contents of this node.
-
-      :param data: the list to set
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List.set_list
+         :renderer: rst
 
    .. py:method:: _using_list_reference()
       :canonical: aiida.orm.nodes.data.list.List._using_list_reference
 
-      This function tells the class if we are using a list reference.  This
-      means that calls to self.get_list return a reference rather than a copy
-      of the underlying list and therefore self.set_list need not be called.
-      This knwoledge is essential to make sure this class is performant.
-
-      Currently the implementation assumes that if the node needs to be
-      stored then it is using the attributes cache which is a reference.
-
-      :return: True if using self.get_list returns a reference to the
-          underlying sequence.  False otherwise.
-      :rtype: bool
+      .. autodoc2-docstring:: aiida.orm.nodes.data.list.List._using_list_reference
+         :renderer: rst
 
 .. py:class:: Log(time: datetime.datetime, loggername: str, levelname: str, dbnode_id: int, message: str = '', metadata: typing.Optional[typing.Dict[str, typing.Any]] = None, backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.logs.Log
 
    Bases: :py:obj:`aiida.orm.entities.Entity`\ [\ :py:obj:`aiida.orm.implementation.BackendLog`\ , :py:obj:`aiida.orm.logs.LogCollection`\ ]
 
-   An AiiDA Log entity.  Corresponds to a logged message against a particular AiiDA node.
+   .. autodoc2-docstring:: aiida.orm.logs.Log
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new log
-
-   :param time: time
-   :param loggername: name of logger
-   :param levelname: name of log level
-   :param dbnode_id: id of database node
-   :param message: log message
-   :param metadata: metadata
-   :param backend: database backend
+   .. autodoc2-docstring:: aiida.orm.logs.Log.__init__
+      :renderer: rst
 
    .. py:attribute:: _CLS_COLLECTION
       :canonical: aiida.orm.logs.Log._CLS_COLLECTION
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.logs.Log._CLS_COLLECTION
+         :renderer: rst
+
    .. py:property:: uuid
       :canonical: aiida.orm.logs.Log.uuid
       :type: str
 
-      Return the UUID for this log.
-
-      This identifier is unique across all entities types and backend instances.
-
-      :return: the entity uuid
+      .. autodoc2-docstring:: aiida.orm.logs.Log.uuid
+         :renderer: rst
 
    .. py:property:: time
       :canonical: aiida.orm.logs.Log.time
       :type: datetime.datetime
 
-      Get the time corresponding to the entry
-
-      :return: The entry timestamp
+      .. autodoc2-docstring:: aiida.orm.logs.Log.time
+         :renderer: rst
 
    .. py:property:: loggername
       :canonical: aiida.orm.logs.Log.loggername
       :type: str
 
-      The name of the logger that created this entry
-
-      :return: The entry loggername
+      .. autodoc2-docstring:: aiida.orm.logs.Log.loggername
+         :renderer: rst
 
    .. py:property:: levelname
       :canonical: aiida.orm.logs.Log.levelname
       :type: str
 
-      The name of the log level
-
-      :return: The entry log level name
+      .. autodoc2-docstring:: aiida.orm.logs.Log.levelname
+         :renderer: rst
 
    .. py:property:: dbnode_id
       :canonical: aiida.orm.logs.Log.dbnode_id
       :type: int
 
-      Get the id of the object that created the log entry
-
-      :return: The id of the object that created the log entry
+      .. autodoc2-docstring:: aiida.orm.logs.Log.dbnode_id
+         :renderer: rst
 
    .. py:property:: message
       :canonical: aiida.orm.logs.Log.message
       :type: str
 
-      Get the message corresponding to the entry
-
-      :return: The entry message
+      .. autodoc2-docstring:: aiida.orm.logs.Log.message
+         :renderer: rst
 
    .. py:property:: metadata
       :canonical: aiida.orm.logs.Log.metadata
       :type: typing.Dict[str, typing.Any]
 
-      Get the metadata corresponding to the entry
-
-      :return: The entry metadata
+      .. autodoc2-docstring:: aiida.orm.logs.Log.metadata
+         :renderer: rst
 
 .. py:class:: Node(backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None, user: typing.Optional[aiida.orm.users.User] = None, computer: typing.Optional[aiida.orm.computers.Computer] = None, **kwargs: typing.Any)
    :canonical: aiida.orm.nodes.node.Node
 
    Bases: :py:obj:`aiida.orm.entities.Entity`\ [\ :py:obj:`aiida.orm.implementation.BackendNode`\ , :py:obj:`aiida.orm.nodes.node.NodeCollection`\ ]
 
-   Base class for all nodes in AiiDA.
-
-   Stores attributes starting with an underscore.
-
-   Caches files and attributes before the first save, and saves everything
-   only on store(). After the call to store(), attributes cannot be changed.
-
-   Only after storing (or upon loading from uuid) extras can be modified
-   and in this case they are directly set on the db.
-
-   In the plugin, also set the _plugin_type_string, to be set in the DB in
-   the 'type' field.
+   .. autodoc2-docstring:: aiida.orm.nodes.node.Node
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   :param backend_entity: the backend model supporting this entity
+   .. autodoc2-docstring:: aiida.orm.nodes.node.Node.__init__
+      :renderer: rst
 
    .. py:attribute:: _CLS_COLLECTION
       :canonical: aiida.orm.nodes.node.Node._CLS_COLLECTION
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._CLS_COLLECTION
+         :renderer: rst
+
    .. py:attribute:: _CLS_NODE_LINKS
       :canonical: aiida.orm.nodes.node.Node._CLS_NODE_LINKS
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._CLS_NODE_LINKS
+         :renderer: rst
+
    .. py:attribute:: _CLS_NODE_CACHING
       :canonical: aiida.orm.nodes.node.Node._CLS_NODE_CACHING
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._CLS_NODE_CACHING
+         :renderer: rst
 
    .. py:attribute:: _plugin_type_string
       :canonical: aiida.orm.nodes.node.Node._plugin_type_string
       :type: typing.ClassVar[str]
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._plugin_type_string
+         :renderer: rst
+
    .. py:attribute:: _query_type_string
       :canonical: aiida.orm.nodes.node.Node._query_type_string
       :type: typing.ClassVar[str]
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._query_type_string
+         :renderer: rst
 
    .. py:attribute:: _logger
       :canonical: aiida.orm.nodes.node.Node._logger
       :type: typing.Optional[logging.Logger]
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._logger
+         :renderer: rst
+
    .. py:attribute:: _updatable_attributes
       :canonical: aiida.orm.nodes.node.Node._updatable_attributes
       :type: typing.Tuple[str, ...]
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._updatable_attributes
+         :renderer: rst
 
    .. py:attribute:: _hash_ignored_attributes
       :canonical: aiida.orm.nodes.node.Node._hash_ignored_attributes
       :type: typing.Tuple[str, ...]
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._hash_ignored_attributes
+         :renderer: rst
+
    .. py:attribute:: _cachable
       :canonical: aiida.orm.nodes.node.Node._cachable
       :value: False
+
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._cachable
+         :renderer: rst
 
    .. py:attribute:: _storable
       :canonical: aiida.orm.nodes.node.Node._storable
       :value: False
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._storable
+         :renderer: rst
+
    .. py:attribute:: _unstorable_message
       :canonical: aiida.orm.nodes.node.Node._unstorable_message
       :value: 'only Data, WorkflowNode, CalculationNode or their subclasses can be stored'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._unstorable_message
+         :renderer: rst
+
    .. py:method:: base() -> aiida.orm.nodes.node.NodeBase
       :canonical: aiida.orm.nodes.node.Node.base
 
-      Return the node base namespace.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.base
+         :renderer: rst
 
    .. py:method:: _check_mutability_attributes(keys: typing.Optional[typing.List[str]] = None) -> None
       :canonical: aiida.orm.nodes.node.Node._check_mutability_attributes
 
-      Check if the entity is mutable and raise an exception if not.
-
-      This is called from `NodeAttributes` methods that modify the attributes.
-
-      :param keys: the keys that will be mutated, or all if None
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._check_mutability_attributes
+         :renderer: rst
 
    .. py:method:: __eq__(other: typing.Any) -> bool
       :canonical: aiida.orm.nodes.node.Node.__eq__
 
-      Fallback equality comparison by uuid (can be overwritten by specific types)
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.__eq__
+         :renderer: rst
 
    .. py:method:: __hash__() -> int
       :canonical: aiida.orm.nodes.node.Node.__hash__
 
-      Python-Hash: Implementation that is compatible with __eq__
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.__hash__
+         :renderer: rst
 
    .. py:method:: __repr__() -> str
       :canonical: aiida.orm.nodes.node.Node.__repr__
 
-      Return repr(self).
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.__repr__
+         :renderer: rst
 
    .. py:method:: __str__() -> str
       :canonical: aiida.orm.nodes.node.Node.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.__str__
+         :renderer: rst
 
    .. py:method:: __copy__()
       :canonical: aiida.orm.nodes.node.Node.__copy__
 
-      Copying a Node is not supported in general, but only for the Data sub class.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.__copy__
+         :renderer: rst
 
    .. py:method:: __deepcopy__(memo)
       :canonical: aiida.orm.nodes.node.Node.__deepcopy__
 
-      Deep copying a Node is not supported in general, but only for the Data sub class.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.__deepcopy__
+         :renderer: rst
 
    .. py:method:: _validate() -> bool
       :canonical: aiida.orm.nodes.node.Node._validate
 
-      Validate information stored in Node object.
-
-      For the :py:class:`~aiida.orm.Node` base class, this check is always valid.
-      Subclasses can override this method to perform additional checks
-      and should usually call ``super()._validate()`` first!
-
-      This method is called automatically before storing the node in the DB.
-      Therefore, use :py:meth:`~aiida.orm.nodes.attributes.NodeAttributes.get()` and similar methods that
-      automatically read either from the DB or from the internal attribute cache.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._validate
+         :renderer: rst
 
    .. py:method:: _validate_storability() -> None
       :canonical: aiida.orm.nodes.node.Node._validate_storability
 
-      Verify that the current node is allowed to be stored.
-
-      :raises `aiida.common.exceptions.StoringNotAllowed`: if the node does not match all requirements for storing
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._validate_storability
+         :renderer: rst
 
    .. py:method:: class_node_type() -> str
       :canonical: aiida.orm.nodes.node.Node.class_node_type
 
-      Returns the node type of this node (sub) class.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.class_node_type
+         :renderer: rst
 
    .. py:method:: entry_point() -> typing.Optional[aiida.plugins.entry_point.EntryPoint]
       :canonical: aiida.orm.nodes.node.Node.entry_point
 
-      Return the entry point associated this node class.
-
-      :return: the associated entry point or ``None`` if it isn't known.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.entry_point
+         :renderer: rst
 
    .. py:property:: logger
       :canonical: aiida.orm.nodes.node.Node.logger
       :type: typing.Optional[logging.Logger]
 
-      Return the logger configured for this Node.
-
-      :return: Logger object
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.logger
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.orm.nodes.node.Node.uuid
       :type: str
 
-      Return the node UUID.
-
-      :return: the string representation of the UUID
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.uuid
+         :renderer: rst
 
    .. py:property:: node_type
       :canonical: aiida.orm.nodes.node.Node.node_type
       :type: str
 
-      Return the node type.
-
-      :return: the node type
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.node_type
+         :renderer: rst
 
    .. py:property:: process_type
       :canonical: aiida.orm.nodes.node.Node.process_type
       :type: typing.Optional[str]
 
-      Return the node process type.
-
-      :return: the process type
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.process_type
+         :renderer: rst
 
    .. py:property:: label
       :canonical: aiida.orm.nodes.node.Node.label
       :type: str
 
-      Return the node label.
-
-      :return: the label
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.label
+         :renderer: rst
 
    .. py:property:: description
       :canonical: aiida.orm.nodes.node.Node.description
       :type: str
 
-      Return the node description.
-
-      :return: the description
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.description
+         :renderer: rst
 
    .. py:property:: computer
       :canonical: aiida.orm.nodes.node.Node.computer
       :type: typing.Optional[aiida.orm.computers.Computer]
 
-      Return the computer of this node.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.computer
+         :renderer: rst
 
    .. py:property:: user
       :canonical: aiida.orm.nodes.node.Node.user
       :type: aiida.orm.users.User
 
-      Return the user of this node.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.user
+         :renderer: rst
 
    .. py:property:: ctime
       :canonical: aiida.orm.nodes.node.Node.ctime
       :type: datetime.datetime
 
-      Return the node ctime.
-
-      :return: the ctime
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.ctime
+         :renderer: rst
 
    .. py:property:: mtime
       :canonical: aiida.orm.nodes.node.Node.mtime
       :type: datetime.datetime
 
-      Return the node mtime.
-
-      :return: the mtime
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.mtime
+         :renderer: rst
 
    .. py:method:: store_all(with_transaction: bool = True) -> aiida.orm.nodes.node.Node
       :canonical: aiida.orm.nodes.node.Node.store_all
 
-      Store the node, together with all input links.
-
-      Unstored nodes from cached incoming linkswill also be stored.
-
-      :parameter with_transaction: if False, do not use a transaction because the caller will already have opened one.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.store_all
+         :renderer: rst
 
    .. py:method:: store(with_transaction: bool = True) -> aiida.orm.nodes.node.Node
       :canonical: aiida.orm.nodes.node.Node.store
 
-      Store the node in the database while saving its attributes and repository directory.
-
-      After being called attributes cannot be changed anymore! Instead, extras can be changed only AFTER calling
-      this store() function.
-
-      :note: After successful storage, those links that are in the cache, and for which also the parent node is
-          already stored, will be automatically stored. The others will remain unstored.
-
-      :parameter with_transaction: if False, do not use a transaction because the caller will already have opened one.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.store
+         :renderer: rst
 
    .. py:method:: _store(with_transaction: bool = True, clean: bool = True) -> aiida.orm.nodes.node.Node
       :canonical: aiida.orm.nodes.node.Node._store
 
-      Store the node in the database while saving its attributes and repository directory.
-
-      :param with_transaction: if False, do not use a transaction because the caller will already have opened one.
-      :param clean: boolean, if True, will clean the attributes and extras before attempting to store
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._store
+         :renderer: rst
 
    .. py:method:: _verify_are_parents_stored() -> None
       :canonical: aiida.orm.nodes.node.Node._verify_are_parents_stored
 
-      Verify that all `parent` nodes are already stored.
-
-      :raise aiida.common.ModificationNotAllowed: if one of the source nodes of incoming links is not stored.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._verify_are_parents_stored
+         :renderer: rst
 
    .. py:method:: _store_from_cache(cache_node: aiida.orm.nodes.node.Node, with_transaction: bool) -> None
       :canonical: aiida.orm.nodes.node.Node._store_from_cache
 
-      Store this node from an existing cache node.
-
-      .. note::
-
-          With the current implementation of the backend repository, which automatically deduplicates the content that
-          it contains, we do not have to copy the contents of the source node. Since the content should be exactly
-          equal, the repository will already contain it and there is nothing to copy. We simply replace the current
-          ``repository`` instance with a clone of that of the source node, which does not actually copy any files.
-
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._store_from_cache
+         :renderer: rst
 
    .. py:method:: _add_outputs_from_cache(cache_node: aiida.orm.nodes.node.Node) -> None
       :canonical: aiida.orm.nodes.node.Node._add_outputs_from_cache
 
-      Replicate the output links and nodes from the cached node onto this node.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._add_outputs_from_cache
+         :renderer: rst
 
    .. py:method:: get_description() -> str
       :canonical: aiida.orm.nodes.node.Node.get_description
 
-      Return a string with a description of the node.
-
-      :return: a description string
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.get_description
+         :renderer: rst
 
    .. py:property:: is_valid_cache
       :canonical: aiida.orm.nodes.node.Node.is_valid_cache
       :type: bool
 
-      Hook to exclude certain ``Node`` classes from being considered a valid cache.
-
-      The base class assumes that all node instances are valid to cache from, unless the ``_VALID_CACHE_KEY`` extra
-      has been set to ``False`` explicitly. Subclasses can override this property with more specific logic, but should
-      probably also consider the value returned by this base class.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.is_valid_cache
+         :renderer: rst
 
    .. py:attribute:: _deprecated_repo_methods
       :canonical: aiida.orm.nodes.node.Node._deprecated_repo_methods
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._deprecated_repo_methods
+         :renderer: rst
+
    .. py:attribute:: _deprecated_attr_methods
       :canonical: aiida.orm.nodes.node.Node._deprecated_attr_methods
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._deprecated_attr_methods
+         :renderer: rst
 
    .. py:attribute:: _deprecated_extra_methods
       :canonical: aiida.orm.nodes.node.Node._deprecated_extra_methods
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._deprecated_extra_methods
+         :renderer: rst
+
    .. py:attribute:: _deprecated_comment_methods
       :canonical: aiida.orm.nodes.node.Node._deprecated_comment_methods
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._deprecated_comment_methods
+         :renderer: rst
 
    .. py:attribute:: _deprecated_caching_methods
       :canonical: aiida.orm.nodes.node.Node._deprecated_caching_methods
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._deprecated_caching_methods
+         :renderer: rst
+
    .. py:attribute:: _deprecated_links_methods
       :canonical: aiida.orm.nodes.node.Node._deprecated_links_methods
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node._deprecated_links_methods
+         :renderer: rst
+
    .. py:method:: Collection()
       :canonical: aiida.orm.nodes.node.Node.Collection
 
-      Return the collection type for this class.
-
-      This used to be a class argument with the value ``NodeCollection``. The argument is deprecated and this property
-      is here for backwards compatibility to print the deprecation warning.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.Collection
+         :renderer: rst
 
    .. py:method:: __getattr__(name: str) -> typing.Any
       :canonical: aiida.orm.nodes.node.Node.__getattr__
 
-      This method is called when an attribute is not found in the instance.
-
-      It allows for the handling of deprecated mixin methods.
+      .. autodoc2-docstring:: aiida.orm.nodes.node.Node.__getattr__
+         :renderer: rst
 
 .. py:class:: NodeAttributes(node: aiida.orm.nodes.node.Node)
    :canonical: aiida.orm.nodes.attributes.NodeAttributes
 
-   Interface to the attributes of a node instance.
-
-   Attributes are a JSONable dictionary, stored on each node,
-   allowing for arbitrary data to be stored by node subclasses (and thus data plugins).
-
-   Once the node is stored, the attributes are generally deemed immutable
-   (except for some updatable keys on process nodes, which can be mutated whilst the node is not "sealed").
+   .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize the interface.
+   .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.__init__
+      :renderer: rst
 
    .. py:method:: __contains__(key: str) -> bool
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.__contains__
 
-      Check if the node contains an attribute with the given key.
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.__contains__
+         :renderer: rst
 
    .. py:property:: all
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.all
       :type: typing.Dict[str, typing.Any]
 
-      Return the complete attributes dictionary.
-
-      .. warning:: While the entity is unstored, this will return references of the attributes on the database model,
-          meaning that changes on the returned values (if they are mutable themselves, e.g. a list or dictionary) will
-          automatically be reflected on the database model as well. As soon as the entity is stored, the returned
-          attributes will be a deep copy and mutations of the database attributes will have to go through the
-          appropriate set methods. Therefore, once stored, retrieving a deep copy can be a heavy operation. If you
-          only need the keys or some values, use the iterators `keys` and `items`, or the
-          getters `get` and `get_many` instead.
-
-      :return: the attributes as a dictionary
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.all
+         :renderer: rst
 
    .. py:method:: get(key: str, default=_NO_DEFAULT) -> typing.Any
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.get
 
-      Return the value of an attribute.
-
-      .. warning:: While the entity is unstored, this will return a reference of the attribute on the database model,
-          meaning that changes on the returned value (if they are mutable themselves, e.g. a list or dictionary) will
-          automatically be reflected on the database model as well. As soon as the entity is stored, the returned
-          attribute will be a deep copy and mutations of the database attributes will have to go through the
-          appropriate set methods.
-
-      :param key: name of the attribute
-      :param default: return this value instead of raising if the attribute does not exist
-      :return: the value of the attribute
-      :raises AttributeError: if the attribute does not exist and no default is specified
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.get
+         :renderer: rst
 
    .. py:method:: get_many(keys: typing.List[str]) -> typing.List[typing.Any]
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.get_many
 
-      Return the values of multiple attributes.
-
-      .. warning:: While the entity is unstored, this will return references of the attributes on the database model,
-          meaning that changes on the returned values (if they are mutable themselves, e.g. a list or dictionary) will
-          automatically be reflected on the database model as well. As soon as the entity is stored, the returned
-          attributes will be a deep copy and mutations of the database attributes will have to go through the
-          appropriate set methods. Therefore, once stored, retrieving a deep copy can be a heavy operation. If you
-          only need the keys or some values, use the iterators `keys` and `items`, or the
-          getters `get` and `get_many` instead.
-
-      :param keys: a list of attribute names
-      :return: a list of attribute values
-      :raises AttributeError: if at least one attribute does not exist
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.get_many
+         :renderer: rst
 
    .. py:method:: set(key: str, value: typing.Any) -> None
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.set
 
-      Set an attribute to the given value.
-
-      :param key: name of the attribute
-      :param value: value of the attribute
-      :raise aiida.common.ValidationError: if the key is invalid, i.e. contains periods
-      :raise aiida.common.ModificationNotAllowed: if the entity is stored
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.set
+         :renderer: rst
 
    .. py:method:: set_many(attributes: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.set_many
 
-      Set multiple attributes.
-
-      .. note:: This will override any existing attributes that are present in the new dictionary.
-
-      :param attributes: a dictionary with the attributes to set
-      :raise aiida.common.ValidationError: if any of the keys are invalid, i.e. contain periods
-      :raise aiida.common.ModificationNotAllowed: if the entity is stored
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.set_many
+         :renderer: rst
 
    .. py:method:: reset(attributes: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.reset
 
-      Reset the attributes.
-
-      .. note:: This will completely clear any existing attributes and replace them with the new dictionary.
-
-      :param attributes: a dictionary with the attributes to set
-      :raise aiida.common.ValidationError: if any of the keys are invalid, i.e. contain periods
-      :raise aiida.common.ModificationNotAllowed: if the entity is stored
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.reset
+         :renderer: rst
 
    .. py:method:: delete(key: str) -> None
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.delete
 
-      Delete an attribute.
-
-      :param key: name of the attribute
-      :raises AttributeError: if the attribute does not exist
-      :raise aiida.common.ModificationNotAllowed: if the entity is stored
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.delete
+         :renderer: rst
 
    .. py:method:: delete_many(keys: typing.List[str]) -> None
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.delete_many
 
-      Delete multiple attributes.
-
-      :param keys: names of the attributes to delete
-      :raises AttributeError: if at least one of the attribute does not exist
-      :raise aiida.common.ModificationNotAllowed: if the entity is stored
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.delete_many
+         :renderer: rst
 
    .. py:method:: clear() -> None
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.clear
 
-      Delete all attributes.
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.clear
+         :renderer: rst
 
    .. py:method:: items() -> typing.Iterable[typing.Tuple[str, typing.Any]]
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.items
 
-      Return an iterator over the attributes.
-
-      :return: an iterator with attribute key value pairs
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.items
+         :renderer: rst
 
    .. py:method:: keys() -> typing.Iterable[str]
       :canonical: aiida.orm.nodes.attributes.NodeAttributes.keys
 
-      Return an iterator over the attribute keys.
-
-      :return: an iterator with attribute keys
+      .. autodoc2-docstring:: aiida.orm.nodes.attributes.NodeAttributes.keys
+         :renderer: rst
 
 .. py:class:: NodeEntityLoader
    :canonical: aiida.orm.utils.loaders.NodeEntityLoader
 
    Bases: :py:obj:`aiida.orm.utils.loaders.OrmEntityLoader`
 
-   Loader for the `Node` entity and sub classes.
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.NodeEntityLoader
+      :renderer: rst
 
    .. py:method:: orm_base_class()
       :canonical: aiida.orm.utils.loaders.NodeEntityLoader.orm_base_class
 
-      Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
-      may further narrow the query set by defining a more specific set of orm classes, as long as each of
-      those is a strict sub class of the orm base class.
-
-      :returns: the orm base class
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.NodeEntityLoader.orm_base_class
+         :renderer: rst
 
    .. py:method:: _get_query_builder_label_identifier(identifier, classes, operator='==', project='*')
       :canonical: aiida.orm.utils.loaders.NodeEntityLoader._get_query_builder_label_identifier
       :classmethod:
 
-      Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
-      defined for this loader class, interpreting the identifier as a LABEL like identifier
-
-      :param identifier: the LABEL identifier
-      :param classes: a tuple of orm classes to which the identifier should be mapped
-      :param operator: the operator to use in the query
-      :param project: the property or properties to project for entities matching the query
-      :returns: the query builder instance that should retrieve the entity corresponding to the identifier
-      :raises ValueError: if the identifier is invalid
-      :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.NodeEntityLoader._get_query_builder_label_identifier
+         :renderer: rst
 
 .. py:class:: NodeLinksManager(node, link_type, incoming)
    :canonical: aiida.orm.utils.managers.NodeLinksManager
 
-   A manager that allows to inspect, with tab-completion, nodes linked to a given one.
-   See an example of its use in `CalculationNode.inputs`.
+   .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialise the link manager.
-
-   :param node: the reference node object
-   :param link_type: the link_type to inspect
-   :param incoming: if True, inspect incoming links, otherwise inspect
-       outgoing links
+   .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager.__init__
+      :renderer: rst
 
    .. py:attribute:: _namespace_separator
       :canonical: aiida.orm.utils.managers.NodeLinksManager._namespace_separator
       :value: '__'
 
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager._namespace_separator
+         :renderer: rst
+
    .. py:method:: _construct_attribute_dict(incoming)
       :canonical: aiida.orm.utils.managers.NodeLinksManager._construct_attribute_dict
 
-      Construct an attribute dict from all links of the node, recreating nested namespaces from flat link labels.
-
-      :param incoming: if True, inspect incoming links, otherwise inspect outgoing links.
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager._construct_attribute_dict
+         :renderer: rst
 
    .. py:method:: _get_keys()
       :canonical: aiida.orm.utils.managers.NodeLinksManager._get_keys
 
-      Return the valid link labels, used e.g. to make getattr() work
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager._get_keys
+         :renderer: rst
 
    .. py:method:: _get_node_by_link_label(label)
       :canonical: aiida.orm.utils.managers.NodeLinksManager._get_node_by_link_label
 
-      Return the linked node with a given link label.
-
-      Nested namespaces in link labels get represented by double underscores in the database. Up until now, the link
-      manager didn't automatically unroll these again into nested namespaces and so a user was forced to pass the link
-      with double underscores to dereference the corresponding node. For example, when used with the ``inputs``
-      attribute of a ``ProcessNode`` one had to do:
-
-          node.inputs.nested__sub__namespace
-
-      Now it is possible to do
-
-          node.inputs.nested.sub.namespace
-
-      which is more intuitive since the double underscore replacement is just for the database and the user shouldn't
-      even have to know about it. For compatibility we support the old version a bit longer and it will emit a
-      deprecation warning.
-
-      :param label: the link label connecting the current node to the node to get.
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager._get_node_by_link_label
+         :renderer: rst
 
    .. py:method:: __dir__()
       :canonical: aiida.orm.utils.managers.NodeLinksManager.__dir__
 
-      Allow to list all valid input links
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager.__dir__
+         :renderer: rst
 
    .. py:method:: __iter__()
       :canonical: aiida.orm.utils.managers.NodeLinksManager.__iter__
 
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager.__iter__
+         :renderer: rst
+
    .. py:method:: __getattr__(name)
       :canonical: aiida.orm.utils.managers.NodeLinksManager.__getattr__
 
-      :param name: name of the attribute to be asked to the parser results.
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager.__getattr__
+         :renderer: rst
 
    .. py:method:: __contains__(key)
       :canonical: aiida.orm.utils.managers.NodeLinksManager.__contains__
 
-      Override the operator of the base class to emit deprecation warning if double underscore is used in key.
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager.__contains__
+         :renderer: rst
 
    .. py:method:: __getitem__(name)
       :canonical: aiida.orm.utils.managers.NodeLinksManager.__getitem__
 
-      interface to get to the parser results as a dictionary.
-
-      :param name: name of the attribute to be asked to the parser results.
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager.__getitem__
+         :renderer: rst
 
    .. py:method:: __str__()
       :canonical: aiida.orm.utils.managers.NodeLinksManager.__str__
 
-      Return a string representation of the manager
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager.__str__
+         :renderer: rst
 
    .. py:method:: __repr__()
       :canonical: aiida.orm.utils.managers.NodeLinksManager.__repr__
 
-      Return repr(self).
+      .. autodoc2-docstring:: aiida.orm.utils.managers.NodeLinksManager.__repr__
+         :renderer: rst
 
 .. py:class:: NodeRepository(node: aiida.orm.nodes.node.Node)
    :canonical: aiida.orm.nodes.repository.NodeRepository
 
-   Interface to the file repository of a node instance.
-
-   This is the compatibility layer between the `Node` class and the `Repository` class. The repository in principle has
-   no concept of immutability, so it is implemented here. Any mutating operations will raise a `ModificationNotAllowed`
-   exception if the node is stored. Otherwise the operation is just forwarded to the repository instance.
-
-   The repository instance keeps an internal mapping of the file hierarchy that it maintains, starting from an empty
-   hierarchy if the instance was constructed normally, or from a specific hierarchy if reconstructred through the
-   ``Repository.from_serialized`` classmethod. This is only the case for stored nodes, because unstored nodes do not
-   have any files yet when they are constructed. Once the node get's stored, the repository is asked to serialize its
-   metadata contents which is then stored in the ``repository_metadata`` field of the backend node.
-   This layer explicitly does not update the metadata of the node on a mutation action.
-   The reason is that for stored nodes these actions are anyway forbidden and for unstored nodes,
-   the final metadata will be stored in one go, once the node is stored,
-   so there is no need to keep updating the node metadata intermediately.
-   Note that this does mean that ``repository_metadata`` does not give accurate information,
-   as long as the node is not yet stored.
+   .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance of the repository interface.
+   .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.__init__
+      :renderer: rst
 
    .. py:property:: metadata
       :canonical: aiida.orm.nodes.repository.NodeRepository.metadata
       :type: typing.Dict[str, typing.Any]
 
-      Return the repository metadata, representing the virtual file hierarchy.
-
-      Note, this is only accurate if the node is stored.
-
-      :return: the repository metadata
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.metadata
+         :renderer: rst
 
    .. py:method:: _update_repository_metadata()
       :canonical: aiida.orm.nodes.repository.NodeRepository._update_repository_metadata
 
-      Refresh the repository metadata of the node if it is stored.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository._update_repository_metadata
+         :renderer: rst
 
    .. py:method:: _check_mutability()
       :canonical: aiida.orm.nodes.repository.NodeRepository._check_mutability
 
-      Check if the node is mutable.
-
-      :raises `~aiida.common.exceptions.ModificationNotAllowed`: when the node is stored and therefore immutable.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository._check_mutability
+         :renderer: rst
 
    .. py:property:: _repository
       :canonical: aiida.orm.nodes.repository.NodeRepository._repository
       :type: aiida.repository.Repository
 
-      Return the repository instance, lazily constructing it if necessary.
-
-      .. note:: this property is protected because a node's repository should not be accessed outside of its scope.
-
-      :return: the file repository instance.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository._repository
+         :renderer: rst
 
    .. py:method:: _store() -> None
       :canonical: aiida.orm.nodes.repository.NodeRepository._store
 
-      Store the repository in the backend.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository._store
+         :renderer: rst
 
    .. py:method:: _copy(repo: aiida.orm.nodes.repository.NodeRepository) -> None
       :canonical: aiida.orm.nodes.repository.NodeRepository._copy
 
-      Copy a repository from another instance.
-
-      This is used when storing cached nodes.
-
-      :param repo: the repository to clone.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository._copy
+         :renderer: rst
 
    .. py:method:: _clone(repo: aiida.orm.nodes.repository.NodeRepository) -> None
       :canonical: aiida.orm.nodes.repository.NodeRepository._clone
 
-      Clone the repository from another instance.
-
-      This is used when cloning a node.
-
-      :param repo: the repository to clone.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository._clone
+         :renderer: rst
 
    .. py:method:: serialize() -> typing.Dict
       :canonical: aiida.orm.nodes.repository.NodeRepository.serialize
 
-      Serialize the metadata of the repository content into a JSON-serializable format.
-
-      :return: dictionary with the content metadata.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.serialize
+         :renderer: rst
 
    .. py:method:: hash() -> str
       :canonical: aiida.orm.nodes.repository.NodeRepository.hash
 
-      Generate a hash of the repository's contents.
-
-      :return: the hash representing the contents of the repository.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.hash
+         :renderer: rst
 
    .. py:method:: list_objects(path: typing.Optional[str] = None) -> typing.List[aiida.repository.File]
       :canonical: aiida.orm.nodes.repository.NodeRepository.list_objects
 
-      Return a list of the objects contained in this repository sorted by name, optionally in given sub directory.
-
-      :param path: the relative path where to store the object in the repository.
-      :return: a list of `File` named tuples representing the objects present in directory with the given key.
-      :raises TypeError: if the path is not a string and relative path.
-      :raises FileNotFoundError: if no object exists for the given path.
-      :raises NotADirectoryError: if the object at the given path is not a directory.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.list_objects
+         :renderer: rst
 
    .. py:method:: list_object_names(path: typing.Optional[str] = None) -> typing.List[str]
       :canonical: aiida.orm.nodes.repository.NodeRepository.list_object_names
 
-      Return a sorted list of the object names contained in this repository, optionally in the given sub directory.
-
-      :param path: the relative path where to store the object in the repository.
-      :return: a list of `File` named tuples representing the objects present in directory with the given key.
-      :raises TypeError: if the path is not a string and relative path.
-      :raises FileNotFoundError: if no object exists for the given path.
-      :raises NotADirectoryError: if the object at the given path is not a directory.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.list_object_names
+         :renderer: rst
 
    .. py:method:: open(path: str, mode='r') -> typing.Iterator[typing.Union[typing.BinaryIO, typing.TextIO]]
       :canonical: aiida.orm.nodes.repository.NodeRepository.open
 
-      Open a file handle to an object stored under the given key.
-
-      .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
-          ``put_object_from_filelike`` instead.
-
-      :param path: the relative path of the object within the repository.
-      :return: yield a byte stream object.
-      :raises TypeError: if the path is not a string and relative path.
-      :raises FileNotFoundError: if the file does not exist.
-      :raises IsADirectoryError: if the object is a directory and not a file.
-      :raises OSError: if the file could not be opened.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.open
+         :renderer: rst
 
    .. py:method:: get_object(path: typing.Optional[aiida.orm.nodes.repository.FilePath] = None) -> aiida.repository.File
       :canonical: aiida.orm.nodes.repository.NodeRepository.get_object
 
-      Return the object at the given path.
-
-      :param path: the relative path where to store the object in the repository.
-      :return: the `File` representing the object located at the given relative path.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
-      :raises FileNotFoundError: if no object exists for the given path.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.get_object
+         :renderer: rst
 
    .. py:method:: get_object_content(path: str, mode='r') -> typing.Union[str, bytes]
       :canonical: aiida.orm.nodes.repository.NodeRepository.get_object_content
 
-      Return the content of a object identified by key.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :raises TypeError: if the path is not a string and relative path.
-      :raises FileNotFoundError: if the file does not exist.
-      :raises IsADirectoryError: if the object is a directory and not a file.
-      :raises OSError: if the file could not be opened.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.get_object_content
+         :renderer: rst
 
    .. py:method:: put_object_from_bytes(content: bytes, path: str) -> None
       :canonical: aiida.orm.nodes.repository.NodeRepository.put_object_from_bytes
 
-      Store the given content in the repository at the given path.
-
-      :param path: the relative path where to store the object in the repository.
-      :param content: the content to store.
-      :raises TypeError: if the path is not a string and relative path.
-      :raises FileExistsError: if an object already exists at the given path.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.put_object_from_bytes
+         :renderer: rst
 
    .. py:method:: put_object_from_filelike(handle: io.BufferedReader, path: str)
       :canonical: aiida.orm.nodes.repository.NodeRepository.put_object_from_filelike
 
-      Store the byte contents of a file in the repository.
-
-      :param handle: filelike object with the byte content to be stored.
-      :param path: the relative path where to store the object in the repository.
-      :raises TypeError: if the path is not a string and relative path.
-      :raises `~aiida.common.exceptions.ModificationNotAllowed`: when the node is stored and therefore immutable.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.put_object_from_filelike
+         :renderer: rst
 
    .. py:method:: put_object_from_file(filepath: str, path: str)
       :canonical: aiida.orm.nodes.repository.NodeRepository.put_object_from_file
 
-      Store a new object under `path` with contents of the file located at `filepath` on the local file system.
-
-      :param filepath: absolute path of file whose contents to copy to the repository
-      :param path: the relative path where to store the object in the repository.
-      :raises TypeError: if the path is not a string and relative path, or the handle is not a byte stream.
-      :raises `~aiida.common.exceptions.ModificationNotAllowed`: when the node is stored and therefore immutable.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.put_object_from_file
+         :renderer: rst
 
    .. py:method:: put_object_from_tree(filepath: str, path: typing.Optional[str] = None)
       :canonical: aiida.orm.nodes.repository.NodeRepository.put_object_from_tree
 
-      Store the entire contents of `filepath` on the local file system in the repository with under given `path`.
-
-      :param filepath: absolute path of the directory whose contents to copy to the repository.
-      :param path: the relative path where to store the objects in the repository.
-      :raises TypeError: if the path is not a string and relative path.
-      :raises `~aiida.common.exceptions.ModificationNotAllowed`: when the node is stored and therefore immutable.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.put_object_from_tree
+         :renderer: rst
 
    .. py:method:: walk(path: typing.Optional[aiida.orm.nodes.repository.FilePath] = None) -> typing.Iterable[typing.Tuple[pathlib.PurePosixPath, typing.List[str], typing.List[str]]]
       :canonical: aiida.orm.nodes.repository.NodeRepository.walk
 
-      Walk over the directories and files contained within this repository.
-
-      .. note:: the order of the dirname and filename lists that are returned is not necessarily sorted. This is in
-          line with the ``os.walk`` implementation where the order depends on the underlying file system used.
-
-      :param path: the relative path of the directory within the repository whose contents to walk.
-      :return: tuples of root, dirnames and filenames just like ``os.walk``, with the exception that the root path is
-          always relative with respect to the repository root, instead of an absolute path and it is an instance of
-          ``pathlib.PurePosixPath`` instead of a normal string
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.walk
+         :renderer: rst
 
    .. py:method:: glob() -> typing.Iterable[pathlib.PurePosixPath]
       :canonical: aiida.orm.nodes.repository.NodeRepository.glob
 
-      Yield a recursive list of all paths (files and directories).
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.glob
+         :renderer: rst
 
    .. py:method:: copy_tree(target: typing.Union[str, pathlib.Path], path: typing.Optional[aiida.orm.nodes.repository.FilePath] = None) -> None
       :canonical: aiida.orm.nodes.repository.NodeRepository.copy_tree
 
-      Copy the contents of the entire node repository to another location on the local file system.
-
-      :param target: absolute path of the directory where to copy the contents to.
-      :param path: optional relative path whose contents to copy.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.copy_tree
+         :renderer: rst
 
    .. py:method:: delete_object(path: str)
       :canonical: aiida.orm.nodes.repository.NodeRepository.delete_object
 
-      Delete the object from the repository.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :raises TypeError: if the path is not a string and relative path.
-      :raises FileNotFoundError: if the file does not exist.
-      :raises IsADirectoryError: if the object is a directory and not a file.
-      :raises OSError: if the file could not be deleted.
-      :raises `~aiida.common.exceptions.ModificationNotAllowed`: when the node is stored and therefore immutable.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.delete_object
+         :renderer: rst
 
    .. py:method:: erase()
       :canonical: aiida.orm.nodes.repository.NodeRepository.erase
 
-      Delete all objects from the repository.
-
-      :raises `~aiida.common.exceptions.ModificationNotAllowed`: when the node is stored and therefore immutable.
+      .. autodoc2-docstring:: aiida.orm.nodes.repository.NodeRepository.erase
+         :renderer: rst
 
 .. py:class:: NumericType
    :canonical: aiida.orm.nodes.data.numeric.NumericType
 
    Bases: :py:obj:`aiida.orm.nodes.data.base.BaseType`
 
-   Sub class of Data to store numbers, overloading common operators (``+``, ``*``, ...).
+   .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType
+      :renderer: rst
 
    .. py:method:: __add__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__add__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__add__
+         :renderer: rst
+
    .. py:method:: __radd__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__radd__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__radd__
+         :renderer: rst
 
    .. py:method:: __sub__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__sub__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__sub__
+         :renderer: rst
+
    .. py:method:: __rsub__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__rsub__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__rsub__
+         :renderer: rst
 
    .. py:method:: __mul__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__mul__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__mul__
+         :renderer: rst
+
    .. py:method:: __rmul__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__rmul__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__rmul__
+         :renderer: rst
 
    .. py:method:: __div__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__div__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__div__
+         :renderer: rst
+
    .. py:method:: __rdiv__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__rdiv__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__rdiv__
+         :renderer: rst
 
    .. py:method:: __truediv__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__truediv__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__truediv__
+         :renderer: rst
+
    .. py:method:: __rtruediv__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__rtruediv__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__rtruediv__
+         :renderer: rst
 
    .. py:method:: __floordiv__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__floordiv__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__floordiv__
+         :renderer: rst
+
    .. py:method:: __rfloordiv__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__rfloordiv__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__rfloordiv__
+         :renderer: rst
 
    .. py:method:: __pow__(power)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__pow__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__pow__
+         :renderer: rst
+
    .. py:method:: __lt__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__lt__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__lt__
+         :renderer: rst
 
    .. py:method:: __le__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__le__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__le__
+         :renderer: rst
+
    .. py:method:: __gt__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__gt__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__gt__
+         :renderer: rst
 
    .. py:method:: __ge__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__ge__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__ge__
+         :renderer: rst
+
    .. py:method:: __mod__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__mod__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__mod__
+         :renderer: rst
 
    .. py:method:: __rmod__(other)
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__rmod__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__rmod__
+         :renderer: rst
+
    .. py:method:: __float__()
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__float__
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__float__
+         :renderer: rst
+
    .. py:method:: __int__()
       :canonical: aiida.orm.nodes.data.numeric.NumericType.__int__
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.numeric.NumericType.__int__
+         :renderer: rst
 
 .. py:class:: OrbitalData
    :canonical: aiida.orm.nodes.data.orbital.OrbitalData
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   Used for storing collections of orbitals, as well as
-   providing methods for accessing them internally.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.orbital.OrbitalData
+      :renderer: rst
 
    .. py:method:: clear_orbitals()
       :canonical: aiida.orm.nodes.data.orbital.OrbitalData.clear_orbitals
 
-      Remove all orbitals that were added to the class
-      Cannot work if OrbitalData has been already stored
+      .. autodoc2-docstring:: aiida.orm.nodes.data.orbital.OrbitalData.clear_orbitals
+         :renderer: rst
 
    .. py:method:: get_orbitals(**kwargs)
       :canonical: aiida.orm.nodes.data.orbital.OrbitalData.get_orbitals
 
-      Returns all orbitals by default. If a site is provided, returns
-      all orbitals cooresponding to the location of that site, additional
-      arguments may be provided, which act as filters on the retrieved
-      orbitals.
-
-      :param site: if provided, returns all orbitals with position of site
-      :kwargs: attributes than can filter the set of returned orbitals
-      :return list_of_outputs: a list of orbitals
+      .. autodoc2-docstring:: aiida.orm.nodes.data.orbital.OrbitalData.get_orbitals
+         :renderer: rst
 
    .. py:method:: set_orbitals(orbitals)
       :canonical: aiida.orm.nodes.data.orbital.OrbitalData.set_orbitals
 
-      Sets the orbitals into the database. Uses the orbital's inherent
-      set_orbital_dict method to generate a orbital dict string.
-
-      :param orbital: an orbital or list of orbitals to be set
+      .. autodoc2-docstring:: aiida.orm.nodes.data.orbital.OrbitalData.set_orbitals
+         :renderer: rst
 
 .. py:function:: OrderSpecifier(field, direction)
    :canonical: aiida.orm.logs.OrderSpecifier
 
+   .. autodoc2-docstring:: aiida.orm.logs.OrderSpecifier
+      :renderer: rst
+
 .. py:class:: OrmEntityLoader
    :canonical: aiida.orm.utils.loaders.OrmEntityLoader
 
-   Base class for entity loaders.
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader
+      :renderer: rst
 
    .. py:attribute:: label_ambiguity_breaker
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader.label_ambiguity_breaker
       :value: '!'
 
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader.label_ambiguity_breaker
+         :renderer: rst
+
    .. py:method:: orm_base_class()
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader.orm_base_class
       :abstractmethod:
 
-      Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
-      may further narrow the query set by defining a more specific set of orm classes, as long as each of
-      those is a strict sub class of the orm base class.
-
-      :returns: the orm base class
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader.orm_base_class
+         :renderer: rst
 
    .. py:method:: _get_query_builder_label_identifier(identifier, classes, operator='==', project='*')
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader._get_query_builder_label_identifier
       :abstractmethod:
       :classmethod:
 
-      Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
-      defined for this loader class, interpreting the identifier as a LABEL like identifier
-
-      :param identifier: the LABEL identifier
-      :param classes: a tuple of orm classes to which the identifier should be mapped
-      :param operator: the operator to use in the query
-      :param project: the property or properties to project for entities matching the query
-      :returns: the query builder instance
-      :raises ValueError: if the identifier is invalid
-      :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader._get_query_builder_label_identifier
+         :renderer: rst
 
    .. py:method:: _get_query_builder_id_identifier(identifier, classes)
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader._get_query_builder_id_identifier
       :classmethod:
 
-      Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
-      defined for this loader class, interpreting the identifier as an ID like identifier
-
-      :param identifier: the ID identifier
-      :param classes: a tuple of orm classes to which the identifier should be mapped
-      :returns: the query builder instance
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader._get_query_builder_id_identifier
+         :renderer: rst
 
    .. py:method:: _get_query_builder_uuid_identifier(identifier, classes, query_with_dashes)
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader._get_query_builder_uuid_identifier
       :classmethod:
 
-      Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
-      defined for this loader class, interpreting the identifier as a UUID like identifier
-
-      :param identifier: the UUID identifier
-      :param classes: a tuple of orm classes to which the identifier should be mapped
-      :returns: the query builder instance
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader._get_query_builder_uuid_identifier
+         :renderer: rst
 
    .. py:method:: get_query_builder(identifier, identifier_type=None, sub_classes=None, query_with_dashes=True, operator='==', project='*')
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader.get_query_builder
       :classmethod:
 
-      Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
-      defined for this loader class, inferring the identifier type if it is not defined.
-
-      :param identifier: the identifier
-      :param identifier_type: the type of the identifier
-      :param sub_classes: an optional tuple of orm classes, that should each be strict sub classes of the
-          base orm class of the loader, that will narrow the queryset
-      :param operator: the operator to use in the query
-      :param project: the property or properties to project for entities matching the query
-      :returns: the query builder instance and a dictionary of used query parameters
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader.get_query_builder
+         :renderer: rst
 
    .. py:method:: get_options(incomplete, project='*')
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader.get_options
       :classmethod:
 
-      Return the list of entities that match the `incomplete` identifier.
-
-      .. note:: For the time being only `LABEL` auto-completion is supported so the identifier type is not inferred
-          but hard-coded to be `IdentifierType.LABEL`
-
-      :param incomplete: the incomplete identifier
-      :param project: the field(s) to project for each entity that matches the incomplete identifier
-      :return: list of entities matching the incomplete identifier
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader.get_options
+         :renderer: rst
 
    .. py:method:: load_entity(identifier, identifier_type=None, sub_classes=None, query_with_dashes=True)
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader.load_entity
       :classmethod:
 
-      Load an entity that uniquely corresponds to the provided identifier of the identifier type.
-
-      :param identifier: the identifier
-      :param identifier_type: the type of the identifier
-      :param sub_classes: an optional tuple of orm classes, that should each be strict sub classes of the
-          base orm class of the loader, that will narrow the queryset
-      :returns: the loaded entity
-      :raises aiida.common.MultipleObjectsError: if the identifier maps onto multiple entities
-      :raises aiida.common.NotExistent: if the identifier maps onto not a single entity
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader.load_entity
+         :renderer: rst
 
    .. py:method:: get_query_classes(sub_classes=None)
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader.get_query_classes
       :classmethod:
 
-      Get the tuple of classes to be used for the entity query. If sub_classes is defined, each class will be
-      validated by verifying that it is a sub class of the loader's orm base class.
-      Validate a tuple of classes if a user passes in a specific one when attempting to load an entity. Each class
-      should be a sub class of the entity loader's orm base class
-
-      :param sub_classes: an optional tuple of orm classes, that should each be strict sub classes of the
-          base orm class of the loader, that will narrow the queryset
-      :returns: the tuple of orm classes to be used for the entity query
-      :raises ValueError: if any of the classes are not a sub class of the entity loader's orm base class
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader.get_query_classes
+         :renderer: rst
 
    .. py:method:: infer_identifier_type(value)
       :canonical: aiida.orm.utils.loaders.OrmEntityLoader.infer_identifier_type
       :classmethod:
 
-      This method will attempt to automatically distinguish which identifier type is implied for the given value, if
-      the value itself has no type from which it can be inferred.
-
-      The strategy is to first attempt to convert the value to an integer. If successful, it is assumed that the value
-      represents an ID. If that fails, we attempt to interpret the value as a base 16 encoded integer, after having
-      removed any dashes from the string. If that succeeds, it is most likely a UUID. If it seems to be neither an ID
-      nor a UUID, it is assumed to be a LABEL like identifier.
-
-      With this approach there is the possibility for ambiguity. Since it is allowed to pass a partial UUID, it is
-      possible that the partial UUID is also a valid ID. Likewise, a LABEL identifier might also be a valid ID, or a
-      valid (partial) UUID. Fortunately, these ambiguities can be solved though:
-
-       * ID/UUID: can always be solved by passing a partial UUID with at least one dash
-       * ID/LABEL: appending an exclamation point ! to the identifier, will force LABEL interpretation
-       * UUID/LABEL: appending an exclamation point ! to the identifier, will force LABEL interpretation
-
-      As one can see, the user will always be able to include at least one dash of the UUID identifier to prevent it
-      from being interpreted as an ID. For the potential ambiguities in LABEL identifiers, we had to introduce a
-      special marker to provide a surefire way of breaking any ambiguity that may arise. Adding an exclamation point
-      will break the normal strategy and the identifier will directly be interpreted as a LABEL identifier.
-
-      :param value: the value of the identifier
-      :returns: the identifier and identifier type
-      :raises ValueError: if the value is an invalid identifier
+      .. autodoc2-docstring:: aiida.orm.utils.loaders.OrmEntityLoader.infer_identifier_type
+         :renderer: rst
 
 .. py:class:: PortableCode(filepath_executable: str, filepath_files: pathlib.Path, **kwargs)
    :canonical: aiida.orm.nodes.data.code.portable.PortableCode
 
    Bases: :py:obj:`aiida.orm.nodes.data.code.legacy.Code`
 
-   Data plugin representing an executable code stored in AiiDA's storage.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance.
-
-   .. note:: If the files necessary for this code are not all located in a single directory or the directory
-       contains files that should not be uploaded, and so the ``filepath_files`` cannot be used. One can use the
-       methods of the :class:`aiida.orm.nodes.repository.NodeRepository` class. This can be accessed through the
-       ``base.repository`` attribute of the instance after it has been constructed. For example::
-
-           code = PortableCode(filepath_executable='some_name.exe')
-           code.put_object_from_file()
-           code.put_object_from_filelike()
-           code.put_object_from_tree()
-
-   :param filepath_executable: The relative filepath of the executable within the directory of uploaded files.
-   :param filepath_files: The filepath to the directory containing all the files of the code.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode.__init__
+      :renderer: rst
 
    .. py:attribute:: _KEY_ATTRIBUTE_FILEPATH_EXECUTABLE
       :canonical: aiida.orm.nodes.data.code.portable.PortableCode._KEY_ATTRIBUTE_FILEPATH_EXECUTABLE
       :type: str
       :value: 'filepath_executable'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode._KEY_ATTRIBUTE_FILEPATH_EXECUTABLE
+         :renderer: rst
+
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.code.portable.PortableCode._validate
 
-      Validate the instance by checking that an executable is defined and it is part of the repository files.
-
-      :raises :class:`aiida.common.exceptions.ValidationError`: If the state of the node is invalid.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode._validate
+         :renderer: rst
 
    .. py:method:: can_run_on_computer(computer: aiida.orm.Computer) -> bool
       :canonical: aiida.orm.nodes.data.code.portable.PortableCode.can_run_on_computer
 
-      Return whether the code can run on a given computer.
-
-      A ``PortableCode`` should be able to be run on any computer in principle.
-
-      :param computer: The computer.
-      :return: ``True`` if the provided computer is the same as the one configured for this code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode.can_run_on_computer
+         :renderer: rst
 
    .. py:method:: get_executable() -> pathlib.PurePosixPath
       :canonical: aiida.orm.nodes.data.code.portable.PortableCode.get_executable
 
-      Return the executable that the submission script should execute to run the code.
-
-      :return: The executable to be called in the submission script.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode.get_executable
+         :renderer: rst
 
    .. py:method:: validate_working_directory(folder: aiida.common.folders.Folder)
       :canonical: aiida.orm.nodes.data.code.portable.PortableCode.validate_working_directory
 
-      Validate content of the working directory created by the :class:`~aiida.engine.CalcJob` plugin.
-
-      This method will be called by :meth:`~aiida.engine.processes.calcjobs.calcjob.CalcJob.presubmit` when a new
-      calculation job is launched, passing the :class:`~aiida.common.folders.Folder` that was used by the plugin used
-      for the calculation to create the input files for the working directory. This method can be overridden by
-      implementations of the ``AbstractCode`` class that need to validate the contents of that folder.
-
-      :param folder: A sandbox folder that the ``CalcJob`` plugin wrote input files to that will be copied to the
-          working directory for the corresponding calculation job instance.
-      :raises PluginInternalError: The ``CalcJob`` plugin created a file that has the same relative filepath as the
-          executable for this portable code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode.validate_working_directory
+         :renderer: rst
 
    .. py:property:: full_label
       :canonical: aiida.orm.nodes.data.code.portable.PortableCode.full_label
       :type: str
 
-      Return the full label of this code.
-
-      The full label can be just the label itself but it can be something else. However, it at the very least has to
-      include the label of the code.
-
-      :return: The full label of the code.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode.full_label
+         :renderer: rst
 
    .. py:property:: filepath_executable
       :canonical: aiida.orm.nodes.data.code.portable.PortableCode.filepath_executable
       :type: pathlib.PurePosixPath
 
-      Return the relative filepath of the executable that this code represents.
-
-      :return: The relative filepath of the executable.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode.filepath_executable
+         :renderer: rst
 
    .. py:method:: _get_cli_options() -> dict
       :canonical: aiida.orm.nodes.data.code.portable.PortableCode._get_cli_options
       :classmethod:
 
-      Return the CLI options that would allow to create an instance of this class.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.code.portable.PortableCode._get_cli_options
+         :renderer: rst
 
 .. py:class:: ProcessNode(backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None, user: typing.Optional[aiida.orm.users.User] = None, computer: typing.Optional[aiida.orm.computers.Computer] = None, **kwargs: typing.Any)
    :canonical: aiida.orm.nodes.process.process.ProcessNode
 
    Bases: :py:obj:`aiida.orm.utils.mixins.Sealable`, :py:obj:`aiida.orm.nodes.node.Node`
 
-   Base class for all nodes representing the execution of a process
-
-   This class and its subclasses serve as proxies in the database, for actual `Process` instances being run. The
-   `Process` instance in memory will leverage an instance of this class (the exact sub class depends on the sub class
-   of `Process`) to persist important information of its state to the database. This serves as a way for the user to
-   inspect the state of the `Process` during its execution as well as a permanent record of its execution in the
-   provenance graph, after the execution has terminated.
+   .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   :param backend_entity: the backend model supporting this entity
+   .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.__init__
+      :renderer: rst
 
    .. py:attribute:: _CLS_NODE_LINKS
       :canonical: aiida.orm.nodes.process.process.ProcessNode._CLS_NODE_LINKS
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode._CLS_NODE_LINKS
+         :renderer: rst
+
    .. py:attribute:: _CLS_NODE_CACHING
       :canonical: aiida.orm.nodes.process.process.ProcessNode._CLS_NODE_CACHING
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode._CLS_NODE_CACHING
+         :renderer: rst
 
    .. py:attribute:: CHECKPOINT_KEY
       :canonical: aiida.orm.nodes.process.process.ProcessNode.CHECKPOINT_KEY
       :value: 'checkpoints'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.CHECKPOINT_KEY
+         :renderer: rst
+
    .. py:attribute:: EXCEPTION_KEY
       :canonical: aiida.orm.nodes.process.process.ProcessNode.EXCEPTION_KEY
       :value: 'exception'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.EXCEPTION_KEY
+         :renderer: rst
 
    .. py:attribute:: EXIT_MESSAGE_KEY
       :canonical: aiida.orm.nodes.process.process.ProcessNode.EXIT_MESSAGE_KEY
       :value: 'exit_message'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.EXIT_MESSAGE_KEY
+         :renderer: rst
+
    .. py:attribute:: EXIT_STATUS_KEY
       :canonical: aiida.orm.nodes.process.process.ProcessNode.EXIT_STATUS_KEY
       :value: 'exit_status'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.EXIT_STATUS_KEY
+         :renderer: rst
 
    .. py:attribute:: PROCESS_PAUSED_KEY
       :canonical: aiida.orm.nodes.process.process.ProcessNode.PROCESS_PAUSED_KEY
       :value: 'paused'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.PROCESS_PAUSED_KEY
+         :renderer: rst
+
    .. py:attribute:: PROCESS_LABEL_KEY
       :canonical: aiida.orm.nodes.process.process.ProcessNode.PROCESS_LABEL_KEY
       :value: 'process_label'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.PROCESS_LABEL_KEY
+         :renderer: rst
 
    .. py:attribute:: PROCESS_STATE_KEY
       :canonical: aiida.orm.nodes.process.process.ProcessNode.PROCESS_STATE_KEY
       :value: 'process_state'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.PROCESS_STATE_KEY
+         :renderer: rst
+
    .. py:attribute:: PROCESS_STATUS_KEY
       :canonical: aiida.orm.nodes.process.process.ProcessNode.PROCESS_STATUS_KEY
       :value: 'process_status'
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.PROCESS_STATUS_KEY
+         :renderer: rst
 
    .. py:attribute:: _unstorable_message
       :canonical: aiida.orm.nodes.process.process.ProcessNode._unstorable_message
       :value: 'only Data, WorkflowNode, CalculationNode or their subclasses can be stored'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode._unstorable_message
+         :renderer: rst
+
    .. py:method:: __str__() -> str
       :canonical: aiida.orm.nodes.process.process.ProcessNode.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.__str__
+         :renderer: rst
 
    .. py:method:: _updatable_attributes() -> typing.Tuple[str, ...]
       :canonical: aiida.orm.nodes.process.process.ProcessNode._updatable_attributes
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode._updatable_attributes
+         :renderer: rst
+
    .. py:property:: logger
       :canonical: aiida.orm.nodes.process.process.ProcessNode.logger
 
-      Get the logger of the Calculation object, so that it also logs to the DB.
-
-      :return: LoggerAdapter object, that works like a logger, but also has the 'extra' embedded
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.logger
+         :renderer: rst
 
    .. py:method:: get_builder_restart() -> aiida.engine.processes.builder.ProcessBuilder
       :canonical: aiida.orm.nodes.process.process.ProcessNode.get_builder_restart
 
-      Return a `ProcessBuilder` that is ready to relaunch the process that created this node.
-
-      The process class will be set based on the `process_type` of this node and the inputs of the builder will be
-      prepopulated with the inputs registered for this node. This functionality is very useful if a process has
-      completed and you want to relaunch it with slightly different inputs.
-
-      :return: `~aiida.engine.processes.builder.ProcessBuilder` instance
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.get_builder_restart
+         :renderer: rst
 
    .. py:property:: process_class
       :canonical: aiida.orm.nodes.process.process.ProcessNode.process_class
       :type: typing.Type[aiida.engine.processes.Process]
 
-      Return the process class that was used to create this node.
-
-      :return: `Process` class
-      :raises ValueError: if no process type is defined, it is an invalid process type string or cannot be resolved
-          to load the corresponding class
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.process_class
+         :renderer: rst
 
    .. py:method:: set_process_type(process_type_string: str) -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.set_process_type
 
-      Set the process type string.
-
-      :param process_type: the process type string identifying the class using this process node as storage.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.set_process_type
+         :renderer: rst
 
    .. py:property:: process_label
       :canonical: aiida.orm.nodes.process.process.ProcessNode.process_label
       :type: typing.Optional[str]
 
-      Return the process label
-
-      :returns: the process label
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.process_label
+         :renderer: rst
 
    .. py:method:: set_process_label(label: str) -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.set_process_label
 
-      Set the process label
-
-      :param label: process label string
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.set_process_label
+         :renderer: rst
 
    .. py:property:: process_state
       :canonical: aiida.orm.nodes.process.process.ProcessNode.process_state
       :type: typing.Optional[plumpy.process_states.ProcessState]
 
-      Return the process state
-
-      :returns: the process state instance of ProcessState enum
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.process_state
+         :renderer: rst
 
    .. py:method:: set_process_state(state: typing.Union[str, plumpy.process_states.ProcessState, None])
       :canonical: aiida.orm.nodes.process.process.ProcessNode.set_process_state
 
-      Set the process state
-
-      :param state: value or instance of ProcessState enum
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.set_process_state
+         :renderer: rst
 
    .. py:property:: process_status
       :canonical: aiida.orm.nodes.process.process.ProcessNode.process_status
       :type: typing.Optional[str]
 
-      Return the process status
-
-      The process status is a generic status message e.g. the reason it might be paused or when it is being killed
-
-      :returns: the process status
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.process_status
+         :renderer: rst
 
    .. py:method:: set_process_status(status: typing.Optional[str]) -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.set_process_status
 
-      Set the process status
-
-      The process status is a generic status message e.g. the reason it might be paused or when it is being killed.
-      If status is None, the corresponding attribute will be deleted.
-
-      :param status: string process status
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.set_process_status
+         :renderer: rst
 
    .. py:property:: is_terminated
       :canonical: aiida.orm.nodes.process.process.ProcessNode.is_terminated
       :type: bool
 
-      Return whether the process has terminated
-
-      Terminated means that the process has reached any terminal state.
-
-      :return: True if the process has terminated, False otherwise
-      :rtype: bool
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.is_terminated
+         :renderer: rst
 
    .. py:property:: is_excepted
       :canonical: aiida.orm.nodes.process.process.ProcessNode.is_excepted
       :type: bool
 
-      Return whether the process has excepted
-
-      Excepted means that during execution of the process, an exception was raised that was not caught.
-
-      :return: True if during execution of the process an exception occurred, False otherwise
-      :rtype: bool
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.is_excepted
+         :renderer: rst
 
    .. py:property:: is_killed
       :canonical: aiida.orm.nodes.process.process.ProcessNode.is_killed
       :type: bool
 
-      Return whether the process was killed
-
-      Killed means the process was killed directly by the user or by the calling process being killed.
-
-      :return: True if the process was killed, False otherwise
-      :rtype: bool
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.is_killed
+         :renderer: rst
 
    .. py:property:: is_finished
       :canonical: aiida.orm.nodes.process.process.ProcessNode.is_finished
       :type: bool
 
-      Return whether the process has finished
-
-      Finished means that the process reached a terminal state nominally.
-      Note that this does not necessarily mean successfully, but there were no exceptions and it was not killed.
-
-      :return: True if the process has finished, False otherwise
-      :rtype: bool
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.is_finished
+         :renderer: rst
 
    .. py:property:: is_finished_ok
       :canonical: aiida.orm.nodes.process.process.ProcessNode.is_finished_ok
       :type: bool
 
-      Return whether the process has finished successfully
-
-      Finished successfully means that it terminated nominally and had a zero exit status.
-
-      :return: True if the process has finished successfully, False otherwise
-      :rtype: bool
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.is_finished_ok
+         :renderer: rst
 
    .. py:property:: is_failed
       :canonical: aiida.orm.nodes.process.process.ProcessNode.is_failed
       :type: bool
 
-      Return whether the process has failed
-
-      Failed means that the process terminated nominally but it had a non-zero exit status.
-
-      :return: True if the process has failed, False otherwise
-      :rtype: bool
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.is_failed
+         :renderer: rst
 
    .. py:property:: exit_status
       :canonical: aiida.orm.nodes.process.process.ProcessNode.exit_status
       :type: typing.Optional[int]
 
-      Return the exit status of the process
-
-      :returns: the exit status, an integer exit code or None
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.exit_status
+         :renderer: rst
 
    .. py:method:: set_exit_status(status: typing.Union[None, enum.Enum, int]) -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.set_exit_status
 
-      Set the exit status of the process
-
-      :param state: an integer exit code or None, which will be interpreted as zero
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.set_exit_status
+         :renderer: rst
 
    .. py:property:: exit_message
       :canonical: aiida.orm.nodes.process.process.ProcessNode.exit_message
       :type: typing.Optional[str]
 
-      Return the exit message of the process
-
-      :returns: the exit message
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.exit_message
+         :renderer: rst
 
    .. py:method:: set_exit_message(message: typing.Optional[str]) -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.set_exit_message
 
-      Set the exit message of the process, if None nothing will be done
-
-      :param message: a string message
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.set_exit_message
+         :renderer: rst
 
    .. py:property:: exception
       :canonical: aiida.orm.nodes.process.process.ProcessNode.exception
       :type: typing.Optional[str]
 
-      Return the exception of the process or None if the process is not excepted.
-
-      If the process is marked as excepted yet there is no exception attribute, an empty string will be returned.
-
-      :returns: the exception message or None
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.exception
+         :renderer: rst
 
    .. py:method:: set_exception(exception: str) -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.set_exception
 
-      Set the exception of the process
-
-      :param exception: the exception message
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.set_exception
+         :renderer: rst
 
    .. py:property:: checkpoint
       :canonical: aiida.orm.nodes.process.process.ProcessNode.checkpoint
       :type: typing.Optional[typing.Dict[str, typing.Any]]
 
-      Return the checkpoint bundle set for the process
-
-      :returns: checkpoint bundle if it exists, None otherwise
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.checkpoint
+         :renderer: rst
 
    .. py:method:: set_checkpoint(checkpoint: typing.Dict[str, typing.Any]) -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.set_checkpoint
 
-      Set the checkpoint bundle set for the process
-
-      :param state: string representation of the stepper state info
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.set_checkpoint
+         :renderer: rst
 
    .. py:method:: delete_checkpoint() -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.delete_checkpoint
 
-      Delete the checkpoint bundle set for the process
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.delete_checkpoint
+         :renderer: rst
 
    .. py:property:: paused
       :canonical: aiida.orm.nodes.process.process.ProcessNode.paused
       :type: bool
 
-      Return whether the process is paused
-
-      :returns: True if the Calculation is marked as paused, False otherwise
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.paused
+         :renderer: rst
 
    .. py:method:: pause() -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.pause
 
-      Mark the process as paused by setting the corresponding attribute.
-
-      This serves only to reflect that the corresponding Process is paused and so this method should not be called
-      by anyone but the Process instance itself.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.pause
+         :renderer: rst
 
    .. py:method:: unpause() -> None
       :canonical: aiida.orm.nodes.process.process.ProcessNode.unpause
 
-      Mark the process as unpaused by removing the corresponding attribute.
-
-      This serves only to reflect that the corresponding Process is unpaused and so this method should not be called
-      by anyone but the Process instance itself.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.unpause
+         :renderer: rst
 
    .. py:property:: called
       :canonical: aiida.orm.nodes.process.process.ProcessNode.called
       :type: typing.List[aiida.orm.nodes.process.process.ProcessNode]
 
-      Return a list of nodes that the process called
-
-      :returns: list of process nodes called by this process
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.called
+         :renderer: rst
 
    .. py:property:: called_descendants
       :canonical: aiida.orm.nodes.process.process.ProcessNode.called_descendants
       :type: typing.List[aiida.orm.nodes.process.process.ProcessNode]
 
-      Return a list of all nodes that have been called downstream of this process
-
-      This will recursively find all the called processes for this process and its children.
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.called_descendants
+         :renderer: rst
 
    .. py:property:: caller
       :canonical: aiida.orm.nodes.process.process.ProcessNode.caller
       :type: typing.Optional[aiida.orm.nodes.process.process.ProcessNode]
 
-      Return the process node that called this process node, or None if it does not have a caller
-
-      :returns: process node that called this process node instance or None
+      .. autodoc2-docstring:: aiida.orm.nodes.process.process.ProcessNode.caller
+         :renderer: rst
 
 .. py:class:: ProjectionData(*args, source=None, **kwargs)
    :canonical: aiida.orm.nodes.data.array.projection.ProjectionData
 
    Bases: :py:obj:`aiida.orm.nodes.data.orbital.OrbitalData`, :py:obj:`aiida.orm.nodes.data.array.array.ArrayData`
 
-   A class to handle arrays of projected wavefunction data. That is projections
-   of a orbitals, usually an atomic-hydrogen orbital, onto a
-   given bloch wavefunction, the bloch wavefunction being indexed by
-   s, n, and k. E.g. the elements are the projections described as
-   < orbital | Bloch wavefunction (s,n,k) >
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance, setting the ``source`` attribute if provided as a keyword argument.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData.__init__
+      :renderer: rst
 
    .. py:method:: _check_projections_bands(projection_array)
       :canonical: aiida.orm.nodes.data.array.projection.ProjectionData._check_projections_bands
 
-      Checks to make sure that a reference bandsdata is already set, and that
-      projection_array is of the same shape of the bands data
-
-      :param projwfc_arrays: nk x nb x nwfc array, to be
-                             checked against bands
-
-      :raise: AttributeError if energy is not already set
-      :raise: AttributeError if input_array is not of same shape as
-              dos_energy
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData._check_projections_bands
+         :renderer: rst
 
    .. py:method:: set_reference_bandsdata(value)
       :canonical: aiida.orm.nodes.data.array.projection.ProjectionData.set_reference_bandsdata
 
-      Sets a reference bandsdata, creates a uuid link between this data
-      object and a bandsdata object, must be set before any projection arrays
-
-      :param value: a BandsData instance, a uuid or a pk
-      :raise: exceptions.NotExistent if there was no BandsData associated with uuid or pk
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData.set_reference_bandsdata
+         :renderer: rst
 
    .. py:method:: get_reference_bandsdata()
       :canonical: aiida.orm.nodes.data.array.projection.ProjectionData.get_reference_bandsdata
 
-      Returns the reference BandsData, using the set uuid via
-      set_reference_bandsdata
-
-      :return: a BandsData instance
-      :raise AttributeError: if the bandsdata has not been set yet
-      :raise exceptions.NotExistent: if the bandsdata uuid did not retrieve bandsdata
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData.get_reference_bandsdata
+         :renderer: rst
 
    .. py:method:: _find_orbitals_and_indices(**kwargs)
       :canonical: aiida.orm.nodes.data.array.projection.ProjectionData._find_orbitals_and_indices
 
-      Finds all the orbitals and their indicies associated with kwargs
-      essential for retrieving the other indexed array parameters
-
-      :param kwargs: kwargs that can call orbitals as in get_orbitals()
-      :return: retrieve_indexes, list of indicicies of orbitals corresponding
-               to the kwargs
-      :return: all_orbitals, list of orbitals to which the indexes correspond
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData._find_orbitals_and_indices
+         :renderer: rst
 
    .. py:method:: get_pdos(**kwargs)
       :canonical: aiida.orm.nodes.data.array.projection.ProjectionData.get_pdos
 
-      Retrieves all the pdos arrays corresponding to the input kwargs
-
-      :param kwargs: inputs describing the orbitals associated with the pdos
-                     arrays
-      :return: a list of tuples containing the orbital, energy array and pdos
-               array associated with all orbitals that correspond to kwargs
-
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData.get_pdos
+         :renderer: rst
 
    .. py:method:: get_projections(**kwargs)
       :canonical: aiida.orm.nodes.data.array.projection.ProjectionData.get_projections
 
-      Retrieves all the pdos arrays corresponding to the input kwargs
-
-      :param kwargs: inputs describing the orbitals associated with the pdos
-                     arrays
-      :return: a list of tuples containing the orbital, and projection arrays
-               associated with all orbitals that correspond to kwargs
-
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData.get_projections
+         :renderer: rst
 
    .. py:method:: _from_index_to_arrayname(index)
       :canonical: aiida.orm.nodes.data.array.projection.ProjectionData._from_index_to_arrayname
       :staticmethod:
 
-      Used internally to determine the array names.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData._from_index_to_arrayname
+         :renderer: rst
 
    .. py:method:: set_projectiondata(list_of_orbitals, list_of_projections=None, list_of_energy=None, list_of_pdos=None, tags=None, bands_check=True)
       :canonical: aiida.orm.nodes.data.array.projection.ProjectionData.set_projectiondata
 
-      Stores the projwfc_array using the projwfc_label, after validating both.
-
-      :param list_of_orbitals: list of orbitals, of class orbital data.
-                               They should be the ones up on which the
-                               projection array corresponds with.
-
-      :param list_of_projections: list of arrays of projections of a atomic
-                            wavefunctions onto bloch wavefunctions. Since the
-                            projection is for every bloch wavefunction which
-                            can be specified by its spin (if used), band, and
-                            kpoint the dimensions must be
-                            nspin x nbands x nkpoints for the projwfc array.
-                            Or nbands x nkpoints if spin is not used.
-
-      :param energy_axis: list of energy axis for the list_of_pdos
-
-      :param list_of_pdos: a list of projected density of states for the
-                           atomic wavefunctions, units in states/eV
-
-      :param tags: A list of tags, not supported currently.
-
-      :param bands_check: if false, skips checks of whether the bands has
-                          been already set, and whether the sizes match. For
-                          use in parsers, where the BandsData has not yet
-                          been stored and therefore get_reference_bandsdata
-                          cannot be called
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData.set_projectiondata
+         :renderer: rst
 
    .. py:method:: set_orbitals(**kwargs)
       :canonical: aiida.orm.nodes.data.array.projection.ProjectionData.set_orbitals
       :abstractmethod:
 
-      This method is inherited from OrbitalData, but is blocked here.
-      If used will raise a NotImplementedError
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.projection.ProjectionData.set_orbitals
+         :renderer: rst
 
 .. py:class:: QueryBuilder(backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None, *, debug: bool = False, path: typing.Optional[typing.Sequence[typing.Union[str, typing.Dict[str, typing.Any], aiida.orm.querybuilder.EntityClsType]]] = (), filters: typing.Optional[typing.Dict[str, aiida.orm.querybuilder.FilterType]] = None, project: typing.Optional[typing.Dict[str, aiida.orm.querybuilder.ProjectType]] = None, limit: typing.Optional[int] = None, offset: typing.Optional[int] = None, order_by: typing.Optional[aiida.orm.querybuilder.OrderByType] = None, distinct: bool = False)
    :canonical: aiida.orm.querybuilder.QueryBuilder
 
-   The class to query the AiiDA database.
-
-   Usage::
-
-       from aiida.orm.querybuilder import QueryBuilder
-       qb = QueryBuilder()
-       # Querying nodes:
-       qb.append(Node)
-       # retrieving the results:
-       results = qb.all()
-
+   .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Instantiates a QueryBuilder instance.
-
-   Which backend is used decided here based on backend-settings (taken from the user profile).
-   This cannot be overridden so far by the user.
-
-   :param debug:
-       Turn on debug mode. This feature prints information on the screen about the stages
-       of the QueryBuilder. Does not affect results.
-   :param path:
-       A list of the vertices to traverse. Leave empty if you plan on using the method
-       :func:`QueryBuilder.append`.
-   :param filters:
-       The filters to apply. You can specify the filters here, when appending to the query
-       using :func:`QueryBuilder.append` or even later using :func:`QueryBuilder.add_filter`.
-       Check latter gives API-details.
-   :param project:
-       The projections to apply. You can specify the projections here, when appending to the query
-       using :func:`QueryBuilder.append` or even later using :func:`QueryBuilder.add_projection`.
-       Latter gives you API-details.
-   :param limit:
-       Limit the number of rows to this number. Check :func:`QueryBuilder.limit`
-       for more information.
-   :param offset:
-       Set an offset for the results returned. Details in :func:`QueryBuilder.offset`.
-   :param order_by:
-       How to order the results. As the 2 above, can be set also at later stage,
-       check :func:`QueryBuilder.order_by` for more information.
-   :param distinct: Whether to return de-duplicated rows
-
+   .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.__init__
+      :renderer: rst
 
    .. py:attribute:: _EDGE_TAG_DELIM
       :canonical: aiida.orm.querybuilder.QueryBuilder._EDGE_TAG_DELIM
       :value: '--'
 
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder._EDGE_TAG_DELIM
+         :renderer: rst
+
    .. py:attribute:: _VALID_PROJECTION_KEYS
       :canonical: aiida.orm.querybuilder.QueryBuilder._VALID_PROJECTION_KEYS
       :value: ('func', 'cast')
+
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder._VALID_PROJECTION_KEYS
+         :renderer: rst
 
    .. py:property:: backend
       :canonical: aiida.orm.querybuilder.QueryBuilder.backend
       :type: aiida.orm.implementation.StorageBackend
 
-      Return the backend used by the QueryBuilder.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.backend
+         :renderer: rst
 
    .. py:method:: as_dict(copy: bool = True) -> aiida.orm.implementation.querybuilder.QueryDictType
       :canonical: aiida.orm.querybuilder.QueryBuilder.as_dict
 
-      Convert to a JSON serialisable dictionary representation of the query.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.as_dict
+         :renderer: rst
 
    .. py:property:: queryhelp
       :canonical: aiida.orm.querybuilder.QueryBuilder.queryhelp
       :type: aiida.orm.implementation.querybuilder.QueryDictType
 
-      "Legacy name for ``as_dict`` method.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.queryhelp
+         :renderer: rst
 
    .. py:method:: from_dict(dct: typing.Dict[str, typing.Any]) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.from_dict
       :classmethod:
 
-      Create an instance from a dictionary representation of the query.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.from_dict
+         :renderer: rst
 
    .. py:method:: __repr__() -> str
       :canonical: aiida.orm.querybuilder.QueryBuilder.__repr__
 
-      Return an unambiguous string representation of the instance.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.__repr__
+         :renderer: rst
 
    .. py:method:: __str__() -> str
       :canonical: aiida.orm.querybuilder.QueryBuilder.__str__
 
-      Return a readable string representation of the instance.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.__str__
+         :renderer: rst
 
    .. py:method:: __deepcopy__(memo) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.__deepcopy__
 
-      Create deep copy of the instance.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.__deepcopy__
+         :renderer: rst
 
    .. py:method:: get_used_tags(vertices: bool = True, edges: bool = True) -> typing.List[str]
       :canonical: aiida.orm.querybuilder.QueryBuilder.get_used_tags
 
-      Returns a list of all the vertices that are being used.
-
-      :param vertices: If True, adds the tags of vertices to the returned list
-      :param edges: If True, adds the tags of edges to the returnend list.
-
-      :returns: A list of tags
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.get_used_tags
+         :renderer: rst
 
    .. py:method:: _get_unique_tag(classifiers: typing.List[aiida.orm.querybuilder.Classifier]) -> str
       :canonical: aiida.orm.querybuilder.QueryBuilder._get_unique_tag
 
-      Using the function get_tag_from_type, I get a tag.
-      I increment an index that is appended to that tag until I have an unused tag.
-      This function is called in :func:`QueryBuilder.append` when no tag is given.
-
-      :param dict classifiers:
-          Classifiers, containing the string that defines the type of the AiiDA ORM class.
-          For subclasses of Node, this is the Node._plugin_type_string, for other they are
-          as defined as returned by :func:`QueryBuilder._get_ormclass`.
-
-          Can also be a list of dictionaries, when multiple classes are passed to QueryBuilder.append
-
-      :returns: A tag as a string (it is a single string also when passing multiple classes).
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder._get_unique_tag
+         :renderer: rst
 
    .. py:method:: append(cls: typing.Optional[typing.Union[aiida.orm.querybuilder.EntityClsType, typing.Sequence[aiida.orm.querybuilder.EntityClsType]]] = None, entity_type: typing.Optional[typing.Union[str, typing.Sequence[str]]] = None, tag: typing.Optional[str] = None, filters: typing.Optional[aiida.orm.querybuilder.FilterType] = None, project: typing.Optional[aiida.orm.querybuilder.ProjectType] = None, subclassing: bool = True, edge_tag: typing.Optional[str] = None, edge_filters: typing.Optional[aiida.orm.querybuilder.FilterType] = None, edge_project: typing.Optional[aiida.orm.querybuilder.ProjectType] = None, outerjoin: bool = False, joining_keyword: typing.Optional[str] = None, joining_value: typing.Optional[typing.Any] = None, orm_base: typing.Optional[str] = None, **kwargs: typing.Any) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.append
 
-      Any iterative procedure to build the path for a graph query
-      needs to invoke this method to append to the path.
-
-      :param cls:
-          The Aiida-class (or backend-class) defining the appended vertice.
-          Also supports a tuple/list of classes. This results in an all instances of
-          this class being accepted in a query. However the classes have to have the same orm-class
-          for the joining to work. I.e. both have to subclasses of Node. Valid is::
-
-              cls=(StructureData, Dict)
-
-          This is invalid:
-
-              cls=(Group, Node)
-
-      :param entity_type: The node type of the class, if cls is not given. Also here, a tuple or list is accepted.
-      :param tag:
-          A unique tag. If none is given, I will create a unique tag myself.
-      :param filters:
-          Filters to apply for this vertex.
-          See :meth:`.add_filter`, the method invoked in the background, or usage examples for details.
-      :param project:
-          Projections to apply. See usage examples for details.
-          More information also in :meth:`.add_projection`.
-      :param subclassing:
-          Whether to include subclasses of the given class (default **True**).
-          E.g. Specifying a ProcessNode as cls will include CalcJobNode, WorkChainNode, CalcFunctionNode, etc..
-      :param edge_tag:
-          The tag that the edge will get. If nothing is specified
-          (and there is a meaningful edge) the default is tag1--tag2 with tag1 being the entity joining
-          from and tag2 being the entity joining to (this entity).
-      :param edge_filters:
-          The filters to apply on the edge. Also here, details in :meth:`.add_filter`.
-      :param edge_project:
-          The project from the edges. API-details in :meth:`.add_projection`.
-      :param outerjoin:
-          If True, (default is False), will do a left outerjoin
-          instead of an inner join
-
-      Joining can be specified in two ways:
-
-          - Specifying the 'joining_keyword' and 'joining_value' arguments
-          - Specify a single keyword argument
-
-      The joining keyword wil be ``with_*`` or ``direction``, depending on the joining entity type.
-      The joining value is the tag name or class of the entity to join to.
-
-      A small usage example how this can be invoked::
-
-          qb = QueryBuilder()             # Instantiating empty querybuilder instance
-          qb.append(cls=StructureData)    # First item is StructureData node
-          # The
-          # next node in the path is a PwCalculation, with
-          # the structure joined as an input
-          qb.append(
-              cls=PwCalculation,
-              with_incoming=StructureData
-          )
-
-      :return: self
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.append
+         :renderer: rst
 
    .. py:method:: order_by(order_by: aiida.orm.querybuilder.OrderByType) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.order_by
 
-      Set the entity to order by
-
-      :param order_by:
-          This is a list of items, where each item is a dictionary specifies
-          what to sort for an entity
-
-      In each dictionary in that list, keys represent valid tags of
-      entities (tables), and values are list of columns.
-
-      Usage::
-
-          #Sorting by id (ascending):
-          qb = QueryBuilder()
-          qb.append(Node, tag='node')
-          qb.order_by({'node':['id']})
-
-          # or
-          #Sorting by id (ascending):
-          qb = QueryBuilder()
-          qb.append(Node, tag='node')
-          qb.order_by({'node':[{'id':{'order':'asc'}}]})
-
-          # for descending order:
-          qb = QueryBuilder()
-          qb.append(Node, tag='node')
-          qb.order_by({'node':[{'id':{'order':'desc'}}]})
-
-          # or (shorter)
-          qb = QueryBuilder()
-          qb.append(Node, tag='node')
-          qb.order_by({'node':[{'id':'desc'}]})
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.order_by
+         :renderer: rst
 
    .. py:method:: add_filter(tagspec: typing.Union[str, aiida.orm.querybuilder.EntityClsType], filter_spec: aiida.orm.querybuilder.FilterType) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.add_filter
 
-      Adding a filter to my filters.
-
-      :param tagspec: A tag string or an ORM class which maps to an existing tag
-      :param filter_spec: The specifications for the filter, has to be a dictionary
-
-      Usage::
-
-          qb = QueryBuilder()         # Instantiating the QueryBuilder instance
-          qb.append(Node, tag='node') # Appending a Node
-          #let's put some filters:
-          qb.add_filter('node',{'id':{'>':12}})
-          # 2 filters together:
-          qb.add_filter('node',{'label':'foo', 'uuid':{'like':'ab%'}})
-          # Now I am overriding the first filter I set:
-          qb.add_filter('node',{'id':13})
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.add_filter
+         :renderer: rst
 
    .. py:method:: _process_filters(filters: aiida.orm.querybuilder.FilterType) -> typing.Dict[str, typing.Any]
       :canonical: aiida.orm.querybuilder.QueryBuilder._process_filters
       :staticmethod:
 
-      Process filters.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder._process_filters
+         :renderer: rst
 
    .. py:method:: _add_node_type_filter(tagspec: str, classifiers: typing.List[aiida.orm.querybuilder.Classifier], subclassing: bool)
       :canonical: aiida.orm.querybuilder.QueryBuilder._add_node_type_filter
 
-      Add a filter based on node type.
-
-      :param tagspec: The tag, which has to exist already as a key in self._filters
-      :param classifiers: a dictionary with classifiers
-      :param subclassing: if True, allow for subclasses of the ormclass
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder._add_node_type_filter
+         :renderer: rst
 
    .. py:method:: _add_process_type_filter(tagspec: str, classifiers: typing.List[aiida.orm.querybuilder.Classifier], subclassing: bool) -> None
       :canonical: aiida.orm.querybuilder.QueryBuilder._add_process_type_filter
 
-      Add a filter based on process type.
-
-      :param tagspec: The tag, which has to exist already as a key in self._filters
-      :param classifiers: a dictionary with classifiers
-      :param subclassing: if True, allow for subclasses of the process type
-
-      Note: This function handles the case when process_type_string is None.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder._add_process_type_filter
+         :renderer: rst
 
    .. py:method:: _add_group_type_filter(tagspec: str, classifiers: typing.List[aiida.orm.querybuilder.Classifier], subclassing: bool) -> None
       :canonical: aiida.orm.querybuilder.QueryBuilder._add_group_type_filter
 
-      Add a filter based on group type.
-
-      :param tagspec: The tag, which has to exist already as a key in self._filters
-      :param classifiers: a dictionary with classifiers
-      :param subclassing: if True, allow for subclasses of the ormclass
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder._add_group_type_filter
+         :renderer: rst
 
    .. py:method:: add_projection(tag_spec: typing.Union[str, aiida.orm.querybuilder.EntityClsType], projection_spec: aiida.orm.querybuilder.ProjectType) -> None
       :canonical: aiida.orm.querybuilder.QueryBuilder.add_projection
 
-      Adds a projection
-
-      :param tag_spec: A tag string or an ORM class which maps to an existing tag
-      :param projection_spec:
-          The specification for the projection.
-          A projection is a list of dictionaries, with each dictionary
-          containing key-value pairs where the key is database entity
-          (e.g. a column / an attribute) and the value is (optional)
-          additional information on how to process this database entity.
-
-      If the given *projection_spec* is not a list, it will be expanded to
-      a list.
-      If the listitems are not dictionaries, but strings (No additional
-      processing of the projected results desired), they will be expanded to
-      dictionaries.
-
-      Usage::
-
-          qb = QueryBuilder()
-          qb.append(StructureData, tag='struc')
-
-          # Will project the uuid and the kinds
-          qb.add_projection('struc', ['uuid', 'attributes.kinds'])
-
-      The above example will project the uuid and the kinds-attribute of all matching structures.
-      There are 2 (so far) special keys.
-
-      The single star *\** will project the *ORM-instance*::
-
-          qb = QueryBuilder()
-          qb.append(StructureData, tag='struc')
-          # Will project the ORM instance
-          qb.add_projection('struc', '*')
-          print type(qb.first()[0])
-          # >>> aiida.orm.nodes.data.structure.StructureData
-
-      The double star ``**`` projects all possible projections of this entity:
-
-          QueryBuilder().append(StructureData,tag='s', project='**').limit(1).dict()[0]['s'].keys()
-
-          # >>> 'user_id, description, ctime, label, extras, mtime, id, attributes, dbcomputer_id, type, uuid'
-
-      Be aware that the result of ``**`` depends on the backend implementation.
-
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.add_projection
+         :renderer: rst
 
    .. py:method:: set_debug(debug: bool) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.set_debug
 
-      Run in debug mode. This does not affect functionality, but prints intermediate stages
-      when creating a query on screen.
-
-      :param debug: Turn debug on or off
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.set_debug
+         :renderer: rst
 
    .. py:method:: debug(msg: str, *objects: typing.Any) -> None
       :canonical: aiida.orm.querybuilder.QueryBuilder.debug
 
-      Log debug message.
-
-      objects will passed to the format string, e.g. ``msg % objects``
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.debug
+         :renderer: rst
 
    .. py:method:: limit(limit: typing.Optional[int]) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.limit
 
-      Set the limit (nr of rows to return)
-
-      :param limit: integers of number of rows of rows to return
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.limit
+         :renderer: rst
 
    .. py:method:: offset(offset: typing.Optional[int]) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.offset
 
-      Set the offset. If offset is set, that many rows are skipped before returning.
-      *offset* = 0 is the same as omitting setting the offset.
-      If both offset and limit appear,
-      then *offset* rows are skipped before starting to count the *limit* rows
-      that are returned.
-
-      :param offset: integers of nr of rows to skip
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.offset
+         :renderer: rst
 
    .. py:method:: distinct(value: bool = True) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.distinct
 
-      Asks for distinct rows, which is the same as asking the backend to remove
-      duplicates.
-      Does not execute the query!
-
-      If you want a distinct query::
-
-          qb = QueryBuilder()
-          # append stuff!
-          qb.append(...)
-          qb.append(...)
-          ...
-          qb.distinct().all() #or
-          qb.distinct().dict()
-
-      :returns: self
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.distinct
+         :renderer: rst
 
    .. py:method:: inputs(**kwargs: typing.Any) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.inputs
 
-      Join to inputs of previous vertice in path.
-
-      :returns: self
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.inputs
+         :renderer: rst
 
    .. py:method:: outputs(**kwargs: typing.Any) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.outputs
 
-      Join to outputs of previous vertice in path.
-
-      :returns: self
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.outputs
+         :renderer: rst
 
    .. py:method:: children(**kwargs: typing.Any) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.children
 
-      Join to children/descendants of previous vertice in path.
-
-      :returns: self
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.children
+         :renderer: rst
 
    .. py:method:: parents(**kwargs: typing.Any) -> aiida.orm.querybuilder.QueryBuilder
       :canonical: aiida.orm.querybuilder.QueryBuilder.parents
 
-      Join to parents/ancestors of previous vertice in path.
-
-      :returns: self
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.parents
+         :renderer: rst
 
    .. py:method:: as_sql(inline: bool = False) -> str
       :canonical: aiida.orm.querybuilder.QueryBuilder.as_sql
 
-      Convert the query to an SQL string representation.
-
-      .. warning::
-
-          This method should be used for debugging purposes only,
-          since normally sqlalchemy will handle this process internally.
-
-      :params inline: Inline bound parameters (this is normally handled by the Python DB-API).
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.as_sql
+         :renderer: rst
 
    .. py:method:: analyze_query(execute: bool = True, verbose: bool = False) -> str
       :canonical: aiida.orm.querybuilder.QueryBuilder.analyze_query
 
-      Return the query plan, i.e. a list of SQL statements that will be executed.
-
-      See: https://www.postgresql.org/docs/11/sql-explain.html
-
-      :params execute: Carry out the command and show actual run times and other statistics.
-      :params verbose: Display additional information regarding the plan.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.analyze_query
+         :renderer: rst
 
    .. py:method:: _get_aiida_entity_res(value) -> typing.Any
       :canonical: aiida.orm.querybuilder.QueryBuilder._get_aiida_entity_res
       :staticmethod:
 
-      Convert a projected query result to front end class if it is an instance of a `BackendEntity`.
-
-      Values that are not an `BackendEntity` instance will be returned unaltered
-
-      :param value: a projected query result to convert
-      :return: the converted value
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder._get_aiida_entity_res
+         :renderer: rst
 
    .. py:method:: first(flat: bool = False) -> typing.Optional[list[typing.Any] | typing.Any]
       :canonical: aiida.orm.querybuilder.QueryBuilder.first
 
-      Return the first result of the query.
-
-      Calling ``first`` results in an execution of the underlying query.
-
-      Note, this may change if several rows are valid for the query, as persistent ordering is not guaranteed unless
-      explicitly specified.
-
-      :param flat: if True, return just the projected quantity if there is just a single projection.
-      :returns: One row of results as a list, or None if no result returned.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.first
+         :renderer: rst
 
    .. py:method:: count() -> int
       :canonical: aiida.orm.querybuilder.QueryBuilder.count
 
-      Counts the number of rows returned by the backend.
-
-      :returns: the number of rows as an integer
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.count
+         :renderer: rst
 
    .. py:method:: iterall(batch_size: typing.Optional[int] = 100) -> typing.Iterable[typing.List[typing.Any]]
       :canonical: aiida.orm.querybuilder.QueryBuilder.iterall
 
-      Same as :meth:`.all`, but returns a generator.
-      Be aware that this is only safe if no commit will take place during this
-      transaction. You might also want to read the SQLAlchemy documentation on
-      https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.yield_per
-
-      :param batch_size:
-          The size of the batches to ask the backend to batch results in subcollections.
-          You can optimize the speed of the query by tuning this parameter.
-
-      :returns: a generator of lists
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.iterall
+         :renderer: rst
 
    .. py:method:: iterdict(batch_size: typing.Optional[int] = 100) -> typing.Iterable[typing.Dict[str, typing.Dict[str, typing.Any]]]
       :canonical: aiida.orm.querybuilder.QueryBuilder.iterdict
 
-      Same as :meth:`.dict`, but returns a generator.
-      Be aware that this is only safe if no commit will take place during this
-      transaction. You might also want to read the SQLAlchemy documentation on
-      https://docs.sqlalchemy.org/en/14/orm/query.html#sqlalchemy.orm.Query.yield_per
-
-      :param batch_size:
-          The size of the batches to ask the backend to batch results in subcollections.
-          You can optimize the speed of the query by tuning this parameter.
-
-      :returns: a generator of dictionaries
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.iterdict
+         :renderer: rst
 
    .. py:method:: all(batch_size: typing.Optional[int] = None, flat: bool = False) -> typing.Union[typing.List[typing.List[typing.Any]], typing.List[typing.Any]]
       :canonical: aiida.orm.querybuilder.QueryBuilder.all
 
-      Executes the full query with the order of the rows as returned by the backend.
-
-      The order inside each row is given by the order of the vertices in the path and the order of the projections for
-      each vertex in the path.
-
-      :param batch_size: the size of the batches to ask the backend to batch results in subcollections. You can
-          optimize the speed of the query by tuning this parameter. Leave the default `None` if speed is not critical
-          or if you don't know what you're doing.
-      :param flat: return the result as a flat list of projected entities without sub lists.
-      :returns: a list of lists of all projected entities.
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.all
+         :renderer: rst
 
    .. py:method:: one() -> typing.List[typing.Any]
       :canonical: aiida.orm.querybuilder.QueryBuilder.one
 
-      Executes the query asking for exactly one results.
-
-      Will raise an exception if this is not the case:
-
-      :raises: MultipleObjectsError if more then one row can be returned
-      :raises: NotExistent if no result was found
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.one
+         :renderer: rst
 
    .. py:method:: dict(batch_size: typing.Optional[int] = None) -> typing.List[typing.Dict[str, typing.Dict[str, typing.Any]]]
       :canonical: aiida.orm.querybuilder.QueryBuilder.dict
 
-      Executes the full query with the order of the rows as returned by the backend.
-      the order inside each row is given by the order of the vertices in the path
-      and the order of the projections for each vertice in the path.
-
-      :param batch_size:
-          The size of the batches to ask the backend to batch results in subcollections.
-          You can optimize the speed of the query by tuning this parameter.
-          Leave the default (*None*) if speed is not critical or if you don't know what you're doing!
-
-      :returns: A list of dictionaries of all projected entities: tag -> field -> value
-
-      Usage::
-
-          qb = QueryBuilder()
-          qb.append(
-              StructureData,
-              tag='structure',
-              filters={'uuid':{'==':myuuid}},
-          )
-          qb.append(
-              Node,
-              with_ancestors='structure',
-              project=['entity_type', 'id'],  # returns entity_type (string) and id (string)
-              tag='descendant'
-          )
-
-          # Return the dictionaries:
-          print "qb.iterdict()"
-          for d in qb.iterdict():
-              print '>>>', d
-
-      results in the following output::
-
-          qb.iterdict()
-          >>> {'descendant': {
-                  'entity_type': 'calculation.job.quantumespresso.pw.PwCalculation.',
-                  'id': 7716}
-              }
-          >>> {'descendant': {
-                  'entity_type': 'data.remote.RemoteData.',
-                  'id': 8510}
-              }
-
+      .. autodoc2-docstring:: aiida.orm.querybuilder.QueryBuilder.dict
+         :renderer: rst
 
 .. py:class:: RemoteData(remote_path=None, **kwargs)
    :canonical: aiida.orm.nodes.data.remote.base.RemoteData
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   Store a link to a file or folder on a remote machine.
-
-   Remember to pass a computer!
+   .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance, setting the ``source`` attribute if provided as a keyword argument.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData.__init__
+      :renderer: rst
 
    .. py:attribute:: KEY_EXTRA_CLEANED
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData.KEY_EXTRA_CLEANED
       :value: 'cleaned'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData.KEY_EXTRA_CLEANED
+         :renderer: rst
+
    .. py:method:: get_remote_path()
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData.get_remote_path
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData.get_remote_path
+         :renderer: rst
 
    .. py:method:: set_remote_path(val)
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData.set_remote_path
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData.set_remote_path
+         :renderer: rst
+
    .. py:property:: is_empty
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData.is_empty
 
-      Check if remote folder is empty
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData.is_empty
+         :renderer: rst
 
    .. py:method:: getfile(relpath, destpath)
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData.getfile
 
-      Connects to the remote folder and retrieves the content of a file.
-
-      :param relpath:  The relative path of the file on the remote to retrieve.
-      :param destpath: The absolute path of where to store the file on the local machine.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData.getfile
+         :renderer: rst
 
    .. py:method:: listdir(relpath='.')
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData.listdir
 
-      Connects to the remote folder and lists the directory content.
-
-      :param relpath: If 'relpath' is specified, lists the content of the given subfolder.
-      :return: a flat list of file/directory names (as strings).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData.listdir
+         :renderer: rst
 
    .. py:method:: listdir_withattributes(path='.')
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData.listdir_withattributes
 
-      Connects to the remote folder and lists the directory content.
-
-      :param relpath: If 'relpath' is specified, lists the content of the given subfolder.
-      :return: a list of dictionaries, where the documentation is in :py:class:Transport.listdir_withattributes.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData.listdir_withattributes
+         :renderer: rst
 
    .. py:method:: _clean(transport=None)
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData._clean
 
-      Remove all content of the remote folder on the remote computer.
-
-      When the cleaning operation is successful, the extra with the key ``RemoteData.KEY_EXTRA_CLEANED`` is set.
-
-      :param transport: Provide an optional transport that is already open. If not provided, a transport will be
-          automatically opened, based on the current default user and the computer of this data node. Passing in the
-          transport can be used for efficiency if a great number of nodes need to be cleaned for the same computer.
-          Note that the user should take care that the correct transport is passed.
-      :raises ValueError: If the hostname of the provided transport does not match that of the node's computer.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData._clean
+         :renderer: rst
 
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData._validate
 
-      Validate information stored in Node object.
-
-      For the :py:class:`~aiida.orm.Node` base class, this check is always valid.
-      Subclasses can override this method to perform additional checks
-      and should usually call ``super()._validate()`` first!
-
-      This method is called automatically before storing the node in the DB.
-      Therefore, use :py:meth:`~aiida.orm.nodes.attributes.NodeAttributes.get()` and similar methods that
-      automatically read either from the DB or from the internal attribute cache.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData._validate
+         :renderer: rst
 
    .. py:method:: get_authinfo()
       :canonical: aiida.orm.nodes.data.remote.base.RemoteData.get_authinfo
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.base.RemoteData.get_authinfo
+         :renderer: rst
 
 .. py:class:: RemoteStashData(stash_mode: aiida.common.datastructures.StashMode, **kwargs)
    :canonical: aiida.orm.nodes.data.remote.stash.base.RemoteStashData
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   Data plugin that models an archived folder on a remote computer.
-
-   A stashed folder is essentially an instance of ``RemoteData`` that has been archived. Archiving in this context can
-   simply mean copying the content of the folder to another location on the same or another filesystem as long as it is
-   on the same machine. In addition, the folder may have been compressed into a single file for efficiency or even
-   written to tape. The ``stash_mode`` attribute will distinguish how the folder was stashed which will allow the
-   implementation to also `unstash` it and transform it back into a ``RemoteData`` such that it can be used as an input
-   for new ``CalcJobs``.
-
-   This class is a non-storable base class that merely registers the ``stash_mode`` attribute. Only its subclasses,
-   that actually implement a certain stash mode, can be instantiated and therefore stored. The reason for this design
-   is that because the behavior of the class can change significantly based on the mode employed to stash the files and
-   implementing all these variants in the same class will lead to an unintuitive interface where certain properties or
-   methods of the class will only be available or function properly based on the ``stash_mode``.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.base.RemoteStashData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance
-
-   :param stash_mode: the stashing mode with which the data was stashed on the remote.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.base.RemoteStashData.__init__
+      :renderer: rst
 
    .. py:attribute:: _storable
       :canonical: aiida.orm.nodes.data.remote.stash.base.RemoteStashData._storable
       :value: False
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.base.RemoteStashData._storable
+         :renderer: rst
+
    .. py:property:: stash_mode
       :canonical: aiida.orm.nodes.data.remote.stash.base.RemoteStashData.stash_mode
       :type: aiida.common.datastructures.StashMode
 
-      Return the mode with which the data was stashed on the remote.
-
-      :return: the stash mode.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.base.RemoteStashData.stash_mode
+         :renderer: rst
 
 .. py:class:: RemoteStashFolderData(stash_mode: aiida.common.datastructures.StashMode, target_basepath: str, source_list: typing.List, **kwargs)
    :canonical: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData
 
    Bases: :py:obj:`aiida.orm.nodes.data.remote.stash.base.RemoteStashData`
 
-   Data plugin that models a folder with files of a completed calculation job that has been stashed through a copy.
-
-   This data plugin can and should be used to stash files if and only if the stash mode is `StashMode.COPY`.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance
-
-   :param stash_mode: the stashing mode with which the data was stashed on the remote.
-   :param target_basepath: the target basepath.
-   :param source_list: the list of source files.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData.__init__
+      :renderer: rst
 
    .. py:attribute:: _storable
       :canonical: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData._storable
       :value: True
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData._storable
+         :renderer: rst
+
    .. py:property:: target_basepath
       :canonical: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData.target_basepath
       :type: str
 
-      Return the target basepath.
-
-      :return: the target basepath.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData.target_basepath
+         :renderer: rst
 
    .. py:property:: source_list
       :canonical: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData.source_list
       :type: typing.Union[typing.List, typing.Tuple]
 
-      Return the list of source files that were stashed.
-
-      :return: the list of source files.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.remote.stash.folder.RemoteStashFolderData.source_list
+         :renderer: rst
 
 .. py:class:: SinglefileData(file, filename=None, **kwargs)
    :canonical: aiida.orm.nodes.data.singlefile.SinglefileData
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   Data class that can be used to store a single file in its repository.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.singlefile.SinglefileData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance and set the contents to that of the file.
-
-   :param file: an absolute filepath or filelike object whose contents to copy.
-       Hint: Pass io.BytesIO(b"my string") to construct the SinglefileData directly from a string.
-   :param filename: specify filename to use (defaults to name of provided file).
+   .. autodoc2-docstring:: aiida.orm.nodes.data.singlefile.SinglefileData.__init__
+      :renderer: rst
 
    .. py:attribute:: DEFAULT_FILENAME
       :canonical: aiida.orm.nodes.data.singlefile.SinglefileData.DEFAULT_FILENAME
       :value: 'file.txt'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.singlefile.SinglefileData.DEFAULT_FILENAME
+         :renderer: rst
+
    .. py:property:: filename
       :canonical: aiida.orm.nodes.data.singlefile.SinglefileData.filename
 
-      Return the name of the file stored.
-
-      :return: the filename under which the file is stored in the repository
+      .. autodoc2-docstring:: aiida.orm.nodes.data.singlefile.SinglefileData.filename
+         :renderer: rst
 
    .. py:method:: open(path=None, mode='r')
       :canonical: aiida.orm.nodes.data.singlefile.SinglefileData.open
 
-      Return an open file handle to the content of this data node.
-
-      :param path: the relative path of the object within the repository.
-      :param mode: the mode with which to open the file handle (default: read mode)
-      :return: a file handle
+      .. autodoc2-docstring:: aiida.orm.nodes.data.singlefile.SinglefileData.open
+         :renderer: rst
 
    .. py:method:: get_content()
       :canonical: aiida.orm.nodes.data.singlefile.SinglefileData.get_content
 
-      Return the content of the single file stored for this data node.
-
-      :return: the content of the file as a string
+      .. autodoc2-docstring:: aiida.orm.nodes.data.singlefile.SinglefileData.get_content
+         :renderer: rst
 
    .. py:method:: set_file(file, filename=None)
       :canonical: aiida.orm.nodes.data.singlefile.SinglefileData.set_file
 
-      Store the content of the file in the node's repository, deleting any other existing objects.
-
-      :param file: an absolute filepath or filelike object whose contents to copy
-          Hint: Pass io.BytesIO(b"my string") to construct the file directly from a string.
-      :param filename: specify filename to use (defaults to name of provided file).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.singlefile.SinglefileData.set_file
+         :renderer: rst
 
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.singlefile.SinglefileData._validate
 
-      Ensure that there is one object stored in the repository, whose key matches value set for `filename` attr.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.singlefile.SinglefileData._validate
+         :renderer: rst
 
 .. py:class:: Site(**kwargs)
    :canonical: aiida.orm.nodes.data.structure.Site
 
-   This class contains the information about a given site of the system.
-
-   It can be a single atom, or an alloy, or even contain vacancies.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Site
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Create a site.
-
-   :param kind_name: a string that identifies the kind (species) of this site.
-           This has to be found in the list of kinds of the StructureData
-           object.
-           Validation will be done at the StructureData level.
-   :param position: the absolute position (three floats) in angstrom
+   .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Site.__init__
+      :renderer: rst
 
    .. py:method:: get_raw()
       :canonical: aiida.orm.nodes.data.structure.Site.get_raw
 
-      Return the raw version of the site, mapped to a suitable dictionary.
-      This is the format that is actually used to store each site of the
-      structure in the DB.
-
-      :return: a python dictionary with the site.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Site.get_raw
+         :renderer: rst
 
    .. py:method:: get_ase(kinds)
       :canonical: aiida.orm.nodes.data.structure.Site.get_ase
 
-      Return a ase.Atom object for this site.
-
-      :param kinds: the list of kinds from the StructureData object.
-
-      .. note:: If any site is an alloy or has vacancies, a ValueError
-          is raised (from the site.get_ase() routine).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Site.get_ase
+         :renderer: rst
 
    .. py:property:: kind_name
       :canonical: aiida.orm.nodes.data.structure.Site.kind_name
 
-      Return the kind name of this site (a string).
-
-      The type of a site is used to decide whether two sites are identical
-      (same mass, symbols, weights, ...) or not.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Site.kind_name
+         :renderer: rst
 
    .. py:property:: position
       :canonical: aiida.orm.nodes.data.structure.Site.position
 
-      Return the position of this site in absolute coordinates,
-      in angstrom.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Site.position
+         :renderer: rst
 
    .. py:method:: __repr__()
       :canonical: aiida.orm.nodes.data.structure.Site.__repr__
 
-      Return repr(self).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Site.__repr__
+         :renderer: rst
 
    .. py:method:: __str__()
       :canonical: aiida.orm.nodes.data.structure.Site.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.Site.__str__
+         :renderer: rst
 
 .. py:class:: Str
    :canonical: aiida.orm.nodes.data.str.Str
 
    Bases: :py:obj:`aiida.orm.nodes.data.base.BaseType`
 
-   `Data` sub class to represent a string value.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.str.Str
+      :renderer: rst
 
    .. py:attribute:: _type
       :canonical: aiida.orm.nodes.data.str.Str._type
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.str.Str._type
+         :renderer: rst
 
 .. py:class:: StructureData(cell=None, pbc=None, ase=None, pymatgen=None, pymatgen_structure=None, pymatgen_molecule=None, **kwargs)
    :canonical: aiida.orm.nodes.data.structure.StructureData
 
    Bases: :py:obj:`aiida.orm.nodes.data.data.Data`
 
-   This class contains the information about a given structure, i.e. a
-   collection of sites together with a cell, the
-   boundary conditions (whether they are periodic or not) and other
-   related useful information.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.__init__
+      :renderer: rst
 
    .. py:attribute:: _set_incompatibilities
       :canonical: aiida.orm.nodes.data.structure.StructureData._set_incompatibilities
       :value: [('ase', 'cell'), ('ase', 'pbc'), ('ase', 'pymatgen'), ('ase', 'pymatgen_molecule'), ('ase', 'pymatg...
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._set_incompatibilities
+         :renderer: rst
+
    .. py:attribute:: _dimensionality_label
       :canonical: aiida.orm.nodes.data.structure.StructureData._dimensionality_label
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._dimensionality_label
+         :renderer: rst
 
    .. py:attribute:: _internal_kind_tags
       :canonical: aiida.orm.nodes.data.structure.StructureData._internal_kind_tags
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._internal_kind_tags
+         :renderer: rst
+
    .. py:method:: get_dimensionality()
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_dimensionality
 
-      Return the dimensionality of the structure and its length/surface/volume.
-
-      Zero-dimensional structures are assigned "volume" 0.
-
-      :return: returns a dictionary with keys "dim" (dimensionality integer), "label" (dimensionality label)
-          and "value" (numerical length/surface/volume).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_dimensionality
+         :renderer: rst
 
    .. py:method:: set_ase(aseatoms)
       :canonical: aiida.orm.nodes.data.structure.StructureData.set_ase
 
-      Load the structure from a ASE object
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.set_ase
+         :renderer: rst
 
    .. py:method:: set_pymatgen(obj, **kwargs)
       :canonical: aiida.orm.nodes.data.structure.StructureData.set_pymatgen
 
-      Load the structure from a pymatgen object.
-
-      .. note:: Requires the pymatgen module (version >= 3.0.13, usage
-          of earlier versions may cause errors).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.set_pymatgen
+         :renderer: rst
 
    .. py:method:: set_pymatgen_molecule(mol, margin=5)
       :canonical: aiida.orm.nodes.data.structure.StructureData.set_pymatgen_molecule
 
-      Load the structure from a pymatgen Molecule object.
-
-      :param margin: the margin to be added in all directions of the
-          bounding box of the molecule.
-
-      .. note:: Requires the pymatgen module (version >= 3.0.13, usage
-          of earlier versions may cause errors).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.set_pymatgen_molecule
+         :renderer: rst
 
    .. py:method:: set_pymatgen_structure(struct)
       :canonical: aiida.orm.nodes.data.structure.StructureData.set_pymatgen_structure
 
-      Load the structure from a pymatgen Structure object.
-
-      .. note:: periodic boundary conditions are set to True in all
-          three directions.
-      .. note:: Requires the pymatgen module (version >= 3.3.5, usage
-          of earlier versions may cause errors).
-
-      :raise ValueError: if there are partial occupancies together with spins.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.set_pymatgen_structure
+         :renderer: rst
 
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.structure.StructureData._validate
 
-      Performs some standard validation tests.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._validate
+         :renderer: rst
 
    .. py:method:: _prepare_xsf(main_file_name='')
       :canonical: aiida.orm.nodes.data.structure.StructureData._prepare_xsf
 
-      Write the given structure to a string of format XSF (for XCrySDen).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._prepare_xsf
+         :renderer: rst
 
    .. py:method:: _prepare_cif(main_file_name='')
       :canonical: aiida.orm.nodes.data.structure.StructureData._prepare_cif
 
-      Write the given structure to a string of format CIF.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._prepare_cif
+         :renderer: rst
 
    .. py:method:: _prepare_chemdoodle(main_file_name='')
       :canonical: aiida.orm.nodes.data.structure.StructureData._prepare_chemdoodle
 
-      Write the given structure to a string of format required by ChemDoodle.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._prepare_chemdoodle
+         :renderer: rst
 
    .. py:method:: _prepare_xyz(main_file_name='')
       :canonical: aiida.orm.nodes.data.structure.StructureData._prepare_xyz
 
-      Write the given structure to a string of format XYZ.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._prepare_xyz
+         :renderer: rst
 
    .. py:method:: _parse_xyz(inputstring)
       :canonical: aiida.orm.nodes.data.structure.StructureData._parse_xyz
 
-      Read the structure from a string of format XYZ.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._parse_xyz
+         :renderer: rst
 
    .. py:method:: _adjust_default_cell(vacuum_factor=1.0, vacuum_addition=10.0, pbc=(False, False, False))
       :canonical: aiida.orm.nodes.data.structure.StructureData._adjust_default_cell
 
-      If the structure was imported from an xyz file, it lacks a cell.
-      This method will adjust the cell
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._adjust_default_cell
+         :renderer: rst
 
    .. py:method:: get_description()
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_description
 
-      Returns a string with infos retrieved from StructureData node's properties
-
-      :param self: the StructureData node
-      :return: retsrt: the description string
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_description
+         :renderer: rst
 
    .. py:method:: get_symbols_set()
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_symbols_set
 
-      Return a set containing the names of all elements involved in
-      this structure (i.e., for it joins the list of symbols for each
-      kind k in the structure).
-
-      :returns: a set of strings of element names.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_symbols_set
+         :renderer: rst
 
    .. py:method:: get_formula(mode='hill', separator='')
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_formula
 
-      Return a string with the chemical formula.
-
-      :param mode: a string to specify how to generate the formula, can
-          assume one of the following values:
-
-          * 'hill' (default): count the number of atoms of each species,
-            then use Hill notation, i.e. alphabetical order with C and H
-            first if one or several C atom(s) is (are) present, e.g.
-            ``['C','H','H','H','O','C','H','H','H']`` will return ``'C2H6O'``
-            ``['S','O','O','H','O','H','O']``  will return ``'H2O4S'``
-            From E. A. Hill, J. Am. Chem. Soc., 22 (8), pp 478–494 (1900)
-
-          * 'hill_compact': same as hill but the number of atoms for each
-            species is divided by the greatest common divisor of all of them, e.g.
-            ``['C','H','H','H','O','C','H','H','H','O','O','O']``
-            will return ``'CH3O2'``
-
-          * 'reduce': group repeated symbols e.g.
-            ``['Ba', 'Ti', 'O', 'O', 'O', 'Ba', 'Ti', 'O', 'O', 'O',
-            'Ba', 'Ti', 'Ti', 'O', 'O', 'O']`` will return ``'BaTiO3BaTiO3BaTi2O3'``
-
-          * 'group': will try to group as much as possible parts of the formula
-            e.g.
-            ``['Ba', 'Ti', 'O', 'O', 'O', 'Ba', 'Ti', 'O', 'O', 'O',
-            'Ba', 'Ti', 'Ti', 'O', 'O', 'O']`` will return ``'(BaTiO3)2BaTi2O3'``
-
-          * 'count': same as hill (i.e. one just counts the number
-            of atoms of each species) without the re-ordering (take the
-            order of the atomic sites), e.g.
-            ``['Ba', 'Ti', 'O', 'O', 'O','Ba', 'Ti', 'O', 'O', 'O']``
-            will return ``'Ba2Ti2O6'``
-
-          * 'count_compact': same as count but the number of atoms
-            for each species is divided by the greatest common divisor of
-            all of them, e.g.
-            ``['Ba', 'Ti', 'O', 'O', 'O','Ba', 'Ti', 'O', 'O', 'O']``
-            will return ``'BaTiO3'``
-
-      :param separator: a string used to concatenate symbols. Default empty.
-
-      :return: a string with the formula
-
-      .. note:: in modes reduce, group, count and count_compact, the
-          initial order in which the atoms were appended by the user is
-          used to group and/or order the symbols in the formula
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_formula
+         :renderer: rst
 
    .. py:method:: get_site_kindnames()
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_site_kindnames
 
-      Return a list with length equal to the number of sites of this structure,
-      where each element of the list is the kind name of the corresponding site.
-
-      .. note:: This is NOT necessarily a list of chemical symbols! Use
-          ``[ self.get_kind(s.kind_name).get_symbols_string() for s in self.sites]``
-          for chemical symbols
-
-      :return: a list of strings
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_site_kindnames
+         :renderer: rst
 
    .. py:method:: get_composition()
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_composition
 
-      Returns the chemical composition of this structure as a dictionary,
-      where each key is the kind symbol (e.g. H, Li, Ba),
-      and each value is the number of occurences of that element in this
-      structure. For BaZrO3 it would return {'Ba':1, 'Zr':1, 'O':3}.
-      No reduction with smallest common divisor!
-
-      :returns: a dictionary with the composition
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_composition
+         :renderer: rst
 
    .. py:method:: get_ase()
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_ase
 
-      Get the ASE object.
-      Requires to be able to import ase.
-
-      :return: an ASE object corresponding to this
-        :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-        object.
-
-      .. note:: If any site is an alloy or has vacancies, a ValueError
-          is raised (from the site.get_ase() routine).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_ase
+         :renderer: rst
 
    .. py:method:: get_pymatgen(**kwargs)
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_pymatgen
 
-      Get pymatgen object. Returns Structure for structures with
-      periodic boundary conditions (in three dimensions) and Molecule
-      otherwise.
-      :param add_spin: True to add the spins to the pymatgen structure.
-      Default is False (no spin added).
-
-      .. note:: The spins are set according to the following rule:
-
-          * if the kind name ends with 1 -> spin=+1
-
-          * if the kind name ends with 2 -> spin=-1
-
-      .. note:: Requires the pymatgen module (version >= 3.0.13, usage
-          of earlier versions may cause errors).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_pymatgen
+         :renderer: rst
 
    .. py:method:: get_pymatgen_structure(**kwargs)
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_pymatgen_structure
 
-      Get the pymatgen Structure object.
-      :param add_spin: True to add the spins to the pymatgen structure.
-      Default is False (no spin added).
-
-      .. note:: The spins are set according to the following rule:
-
-          * if the kind name ends with 1 -> spin=+1
-
-          * if the kind name ends with 2 -> spin=-1
-
-      .. note:: Requires the pymatgen module (version >= 3.0.13, usage
-          of earlier versions may cause errors).
-
-      :return: a pymatgen Structure object corresponding to this
-        :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-        object.
-      :raise ValueError: if periodic boundary conditions do not hold
-        in at least one dimension of real space.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_pymatgen_structure
+         :renderer: rst
 
    .. py:method:: get_pymatgen_molecule()
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_pymatgen_molecule
 
-      Get the pymatgen Molecule object.
-
-      .. note:: Requires the pymatgen module (version >= 3.0.13, usage
-          of earlier versions may cause errors).
-
-      :return: a pymatgen Molecule object corresponding to this
-        :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-        object.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_pymatgen_molecule
+         :renderer: rst
 
    .. py:method:: append_kind(kind)
       :canonical: aiida.orm.nodes.data.structure.StructureData.append_kind
 
-      Append a kind to the
-      :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`.
-      It makes a copy of the kind.
-
-      :param kind: the site to append, must be a Kind object.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.append_kind
+         :renderer: rst
 
    .. py:method:: append_site(site)
       :canonical: aiida.orm.nodes.data.structure.StructureData.append_site
 
-      Append a site to the
-      :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`.
-      It makes a copy of the site.
-
-      :param site: the site to append. It must be a Site object.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.append_site
+         :renderer: rst
 
    .. py:method:: append_atom(**kwargs)
       :canonical: aiida.orm.nodes.data.structure.StructureData.append_atom
 
-      Append an atom to the Structure, taking care of creating the
-      corresponding kind.
-
-      :param ase: the ase Atom object from which we want to create a new atom
-              (if present, this must be the only parameter)
-      :param position: the position of the atom (three numbers in angstrom)
-      :param symbols: passed to the constructor of the Kind object.
-      :param weights: passed to the constructor of the Kind object.
-      :param name: passed to the constructor of the Kind object. See also the note below.
-
-      .. note :: Note on the 'name' parameter (that is, the name of the kind):
-
-          * if specified, no checks are done on existing species. Simply,
-            a new kind with that name is created. If there is a name
-            clash, a check is done: if the kinds are identical, no error
-            is issued; otherwise, an error is issued because you are trying
-            to store two different kinds with the same name.
-
-          * if not specified, the name is automatically generated. Before
-            adding the kind, a check is done. If other species with the
-            same properties already exist, no new kinds are created, but
-            the site is added to the existing (identical) kind.
-            (Actually, the first kind that is encountered).
-            Otherwise, the name is made unique first, by adding to the string
-            containing the list of chemical symbols a number starting from 1,
-            until an unique name is found
-
-      .. note :: checks of equality of species are done using
-        the :py:meth:`~aiida.orm.nodes.data.structure.Kind.compare_with` method.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.append_atom
+         :renderer: rst
 
    .. py:method:: clear_kinds()
       :canonical: aiida.orm.nodes.data.structure.StructureData.clear_kinds
 
-      Removes all kinds for the StructureData object.
-
-      .. note:: Also clear all sites!
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.clear_kinds
+         :renderer: rst
 
    .. py:method:: clear_sites()
       :canonical: aiida.orm.nodes.data.structure.StructureData.clear_sites
 
-      Removes all sites for the StructureData object.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.clear_sites
+         :renderer: rst
 
    .. py:property:: sites
       :canonical: aiida.orm.nodes.data.structure.StructureData.sites
 
-      Returns a list of sites.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.sites
+         :renderer: rst
 
    .. py:property:: kinds
       :canonical: aiida.orm.nodes.data.structure.StructureData.kinds
 
-      Returns a list of kinds.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.kinds
+         :renderer: rst
 
    .. py:method:: get_kind(kind_name)
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_kind
 
-      Return the kind object associated with the given kind name.
-
-      :param kind_name: String, the name of the kind you want to get
-
-      :return: The Kind object associated with the given kind_name, if
-         a Kind with the given name is present in the structure.
-
-      :raise: ValueError if the kind_name is not present.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_kind
+         :renderer: rst
 
    .. py:method:: get_kind_names()
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_kind_names
 
-      Return a list of kind names (in the same order of the ``self.kinds``
-      property, but return the names rather than Kind objects)
-
-      .. note:: This is NOT necessarily a list of chemical symbols! Use
-          get_symbols_set for chemical symbols
-
-      :return: a list of strings.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_kind_names
+         :renderer: rst
 
    .. py:property:: cell
       :canonical: aiida.orm.nodes.data.structure.StructureData.cell
 
-      Returns the cell shape.
-
-      :return: a 3x3 list of lists.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.cell
+         :renderer: rst
 
    .. py:method:: set_cell(value)
       :canonical: aiida.orm.nodes.data.structure.StructureData.set_cell
 
-      Set the cell.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.set_cell
+         :renderer: rst
 
    .. py:method:: reset_cell(new_cell)
       :canonical: aiida.orm.nodes.data.structure.StructureData.reset_cell
 
-      Reset the cell of a structure not yet stored to a new value.
-
-      :param new_cell: list specifying the cell vectors
-
-      :raises:
-          ModificationNotAllowed: if object is already stored
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.reset_cell
+         :renderer: rst
 
    .. py:method:: reset_sites_positions(new_positions, conserve_particle=True)
       :canonical: aiida.orm.nodes.data.structure.StructureData.reset_sites_positions
 
-      Replace all the Site positions attached to the Structure
-
-      :param new_positions: list of (3D) positions for every sites.
-
-      :param conserve_particle: if True, allows the possibility of removing a site.
-          currently not implemented.
-
-      :raises aiida.common.ModificationNotAllowed: if object is stored already
-      :raises ValueError: if positions are invalid
-
-      .. note:: it is assumed that the order of the new_positions is
-          given in the same order of the one it's substituting, i.e. the
-          kind of the site will not be checked.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.reset_sites_positions
+         :renderer: rst
 
    .. py:property:: pbc
       :canonical: aiida.orm.nodes.data.structure.StructureData.pbc
 
-      Get the periodic boundary conditions.
-
-      :return: a tuple of three booleans, each one tells if there are periodic
-          boundary conditions for the i-th real-space direction (i=1,2,3)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.pbc
+         :renderer: rst
 
    .. py:method:: set_pbc(value)
       :canonical: aiida.orm.nodes.data.structure.StructureData.set_pbc
 
-      Set the periodic boundary conditions.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.set_pbc
+         :renderer: rst
 
    .. py:property:: cell_lengths
       :canonical: aiida.orm.nodes.data.structure.StructureData.cell_lengths
 
-      Get the lengths of cell lattice vectors in angstroms.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.cell_lengths
+         :renderer: rst
 
    .. py:method:: set_cell_lengths(value)
       :canonical: aiida.orm.nodes.data.structure.StructureData.set_cell_lengths
       :abstractmethod:
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.set_cell_lengths
+         :renderer: rst
+
    .. py:property:: cell_angles
       :canonical: aiida.orm.nodes.data.structure.StructureData.cell_angles
 
-      Get the angles between the cell lattice vectors in degrees.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.cell_angles
+         :renderer: rst
 
    .. py:method:: set_cell_angles(value)
       :canonical: aiida.orm.nodes.data.structure.StructureData.set_cell_angles
       :abstractmethod:
 
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.set_cell_angles
+         :renderer: rst
+
    .. py:property:: is_alloy
       :canonical: aiida.orm.nodes.data.structure.StructureData.is_alloy
 
-      Return whether the structure contains any alloy kinds.
-
-      :return: a boolean, True if at least one kind is an alloy
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.is_alloy
+         :renderer: rst
 
    .. py:property:: has_vacancies
       :canonical: aiida.orm.nodes.data.structure.StructureData.has_vacancies
 
-      Return whether the structure has vacancies in the structure.
-
-      :return: a boolean, True if at least one kind has a vacancy
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.has_vacancies
+         :renderer: rst
 
    .. py:method:: get_cell_volume()
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_cell_volume
 
-      Returns the three-dimensional cell volume in Angstrom^3.
-
-      Use the `get_dimensionality` method in order to get the area/length of lower-dimensional cells.
-
-      :return: a float.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_cell_volume
+         :renderer: rst
 
    .. py:method:: get_cif(converter='ase', store=False, **kwargs)
       :canonical: aiida.orm.nodes.data.structure.StructureData.get_cif
 
-      Creates :py:class:`aiida.orm.nodes.data.cif.CifData`.
-
-      .. versionadded:: 1.0
-         Renamed from _get_cif
-
-      :param converter: specify the converter. Default 'ase'.
-      :param store: If True, intermediate calculation gets stored in the
-          AiiDA database for record. Default False.
-      :return: :py:class:`aiida.orm.nodes.data.cif.CifData` node.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData.get_cif
+         :renderer: rst
 
    .. py:method:: _get_object_phonopyatoms()
       :canonical: aiida.orm.nodes.data.structure.StructureData._get_object_phonopyatoms
 
-      Converts StructureData to PhonopyAtoms
-
-      :return: a PhonopyAtoms object
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._get_object_phonopyatoms
+         :renderer: rst
 
    .. py:method:: _get_object_ase()
       :canonical: aiida.orm.nodes.data.structure.StructureData._get_object_ase
 
-      Converts
-      :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-      to ase.Atoms
-
-      :return: an ase.Atoms object
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._get_object_ase
+         :renderer: rst
 
    .. py:method:: _get_object_pymatgen(**kwargs)
       :canonical: aiida.orm.nodes.data.structure.StructureData._get_object_pymatgen
 
-      Converts
-      :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-      to pymatgen object
-
-      :return: a pymatgen Structure for structures with periodic boundary
-          conditions (in three dimensions) and Molecule otherwise
-
-      .. note:: Requires the pymatgen module (version >= 3.0.13, usage
-          of earlier versions may cause errors).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._get_object_pymatgen
+         :renderer: rst
 
    .. py:method:: _get_object_pymatgen_structure(**kwargs)
       :canonical: aiida.orm.nodes.data.structure.StructureData._get_object_pymatgen_structure
 
-      Converts
-      :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-      to pymatgen Structure object
-      :param add_spin: True to add the spins to the pymatgen structure.
-      Default is False (no spin added).
-
-      .. note:: The spins are set according to the following rule:
-
-          * if the kind name ends with 1 -> spin=+1
-
-          * if the kind name ends with 2 -> spin=-1
-
-      :return: a pymatgen Structure object corresponding to this
-        :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-        object
-      :raise ValueError: if periodic boundary conditions does not hold
-        in at least one dimension of real space; if there are partial occupancies
-        together with spins (defined by kind names ending with '1' or '2').
-
-      .. note:: Requires the pymatgen module (version >= 3.0.13, usage
-          of earlier versions may cause errors)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._get_object_pymatgen_structure
+         :renderer: rst
 
    .. py:method:: _get_object_pymatgen_molecule(**kwargs)
       :canonical: aiida.orm.nodes.data.structure.StructureData._get_object_pymatgen_molecule
 
-      Converts
-      :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-      to pymatgen Molecule object
-
-      :return: a pymatgen Molecule object corresponding to this
-        :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`
-        object.
-
-      .. note:: Requires the pymatgen module (version >= 3.0.13, usage
-          of earlier versions may cause errors)
+      .. autodoc2-docstring:: aiida.orm.nodes.data.structure.StructureData._get_object_pymatgen_molecule
+         :renderer: rst
 
 .. py:class:: TrajectoryData(structurelist=None, **kwargs)
    :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData
 
    Bases: :py:obj:`aiida.orm.nodes.data.array.array.ArrayData`
 
-   Stores a trajectory (a sequence of crystal structures with timestamps, and
-   possibly with velocities).
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.__init__
+      :renderer: rst
 
    .. py:method:: _internal_validate(stepids, cells, symbols, positions, times, velocities)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData._internal_validate
 
-      Internal function to validate the type and shape of the arrays. See
-      the documentation of py:meth:`.set_trajectory` for a description of the
-      valid shape and type of the parameters.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData._internal_validate
+         :renderer: rst
 
    .. py:method:: set_trajectory(symbols, positions, stepids=None, cells=None, times=None, velocities=None)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.set_trajectory
 
-      Store the whole trajectory, after checking that types and dimensions
-      are correct.
-
-      Parameters ``stepids``, ``cells`` and ``velocities`` are optional
-      variables. If nothing is passed for ``cells`` or ``velocities``
-      nothing will be stored. However, if no input is given for ``stepids``
-      a consecutive sequence [0,1,2,...,len(positions)-1] will be assumed.
-
-
-      :param symbols: string list with dimension ``n``, where ``n`` is the
-                    number of atoms (i.e., sites) in the structure.
-                    The same list is used for each step. Normally, the string
-                    should be a valid chemical symbol, but actually any unique
-                    string works and can be used as the name of the atomic kind
-                    (see also the :py:meth:`.get_step_structure()` method).
-      :param positions: float array with dimension :math:`s \times n \times 3`,
-                    where ``s`` is the
-                    length of the ``stepids`` array and ``n`` is the length
-                    of the ``symbols`` array. Units are angstrom.
-                    In particular,
-                    ``positions[i,j,k]`` is the ``k``-th component of the
-                    ``j``-th atom (or site) in the structure at the time step
-                    with index ``i`` (identified
-                    by step number ``step[i]`` and with timestamp ``times[i]``).
-      :param stepids: integer array with dimension ``s``, where ``s`` is the
-                    number of steps. Typically represents an internal counter
-                    within the code. For instance, if you want to store a
-                    trajectory with one step every 10, starting from step 65,
-                    the array will be ``[65,75,85,...]``.
-                    No checks are done on duplicate elements
-                    or on the ordering, but anyway this array should be
-                    sorted in ascending order, without duplicate elements.
-                    (If not specified, stepids will be set to ``numpy.arange(s)``
-                    by default) It is internally stored as an array named 'steps'.
-      :param cells: if specified float array with dimension
-                    :math:`s \times 3 \times 3`, where ``s`` is the
-                    length of the ``stepids`` array. Units are angstrom.
-                    In particular, ``cells[i,j,k]`` is the ``k``-th component
-                    of the ``j``-th cell vector at the time step with index
-                    ``i`` (identified by step number ``stepid[i]`` and with
-                    timestamp ``times[i]``).
-      :param times: if specified, float array with dimension ``s``, where
-                    ``s`` is the length of the ``stepids`` array. Contains the
-                    timestamp of each step in picoseconds (ps).
-      :param velocities: if specified, must be a float array with the same
-                    dimensions of the ``positions`` array.
-                    The array contains the velocities in the atoms.
-
-      .. todo :: Choose suitable units for velocities
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.set_trajectory
+         :renderer: rst
 
    .. py:method:: set_structurelist(structurelist)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.set_structurelist
 
-      Create trajectory from the list of
-      :py:class:`aiida.orm.nodes.data.structure.StructureData` instances.
-
-      :param structurelist: a list of
-          :py:class:`aiida.orm.nodes.data.structure.StructureData` instances.
-
-      :raises ValueError: if symbol lists of supplied structures are
-          different
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.set_structurelist
+         :renderer: rst
 
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData._validate
 
-      Verify that the required arrays are present and that their type and
-      dimension are correct.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData._validate
+         :renderer: rst
 
    .. py:property:: numsteps
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.numsteps
 
-      Return the number of stored steps, or zero if nothing has been stored yet.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.numsteps
+         :renderer: rst
 
    .. py:property:: numsites
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.numsites
 
-      Return the number of stored sites, or zero if nothing has been stored yet.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.numsites
+         :renderer: rst
 
    .. py:method:: get_stepids()
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_stepids
 
-      Return the array of steps, if it has already been set.
-
-      .. versionadded:: 0.7
-         Renamed from get_steps
-
-      :raises KeyError: if the trajectory has not been set yet.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_stepids
+         :renderer: rst
 
    .. py:method:: get_times()
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_times
 
-      Return the array of times (in ps), if it has already been set.
-
-      :raises KeyError: if the trajectory has not been set yet.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_times
+         :renderer: rst
 
    .. py:method:: get_cells()
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_cells
 
-      Return the array of cells, if it has already been set.
-
-      :raises KeyError: if the trajectory has not been set yet.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_cells
+         :renderer: rst
 
    .. py:property:: symbols
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.symbols
 
-      Return the array of symbols, if it has already been set.
-
-      :raises KeyError: if the trajectory has not been set yet.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.symbols
+         :renderer: rst
 
    .. py:method:: get_positions()
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_positions
 
-      Return the array of positions, if it has already been set.
-
-      :raises KeyError: if the trajectory has not been set yet.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_positions
+         :renderer: rst
 
    .. py:method:: get_velocities()
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_velocities
 
-      Return the array of velocities, if it has already been set.
-
-      .. note :: This function (differently from all other ``get_*``
-        functions, will not raise an exception if the velocities are not
-        set, but rather return ``None`` (both if no trajectory was not set yet,
-        and if it the trajectory was set but no velocities were specified).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_velocities
+         :renderer: rst
 
    .. py:method:: get_index_from_stepid(stepid)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_index_from_stepid
 
-      Given a value for the stepid (i.e., a value among those of the ``steps``
-      array), return the array index of that stepid, that can be used in other
-      methods such as :py:meth:`.get_step_data` or
-      :py:meth:`.get_step_structure`.
-
-      .. versionadded:: 0.7
-         Renamed from get_step_index
-
-      .. note:: Note that this function returns the first index found
-          (i.e. if multiple steps are present with the same value,
-          only the index of the first one is returned).
-
-      :raises ValueError: if no step with the given value is found.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_index_from_stepid
+         :renderer: rst
 
    .. py:method:: get_step_data(index)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_step_data
 
-      Return a tuple with all information concerning the stepid with given
-      index (0 is the first step, 1 the second step and so on). If you know
-      only the step value, use the :py:meth:`.get_index_from_stepid` method
-      to get the corresponding index.
-
-      If no velocities, cells, or times were specified, None is returned as
-      the corresponding element.
-
-      :return: A tuple in the format
-        ``(stepid, time, cell, symbols, positions, velocities)``,
-        where ``stepid`` is an integer, ``time`` is a float, ``cell`` is a
-        :math:`3      imes 3` matrix, ``symbols`` is an array of length ``n``,
-        positions is a :math:`n       imes 3` array, and velocities is either
-        ``None`` or a :math:`n        imes 3` array
-
-      :param index: The index of the step that you want to retrieve, from
-         0 to ``self.numsteps - 1``.
-      :raises IndexError: if you require an index beyond the limits.
-      :raises KeyError: if you did not store the trajectory yet.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_step_data
+         :renderer: rst
 
    .. py:method:: get_step_structure(index, custom_kinds=None)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_step_structure
 
-      Return an AiiDA :py:class:`aiida.orm.nodes.data.structure.StructureData` node
-      (not stored yet!) with the coordinates of the given step, identified by
-      its index. If you know only the step value, use the
-      :py:meth:`.get_index_from_stepid` method to get the corresponding index.
-
-      .. note:: The periodic boundary conditions are always set to True.
-
-      .. versionadded:: 0.7
-         Renamed from step_to_structure
-
-      :param index: The index of the step that you want to retrieve, from
-         0 to ``self.numsteps- 1``.
-      :param custom_kinds: (Optional) If passed must be a list of
-        :py:class:`aiida.orm.nodes.data.structure.Kind` objects. There must be one
-        kind object for each different string in the ``symbols`` array, with
-        ``kind.name`` set to this string.
-        If this parameter is omitted, the automatic kind generation of AiiDA
-        :py:class:`aiida.orm.nodes.data.structure.StructureData` nodes is used,
-        meaning that the strings in the ``symbols`` array must be valid
-        chemical symbols.
-
-      :return: :py:class:`aiida.orm.nodes.data.structure.StructureData` node.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_step_structure
+         :renderer: rst
 
    .. py:method:: _prepare_xsf(index=None, main_file_name='')
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData._prepare_xsf
 
-      Write the given trajectory to a string of format XSF (for XCrySDen).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData._prepare_xsf
+         :renderer: rst
 
    .. py:method:: _prepare_cif(trajectory_index=None, main_file_name='')
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData._prepare_cif
 
-      Write the given trajectory to a string of format CIF.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData._prepare_cif
+         :renderer: rst
 
    .. py:method:: get_structure(store=False, **kwargs)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_structure
 
-      Creates :py:class:`aiida.orm.nodes.data.structure.StructureData`.
-
-      .. versionadded:: 1.0
-          Renamed from _get_aiida_structure
-
-      :param store: If True, intermediate calculation gets stored in the
-          AiiDA database for record. Default False.
-      :param index: The index of the step that you want to retrieve, from
-         0 to ``self.numsteps- 1``.
-      :param custom_kinds: (Optional) If passed must be a list of
-        :py:class:`aiida.orm.nodes.data.structure.Kind` objects. There must be one
-        kind object for each different string in the ``symbols`` array, with
-        ``kind.name`` set to this string.
-        If this parameter is omitted, the automatic kind generation of AiiDA
-        :py:class:`aiida.orm.nodes.data.structure.StructureData` nodes is used,
-        meaning that the strings in the ``symbols`` array must be valid
-        chemical symbols.
-      :param custom_cell: (Optional) The cell matrix of the structure.
-        If omitted, the cell will be read from the trajectory, if present,
-        otherwise the default cell of
-        :py:class:`aiida.orm.nodes.data.structure.StructureData` will be used.
-
-      :return: :py:class:`aiida.orm.nodes.data.structure.StructureData` node.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_structure
+         :renderer: rst
 
    .. py:method:: get_cif(index=None, **kwargs)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_cif
 
-      Creates :py:class:`aiida.orm.nodes.data.cif.CifData`
-
-      .. versionadded:: 1.0
-         Renamed from _get_cif
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.get_cif
+         :renderer: rst
 
    .. py:method:: _parse_xyz_pos(inputstring)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData._parse_xyz_pos
 
-      Load positions from a XYZ file.
-
-      .. note:: The steps and symbols must be set manually before calling this
-          import function as a consistency measure. Even though the symbols
-          and steps could be extracted from the XYZ file, the data present in
-          the XYZ file may or may not be correct and the same logic would have
-          to be present in the XYZ-velocities function. It was therefore
-          decided not to implement it at all but require it to be set
-          explicitly.
-
-      Usage::
-
-          from aiida.orm.nodes.data.array.trajectory import TrajectoryData
-
-          t = TrajectoryData()
-          # get sites and number of timesteps
-          t.set_array('steps', arange(ntimesteps))
-          t.set_array('symbols', array([site.kind for site in s.sites]))
-          t.importfile('some-calc/AIIDA-PROJECT-pos-1.xyz', 'xyz_pos')
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData._parse_xyz_pos
+         :renderer: rst
 
    .. py:method:: _parse_xyz_vel(inputstring)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData._parse_xyz_vel
 
-      Load velocities from a XYZ file.
-
-      .. note:: The steps and symbols must be set manually before calling this
-          import function as a consistency measure. See also comment for
-          :py:meth:`._parse_xyz_pos`
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData._parse_xyz_vel
+         :renderer: rst
 
    .. py:method:: show_mpl_pos(**kwargs)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.show_mpl_pos
 
-      Shows the positions as a function of time, separate for XYZ coordinates
-
-      :param int stepsize: The stepsize for the trajectory, set higher than 1 to
-          reduce number of points
-      :param int mintime: Time to start from
-      :param int maxtime: Maximum time
-      :param list elements:
-          A list of atomic symbols that should be displayed.
-          If not specified, all atoms are displayed.
-      :param list indices:
-          A list of indices of that atoms that can be displayed.
-          If not specified, all atoms of the correct species are displayed.
-      :param bool dont_block: If True, interpreter is not blocked when figure is displayed.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.show_mpl_pos
+         :renderer: rst
 
    .. py:method:: show_mpl_heatmap(**kwargs)
       :canonical: aiida.orm.nodes.data.array.trajectory.TrajectoryData.show_mpl_heatmap
 
-      Show a heatmap of the trajectory with matplotlib.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.trajectory.TrajectoryData.show_mpl_heatmap
+         :renderer: rst
 
 .. py:class:: UpfData(file, filename=None, **kwargs)
    :canonical: aiida.orm.nodes.data.upf.UpfData
 
    Bases: :py:obj:`aiida.orm.nodes.data.singlefile.SinglefileData`
 
-   `Data` sub class to represent a pseudopotential single file in UPF format.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance and set the contents to that of the file.
-
-   :param file: an absolute filepath or filelike object whose contents to copy.
-       Hint: Pass io.BytesIO(b"my string") to construct the SinglefileData directly from a string.
-   :param filename: specify filename to use (defaults to name of provided file).
+   .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.__init__
+      :renderer: rst
 
    .. py:method:: get_or_create(filepath, use_first=False, store_upf=True)
       :canonical: aiida.orm.nodes.data.upf.UpfData.get_or_create
       :classmethod:
 
-      Get the `UpfData` with the same md5 of the given file, or create it if it does not yet exist.
-
-      :param filepath: an absolute filepath on disk
-      :param use_first: if False (default), raise an exception if more than one potential is found.
-          If it is True, instead, use the first available pseudopotential.
-      :param store_upf: boolean, if false, the `UpfData` if created will not be stored.
-      :return: tuple of `UpfData` and boolean indicating whether it was created.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.get_or_create
+         :renderer: rst
 
    .. py:method:: store(*args, **kwargs)
       :canonical: aiida.orm.nodes.data.upf.UpfData.store
 
-      Store the node, reparsing the file so that the md5 and the element are correctly reset.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.store
+         :renderer: rst
 
    .. py:method:: from_md5(md5, backend=None)
       :canonical: aiida.orm.nodes.data.upf.UpfData.from_md5
       :classmethod:
 
-      Return a list of all `UpfData` that match the given md5 hash.
-
-      .. note:: assumes hash of stored `UpfData` nodes is stored in the `md5` attribute
-
-      :param md5: the file hash
-      :return: list of existing `UpfData` nodes that have the same md5 hash
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.from_md5
+         :renderer: rst
 
    .. py:method:: set_file(file, filename=None)
       :canonical: aiida.orm.nodes.data.upf.UpfData.set_file
 
-      Store the file in the repository and parse it to set the `element` and `md5` attributes.
-
-      :param file: filepath or filelike object of the UPF potential file to store.
-          Hint: Pass io.BytesIO(b"my string") to construct the file directly from a string.
-      :param filename: specify filename to use (defaults to name of provided file).
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.set_file
+         :renderer: rst
 
    .. py:method:: get_upf_family_names()
       :canonical: aiida.orm.nodes.data.upf.UpfData.get_upf_family_names
 
-      Get the list of all upf family names to which the pseudo belongs.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.get_upf_family_names
+         :renderer: rst
 
    .. py:property:: element
       :canonical: aiida.orm.nodes.data.upf.UpfData.element
 
-      Return the element of the UPF pseudopotential.
-
-      :return: the element
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.element
+         :renderer: rst
 
    .. py:property:: md5sum
       :canonical: aiida.orm.nodes.data.upf.UpfData.md5sum
 
-      Return the md5 checksum of the UPF pseudopotential file.
-
-      :return: the md5 checksum
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.md5sum
+         :renderer: rst
 
    .. py:method:: _validate()
       :canonical: aiida.orm.nodes.data.upf.UpfData._validate
 
-      Validate the UPF potential file stored for this node.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData._validate
+         :renderer: rst
 
    .. py:method:: _prepare_upf(main_file_name='')
       :canonical: aiida.orm.nodes.data.upf.UpfData._prepare_upf
 
-      Return UPF content.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData._prepare_upf
+         :renderer: rst
 
    .. py:method:: get_upf_group(group_label)
       :canonical: aiida.orm.nodes.data.upf.UpfData.get_upf_group
       :classmethod:
 
-      Return the UPF family group with the given label.
-
-      :param group_label: the family group label
-      :return: the `Group` with the given label, if it exists
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.get_upf_group
+         :renderer: rst
 
    .. py:method:: get_upf_groups(filter_elements=None, user=None, backend=None)
       :canonical: aiida.orm.nodes.data.upf.UpfData.get_upf_groups
       :classmethod:
 
-      Return all names of groups of type UpfFamily, possibly with some filters.
-
-      :param filter_elements: A string or a list of strings.
-          If present, returns only the groups that contains one UPF for every element present in the list. The default
-          is `None`, meaning that all families are returned.
-      :param user: if None (default), return the groups for all users.
-          If defined, it should be either a `User` instance or the user email.
-      :return: list of `Group` entities of type UPF.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData.get_upf_groups
+         :renderer: rst
 
    .. py:method:: _prepare_json(main_file_name='')
       :canonical: aiida.orm.nodes.data.upf.UpfData._prepare_json
 
-      Returns UPF PP in json format.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.upf.UpfData._prepare_json
+         :renderer: rst
 
 .. py:class:: UpfFamily(label: typing.Optional[str] = None, user: typing.Optional[aiida.orm.User] = None, description: str = '', type_string: typing.Optional[str] = None, backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.groups.UpfFamily
 
    Bases: :py:obj:`aiida.orm.groups.Group`
 
-   Group that represents a pseudo potential family containing `UpfData` nodes.
+   .. autodoc2-docstring:: aiida.orm.groups.UpfFamily
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Create a new group. Either pass a dbgroup parameter, to reload
-   a group from the DB (and then, no further parameters are allowed),
-   or pass the parameters for the Group creation.
-
-   :param label: The group label, required on creation
-   :param description: The group description (by default, an empty string)
-   :param user: The owner of the group (by default, the automatic user)
-   :param type_string: a string identifying the type of group (by default,
-       an empty string, indicating an user-defined group.
+   .. autodoc2-docstring:: aiida.orm.groups.UpfFamily.__init__
+      :renderer: rst
 
 .. py:class:: User(email: str, first_name: str = '', last_name: str = '', institution: str = '', backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.orm.users.User
 
    Bases: :py:obj:`aiida.orm.entities.Entity`\ [\ :py:obj:`aiida.orm.implementation.BackendUser`\ , :py:obj:`aiida.orm.users.UserCollection`\ ]
 
-   AiiDA User
+   .. autodoc2-docstring:: aiida.orm.users.User
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Create a new `User`.
+   .. autodoc2-docstring:: aiida.orm.users.User.__init__
+      :renderer: rst
 
    .. py:attribute:: _CLS_COLLECTION
       :canonical: aiida.orm.users.User._CLS_COLLECTION
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.users.User._CLS_COLLECTION
+         :renderer: rst
+
    .. py:method:: __str__() -> str
       :canonical: aiida.orm.users.User.__str__
+
+      .. autodoc2-docstring:: aiida.orm.users.User.__str__
+         :renderer: rst
 
    .. py:method:: normalize_email(email: str) -> str
       :canonical: aiida.orm.users.User.normalize_email
       :staticmethod:
 
-      Normalize the address by lowercasing the domain part of the email address (taken from Django).
+      .. autodoc2-docstring:: aiida.orm.users.User.normalize_email
+         :renderer: rst
 
    .. py:property:: email
       :canonical: aiida.orm.users.User.email
       :type: str
 
+      .. autodoc2-docstring:: aiida.orm.users.User.email
+         :renderer: rst
+
    .. py:property:: first_name
       :canonical: aiida.orm.users.User.first_name
       :type: str
+
+      .. autodoc2-docstring:: aiida.orm.users.User.first_name
+         :renderer: rst
 
    .. py:property:: last_name
       :canonical: aiida.orm.users.User.last_name
       :type: str
 
+      .. autodoc2-docstring:: aiida.orm.users.User.last_name
+         :renderer: rst
+
    .. py:property:: institution
       :canonical: aiida.orm.users.User.institution
       :type: str
 
+      .. autodoc2-docstring:: aiida.orm.users.User.institution
+         :renderer: rst
+
    .. py:method:: get_full_name() -> str
       :canonical: aiida.orm.users.User.get_full_name
 
-      Return the user full name
-
-      :return: the user full name
+      .. autodoc2-docstring:: aiida.orm.users.User.get_full_name
+         :renderer: rst
 
    .. py:method:: get_short_name() -> str
       :canonical: aiida.orm.users.User.get_short_name
 
-      Return the user short name (typically, this returns the email)
-
-      :return: The short name
+      .. autodoc2-docstring:: aiida.orm.users.User.get_short_name
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.orm.users.User.uuid
       :type: None
 
-      For now users do not have UUIDs so always return None
+      .. autodoc2-docstring:: aiida.orm.users.User.uuid
+         :renderer: rst
 
 .. py:class:: WorkChainNode
    :canonical: aiida.orm.nodes.process.workflow.workchain.WorkChainNode
 
    Bases: :py:obj:`aiida.orm.nodes.process.workflow.workflow.WorkflowNode`
 
-   ORM class for all nodes representing the execution of a WorkChain.
+   .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workchain.WorkChainNode
+      :renderer: rst
 
    .. py:attribute:: STEPPER_STATE_INFO_KEY
       :canonical: aiida.orm.nodes.process.workflow.workchain.WorkChainNode.STEPPER_STATE_INFO_KEY
       :value: 'stepper_state_info'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workchain.WorkChainNode.STEPPER_STATE_INFO_KEY
+         :renderer: rst
+
    .. py:method:: _updatable_attributes() -> typing.Tuple[str, ...]
       :canonical: aiida.orm.nodes.process.workflow.workchain.WorkChainNode._updatable_attributes
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workchain.WorkChainNode._updatable_attributes
+         :renderer: rst
 
    .. py:property:: stepper_state_info
       :canonical: aiida.orm.nodes.process.workflow.workchain.WorkChainNode.stepper_state_info
       :type: typing.Optional[str]
 
-      Return the stepper state info
-
-      :returns: string representation of the stepper state info
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workchain.WorkChainNode.stepper_state_info
+         :renderer: rst
 
    .. py:method:: set_stepper_state_info(stepper_state_info: str) -> None
       :canonical: aiida.orm.nodes.process.workflow.workchain.WorkChainNode.set_stepper_state_info
 
-      Set the stepper state info
-
-      :param state: string representation of the stepper state info
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workchain.WorkChainNode.set_stepper_state_info
+         :renderer: rst
 
 .. py:class:: WorkFunctionNode
    :canonical: aiida.orm.nodes.process.workflow.workfunction.WorkFunctionNode
 
    Bases: :py:obj:`aiida.orm.utils.mixins.FunctionCalculationMixin`, :py:obj:`aiida.orm.nodes.process.workflow.workflow.WorkflowNode`
 
-   ORM class for all nodes representing the execution of a workfunction.
+   .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workfunction.WorkFunctionNode
+      :renderer: rst
 
    .. py:attribute:: _CLS_NODE_LINKS
       :canonical: aiida.orm.nodes.process.workflow.workfunction.WorkFunctionNode._CLS_NODE_LINKS
       :value: None
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workfunction.WorkFunctionNode._CLS_NODE_LINKS
+         :renderer: rst
 
 .. py:class:: WorkflowNode(backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None, user: typing.Optional[aiida.orm.users.User] = None, computer: typing.Optional[aiida.orm.computers.Computer] = None, **kwargs: typing.Any)
    :canonical: aiida.orm.nodes.process.workflow.workflow.WorkflowNode
 
    Bases: :py:obj:`aiida.orm.nodes.process.process.ProcessNode`
 
-   Base class for all nodes representing the execution of a workflow process.
+   .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workflow.WorkflowNode
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   :param backend_entity: the backend model supporting this entity
+   .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workflow.WorkflowNode.__init__
+      :renderer: rst
 
    .. py:attribute:: _CLS_NODE_LINKS
       :canonical: aiida.orm.nodes.process.workflow.workflow.WorkflowNode._CLS_NODE_LINKS
       :value: None
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workflow.WorkflowNode._CLS_NODE_LINKS
+         :renderer: rst
+
    .. py:attribute:: _storable
       :canonical: aiida.orm.nodes.process.workflow.workflow.WorkflowNode._storable
       :value: True
+
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workflow.WorkflowNode._storable
+         :renderer: rst
 
    .. py:attribute:: _unstorable_message
       :canonical: aiida.orm.nodes.process.workflow.workflow.WorkflowNode._unstorable_message
       :value: 'storing for this node has been disabled'
 
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workflow.WorkflowNode._unstorable_message
+         :renderer: rst
+
    .. py:property:: inputs
       :canonical: aiida.orm.nodes.process.workflow.workflow.WorkflowNode.inputs
       :type: aiida.orm.utils.managers.NodeLinksManager
 
-      Return an instance of `NodeLinksManager` to manage incoming INPUT_WORK links
-
-      The returned Manager allows you to easily explore the nodes connected to this node
-      via an incoming INPUT_WORK link.
-      The incoming nodes are reachable by their link labels which are attributes of the manager.
-
-      :return: `NodeLinksManager`
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workflow.WorkflowNode.inputs
+         :renderer: rst
 
    .. py:property:: outputs
       :canonical: aiida.orm.nodes.process.workflow.workflow.WorkflowNode.outputs
       :type: aiida.orm.utils.managers.NodeLinksManager
 
-      Return an instance of `NodeLinksManager` to manage outgoing RETURN links
-
-      The returned Manager allows you to easily explore the nodes connected to this node
-      via an outgoing RETURN link.
-      The outgoing nodes are reachable by their link labels which are attributes of the manager.
-
-      :return: `NodeLinksManager`
+      .. autodoc2-docstring:: aiida.orm.nodes.process.workflow.workflow.WorkflowNode.outputs
+         :renderer: rst
 
 .. py:class:: XyData
    :canonical: aiida.orm.nodes.data.array.xy.XyData
 
    Bases: :py:obj:`aiida.orm.nodes.data.array.array.ArrayData`
 
-   A subclass designed to handle arrays that have an "XY" relationship to
-   each other. That is there is one array, the X array, and there are several
-   Y arrays, which can be considered functions of X.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.xy.XyData
+      :renderer: rst
 
    .. py:method:: _arrayandname_validator(array, name, units)
       :canonical: aiida.orm.nodes.data.array.xy.XyData._arrayandname_validator
       :staticmethod:
 
-      Validates that the array is an numpy.ndarray and that the name is
-      of type str. Raises TypeError or ValueError if this not the case.
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.xy.XyData._arrayandname_validator
+         :renderer: rst
 
    .. py:method:: set_x(x_array, x_name, x_units)
       :canonical: aiida.orm.nodes.data.array.xy.XyData.set_x
 
-      Sets the array and the name for the x values.
-
-      :param x_array: A numpy.ndarray, containing only floats
-      :param x_name: a string for the x array name
-      :param x_units: the units of x
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.xy.XyData.set_x
+         :renderer: rst
 
    .. py:method:: set_y(y_arrays, y_names, y_units)
       :canonical: aiida.orm.nodes.data.array.xy.XyData.set_y
 
-      Set array(s) for the y part of the dataset. Also checks if the
-      x_array has already been set, and that, the shape of the y_arrays
-      agree with the x_array.
-      :param y_arrays: A list of y_arrays, numpy.ndarray
-      :param y_names: A list of strings giving the names of the y_arrays
-      :param y_units: A list of strings giving the units of the y_arrays
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.xy.XyData.set_y
+         :renderer: rst
 
    .. py:method:: get_x()
       :canonical: aiida.orm.nodes.data.array.xy.XyData.get_x
 
-      Tries to retrieve the x array and x name raises a NotExistent
-      exception if no x array has been set yet.
-      :return x_name: the name set for the x_array
-      :return x_array: the x array set earlier
-      :return x_units: the x units set earlier
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.xy.XyData.get_x
+         :renderer: rst
 
    .. py:method:: get_y()
       :canonical: aiida.orm.nodes.data.array.xy.XyData.get_y
 
-      Tries to retrieve the y arrays and the y names, raises a
-      NotExistent exception if they have not been set yet, or cannot be
-      retrieved
-      :return y_names: list of strings naming the y_arrays
-      :return y_arrays: list of y_arrays
-      :return y_units: list of strings giving the units for the y_arrays
+      .. autodoc2-docstring:: aiida.orm.nodes.data.array.xy.XyData.get_y
+         :renderer: rst
 
 .. py:function:: cif_from_ase(ase, full_occupancies=False, add_fake_biso=False)
    :canonical: aiida.orm.nodes.data.cif.cif_from_ase
 
-   Construct a CIF datablock from the ASE structure. The code is taken
-   from
-   https://wiki.fysik.dtu.dk/ase/ase/io/formatoptions.html#ase.io.cif.write_cif,
-   as the original ASE code contains a bug in printing the
-   Hermann-Mauguin symmetry space group symbol.
-
-   :param ase: ASE "images"
-   :return: array of CIF datablocks
+   .. autodoc2-docstring:: aiida.orm.nodes.data.cif.cif_from_ase
+      :renderer: rst
 
 .. py:function:: find_bandgap(bandsdata, number_electrons=None, fermi_energy=None)
    :canonical: aiida.orm.nodes.data.array.bands.find_bandgap
 
-   Tries to guess whether the bandsdata represent an insulator.
-   This method is meant to be used only for electronic bands (not phonons)
-   By default, it will try to use the occupations to guess the number of
-   electrons and find the Fermi Energy, otherwise, it can be provided
-   explicitely.
-   Also, there is an implicit assumption that the kpoints grid is
-   "sufficiently" dense, so that the bandsdata are not missing the
-   intersection between valence and conduction band if present.
-   Use this function with care!
-
-   :param number_electrons: (optional, float) number of electrons in the unit cell
-   :param fermi_energy: (optional, float) value of the fermi energy.
-
-   :note: By default, the algorithm uses the occupations array
-     to guess the number of electrons and the occupied bands. This is to be
-     used with care, because the occupations could be smeared so at a
-     non-zero temperature, with the unwanted effect that the conduction bands
-     might be occupied in an insulator.
-     Prefer to pass the number_of_electrons explicitly
-
-   :note: Only one between number_electrons and fermi_energy can be specified at the
-     same time.
-
-   :return: (is_insulator, gap), where is_insulator is a boolean, and gap a
-            float. The gap is None in case of a metal, zero when the homo is
-            equal to the lumo (e.g. in semi-metals).
+   .. autodoc2-docstring:: aiida.orm.nodes.data.array.bands.find_bandgap
+      :renderer: rst
 
 .. py:function:: get_loader(orm_class)
    :canonical: aiida.orm.utils.loaders.get_loader
 
-   Return the correct OrmEntityLoader for the given orm class.
-
-   :param orm_class: the orm class
-   :returns: a subclass of OrmEntityLoader
-   :raises ValueError: if no OrmEntityLoader subclass can be found for the given orm class
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.get_loader
+      :renderer: rst
 
 .. py:function:: get_query_type_from_type_string(type_string)
    :canonical: aiida.orm.utils.node.get_query_type_from_type_string
 
-   Take the type string of a Node and create the queryable type string
-
-   :param type_string: the plugin_type_string attribute of a Node
-   :return: the type string that can be used to query for
+   .. autodoc2-docstring:: aiida.orm.utils.node.get_query_type_from_type_string
+      :renderer: rst
 
 .. py:function:: get_type_string_from_class(class_module, class_name)
    :canonical: aiida.orm.utils.node.get_type_string_from_class
 
-   Given the module and name of a class, determine the orm_class_type string, which codifies the
-   orm class that is to be used. The returned string will always have a terminating period, which
-   is required to query for the string in the database
-
-   :param class_module: module of the class
-   :param class_name: name of the class
+   .. autodoc2-docstring:: aiida.orm.utils.node.get_type_string_from_class
+      :renderer: rst
 
 .. py:function:: has_pycifrw()
    :canonical: aiida.orm.nodes.data.cif.has_pycifrw
 
-   :return: True if the PyCifRW module can be imported, False otherwise.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.cif.has_pycifrw
+      :renderer: rst
 
 .. py:function:: load_code(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True) -> aiida.orm.Code
    :canonical: aiida.orm.utils.loaders.load_code
 
-   Load a Code instance by one of its identifiers: pk, uuid or label
-
-   If the type of the identifier is unknown simply pass it without a keyword and the loader will attempt to
-   automatically infer the type.
-
-   :param identifier: pk (integer), uuid (string) or label (string) of a Code
-   :param pk: pk of a Code
-   :param uuid: uuid of a Code, or the beginning of the uuid
-   :param label: label of a Code
-   :param sub_classes: an optional tuple of orm classes to narrow the queryset. Each class should be a strict sub class
-       of the ORM class of the given entity loader.
-   :param bool query_with_dashes: allow to query for a uuid with dashes
-   :return: the Code instance
-   :raise ValueError: if none or more than one of the identifiers are supplied
-   :raise TypeError: if the provided identifier has the wrong type
-   :raise aiida.common.NotExistent: if no matching Code is found
-   :raise aiida.common.MultipleObjectsError: if more than one Code was found
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.load_code
+      :renderer: rst
 
 .. py:function:: load_computer(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True) -> aiida.orm.Computer
    :canonical: aiida.orm.utils.loaders.load_computer
 
-   Load a Computer instance by one of its identifiers: pk, uuid or label
-
-   If the type of the identifier is unknown simply pass it without a keyword and the loader will attempt to
-   automatically infer the type.
-
-   :param identifier: pk (integer), uuid (string) or label (string) of a Computer
-   :param pk: pk of a Computer
-   :param uuid: uuid of a Computer, or the beginning of the uuid
-   :param label: label of a Computer
-   :param sub_classes: an optional tuple of orm classes to narrow the queryset. Each class should be a strict sub class
-       of the ORM class of the given entity loader.
-   :param bool query_with_dashes: allow to query for a uuid with dashes
-   :return: the Computer instance
-   :raise ValueError: if none or more than one of the identifiers are supplied
-   :raise TypeError: if the provided identifier has the wrong type
-   :raise aiida.common.NotExistent: if no matching Computer is found
-   :raise aiida.common.MultipleObjectsError: if more than one Computer was found
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.load_computer
+      :renderer: rst
 
 .. py:function:: load_entity(entity_loader=None, identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True)
    :canonical: aiida.orm.utils.loaders.load_entity
 
-   Load an entity instance by one of its identifiers: pk, uuid or label
-
-   If the type of the identifier is unknown simply pass it without a keyword and the loader will attempt to
-   automatically infer the type.
-
-   :param identifier: pk (integer), uuid (string) or label (string) of a Code
-   :param pk: pk of a Code
-   :param uuid: uuid of a Code, or the beginning of the uuid
-   :param label: label of a Code
-   :param sub_classes: an optional tuple of orm classes to narrow the queryset. Each class should be a strict sub class
-       of the ORM class of the given entity loader.
-   :param bool query_with_dashes: allow to query for a uuid with dashes
-   :returns: the Code instance
-   :raise ValueError: if none or more than one of the identifiers are supplied
-   :raise TypeError: if the provided identifier has the wrong type
-   :raise aiida.common.NotExistent: if no matching Code is found
-   :raise aiida.common.MultipleObjectsError: if more than one Code was found
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.load_entity
+      :renderer: rst
 
 .. py:function:: load_group(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True) -> aiida.orm.Group
    :canonical: aiida.orm.utils.loaders.load_group
 
-   Load a Group instance by one of its identifiers: pk, uuid or label
-
-   If the type of the identifier is unknown simply pass it without a keyword and the loader will attempt to
-   automatically infer the type.
-
-   :param identifier: pk (integer), uuid (string) or label (string) of a Group
-   :param pk: pk of a Group
-   :param uuid: uuid of a Group, or the beginning of the uuid
-   :param label: label of a Group
-   :param sub_classes: an optional tuple of orm classes to narrow the queryset. Each class should be a strict sub class
-       of the ORM class of the given entity loader.
-   :param bool query_with_dashes: allow to query for a uuid with dashes
-   :return: the Group instance
-   :raise ValueError: if none or more than one of the identifiers are supplied
-   :raise TypeError: if the provided identifier has the wrong type
-   :raise aiida.common.NotExistent: if no matching Group is found
-   :raise aiida.common.MultipleObjectsError: if more than one Group was found
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.load_group
+      :renderer: rst
 
 .. py:function:: load_node(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True) -> aiida.orm.Node
    :canonical: aiida.orm.utils.loaders.load_node
 
-   Load a node by one of its identifiers: pk or uuid. If the type of the identifier is unknown
-   simply pass it without a keyword and the loader will attempt to infer the type
-
-   :param identifier: pk (integer) or uuid (string)
-   :param pk: pk of a node
-   :param uuid: uuid of a node, or the beginning of the uuid
-   :param label: label of a Node
-   :param sub_classes: an optional tuple of orm classes to narrow the queryset. Each class should be a strict sub class
-       of the ORM class of the given entity loader.
-   :param bool query_with_dashes: allow to query for a uuid with dashes
-   :returns: the node instance
-   :raise ValueError: if none or more than one of the identifiers are supplied
-   :raise TypeError: if the provided identifier has the wrong type
-   :raise aiida.common.NotExistent: if no matching Node is found
-   :raise aiida.common.MultipleObjectsError: if more than one Node was found
+   .. autodoc2-docstring:: aiida.orm.utils.loaders.load_node
+      :renderer: rst
 
 .. py:function:: load_node_class(type_string)
    :canonical: aiida.orm.utils.node.load_node_class
 
-   Return the `Node` sub class that corresponds to the given type string.
-
-   :param type_string: the `type` string of the node
-   :return: a sub class of `Node`
+   .. autodoc2-docstring:: aiida.orm.utils.node.load_node_class
+      :renderer: rst
 
 .. py:function:: pycifrw_from_cif(datablocks, loops=None, names=None)
    :canonical: aiida.orm.nodes.data.cif.pycifrw_from_cif
 
-   Constructs PyCifRW's CifFile from an array of CIF datablocks.
-
-   :param datablocks: an array of CIF datablocks
-   :param loops: optional dict of lists of CIF tag loops.
-   :param names: optional list of datablock names
-   :return: CifFile
+   .. autodoc2-docstring:: aiida.orm.nodes.data.cif.pycifrw_from_cif
+      :renderer: rst
 
 .. py:function:: to_aiida_type(value)
    :canonical: aiida.orm.nodes.data.base.to_aiida_type
 
-   Turns basic Python types (str, int, float, bool) into the corresponding AiiDA types.
+   .. autodoc2-docstring:: aiida.orm.nodes.data.base.to_aiida_type
+      :renderer: rst
 
 .. py:function:: validate_link(source: aiida.orm.Node, target: aiida.orm.Node, link_type: aiida.common.links.LinkType, link_label: str, backend: typing.Optional[aiida.orm.implementation.storage_backend.StorageBackend] = None) -> None
    :canonical: aiida.orm.utils.links.validate_link
 
-   Validate adding a link of the given type and label from a given node to ourself.
-
-   This function will first validate the class types of the inputs and will subsequently validate whether a link of
-   the specified type is allowed at all between the nodes types of the source and target.
-
-   Subsequently, the validity of the "indegree" and "outdegree" of the proposed link is validated, which means
-   validating that the uniqueness constraints of the incoming links into the target node and the outgoing links from
-   the source node are not violated. In AiiDA's provenance graph each link type has one of the following three types
-   of "degree" character::
-
-       * unique
-       * unique pair
-       * unique triple
-
-   Each degree character has a different unique constraint on its links, here defined for the indegree::
-
-       * unique: any target node, it can only have a single incoming link of this type, regardless of the link label.
-       * unique pair: a node can have an infinite amount of incoming links of this type, as long as the labels within
-           that sub set, are unique. In short, it is the link pair, i.e. the tuple of the link type and label, that has
-           a uniquess constraint for the incoming links to a given node.
-       * unique triple: a node can have an infinite amount of incoming links of this type, as long as the triple tuple
-           of source node, link type and link label is unique. In other words, it is the link triple that has a
-           uniqueness constraint for the incoming links.
-
-   The same holds for outdegree, but then it concerns outgoing links from the source node to the target node.
-
-   For illustration purposes, consider the following example provenance graphs that are considered legal, where
-   `WN`, `DN` and `CN` represent a `WorkflowNode`, a `DataNode` and a `CalculationNode`, respectively::
-
-                   1                    2                    3
-           ______     ______          ______          ______     ______
-          |      |   |      |        |      |        |      |   |      |
-          |  WN  |   |  DN  |        |  DN  |        |  WN  |   |  WN  |
-          |______|   |______|        |______|        |______|   |______|
-               |     /                |   |               |     /
-             a |    / a             a |   | b           a |    / a
-              _|___/                  |___|_             _|___/
-             |      |                |      |           |      |
-             |  CN  |                |  CN  |           |  DN  |
-             |______|                |______|           |______|
-
-   In example 1, the link uniqueness constraint is not violated because despite the labels having the same label `a`,
-   their link types, `CALL_CALC` and `INPUT_CALC`, respectively, are different and their `unique_pair` indegree is
-   not violated.
-
-   Similarly, in the second example, the constraint is not violated, because despite both links having the same link
-   type `INPUT_CALC`, the have different labels, so the `unique_pair` indegree of the `INPUT_CALC` is not violated.
-
-   Finally, in the third example, we see two `WorkflowNodes` both returning the same `DataNode` and with the same
-   label. Despite the two incoming links here having both the same type as well as the same label, the uniqueness
-   constraint is not violated, because the indegree for `RETURN` links is `unique_triple` which means that the triple
-   of source node and link type and label should be unique.
-
-   :param source: the node from which the link is coming
-   :param target: the node to which the link is going
-   :param link_type: the type of link
-   :param link_label: link label
-   :raise TypeError: if `source` or `target` is not a Node instance, or `link_type` is not a `LinkType` enum
-   :raise ValueError: if the proposed link is invalid
+   .. autodoc2-docstring:: aiida.orm.utils.links.validate_link
+      :renderer: rst

--- a/docs/apidocs/aiida/aiida.parsers.rst
+++ b/docs/apidocs/aiida/aiida.parsers.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Module for classes and utilities to write parsers for calculation jobs.
+.. autodoc2-docstring:: aiida.parsers
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -20,7 +22,9 @@ Classes
    :align: left
 
    * - :py:obj:`Parser <aiida.parsers.parser.Parser>`
-     - Base class for a Parser that can parse the outputs produced by a CalcJob process.
+     - .. autodoc2-docstring:: aiida.parsers.parser.Parser
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -30,94 +34,69 @@ API
 
    Bases: :py:obj:`abc.ABC`
 
-   Base class for a Parser that can parse the outputs produced by a CalcJob process.
+   .. autodoc2-docstring:: aiida.parsers.parser.Parser
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct the Parser instance.
-
-   :param node: the `CalcJobNode` that contains the results of the executed `CalcJob` process.
+   .. autodoc2-docstring:: aiida.parsers.parser.Parser.__init__
+      :renderer: rst
 
    .. py:property:: logger
       :canonical: aiida.parsers.parser.Parser.logger
 
-      Return the logger preconfigured for the calculation node associated with this parser instance.
-
-      :return: `logging.Logger`
+      .. autodoc2-docstring:: aiida.parsers.parser.Parser.logger
+         :renderer: rst
 
    .. py:property:: node
       :canonical: aiida.parsers.parser.Parser.node
       :type: aiida.orm.CalcJobNode
 
-      Return the node instance
-
-      :return: the `CalcJobNode` instance
+      .. autodoc2-docstring:: aiida.parsers.parser.Parser.node
+         :renderer: rst
 
    .. py:property:: exit_codes
       :canonical: aiida.parsers.parser.Parser.exit_codes
       :type: aiida.engine.ExitCodesNamespace
 
-      Return the exit codes defined for the process class of the node being parsed.
-
-      :returns: ExitCodesNamespace of ExitCode named tuples
+      .. autodoc2-docstring:: aiida.parsers.parser.Parser.exit_codes
+         :renderer: rst
 
    .. py:property:: retrieved
       :canonical: aiida.parsers.parser.Parser.retrieved
       :type: aiida.orm.FolderData
 
+      .. autodoc2-docstring:: aiida.parsers.parser.Parser.retrieved
+         :renderer: rst
+
    .. py:property:: outputs
       :canonical: aiida.parsers.parser.Parser.outputs
 
-      Return the dictionary of outputs that have been registered.
-
-      :return: an AttributeDict instance with the registered output nodes
+      .. autodoc2-docstring:: aiida.parsers.parser.Parser.outputs
+         :renderer: rst
 
    .. py:method:: out(link_label: str, node: aiida.orm.Data) -> None
       :canonical: aiida.parsers.parser.Parser.out
 
-      Register a node as an output with the given link label.
-
-      :param link_label: the name of the link label
-      :param node: the node to register as an output
-      :raises aiida.common.ModificationNotAllowed: if an output node was already registered with the same link label
+      .. autodoc2-docstring:: aiida.parsers.parser.Parser.out
+         :renderer: rst
 
    .. py:method:: get_outputs_for_parsing()
       :canonical: aiida.parsers.parser.Parser.get_outputs_for_parsing
 
-      Return the dictionary of nodes that should be passed to the `Parser.parse` call.
-
-      Output nodes can be marked as being required by the `parse` method, by setting the `pass_to_parser` attribute,
-      in the `spec.output` call in the process spec of the `CalcJob`, to True.
-
-      :return: dictionary of nodes that are required by the `parse` method
+      .. autodoc2-docstring:: aiida.parsers.parser.Parser.get_outputs_for_parsing
+         :renderer: rst
 
    .. py:method:: parse_from_node(node: aiida.orm.CalcJobNode, store_provenance=True, retrieved_temporary_folder=None) -> typing.Tuple[typing.Optional[typing.Dict[str, typing.Any]], aiida.orm.CalcFunctionNode]
       :canonical: aiida.parsers.parser.Parser.parse_from_node
       :classmethod:
 
-      Parse the outputs directly from the `CalcJobNode`.
-
-      If `store_provenance` is set to False, a `CalcFunctionNode` will still be generated, but it will not be stored.
-      It's storing method will also be disabled, making it impossible to store, because storing it afterwards would
-      not have the expected effect, as the outputs it produced will not be stored with it.
-
-      This method is useful to test parsing in unit tests where a `CalcJobNode` can be mocked without actually having
-      to run a `CalcJob`. It can also be useful to actually re-perform the parsing of a completed `CalcJob` with a
-      different parser.
-
-      :param node: a `CalcJobNode` instance
-      :param store_provenance: bool, if True will store the parsing as a `CalcFunctionNode` in the provenance
-      :param retrieved_temporary_folder: absolute path to folder with contents of `retrieved_temporary_list`
-      :return: a tuple of the parsed results and the `CalcFunctionNode` representing the process of parsing
+      .. autodoc2-docstring:: aiida.parsers.parser.Parser.parse_from_node
+         :renderer: rst
 
    .. py:method:: parse(**kwargs) -> typing.Optional[aiida.engine.ExitCode]
       :canonical: aiida.parsers.parser.Parser.parse
       :abstractmethod:
 
-      Parse the contents of the output files retrieved in the `FolderData`.
-
-      This method should be implemented in the sub class. Outputs can be registered through the `out` method.
-      After the `parse` call finishes, the runner will automatically link them up to the underlying `CalcJobNode`.
-
-      :param kwargs: output nodes attached to the `CalcJobNode` of the parser instance.
-      :return: an instance of ExitCode or None
+      .. autodoc2-docstring:: aiida.parsers.parser.Parser.parse
+         :renderer: rst

--- a/docs/apidocs/aiida/aiida.plugins.rst
+++ b/docs/apidocs/aiida/aiida.plugins.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Classes and functions to load and interact with plugin classes accessible through defined entry points.
+.. autodoc2-docstring:: aiida.plugins
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -20,7 +22,9 @@ Classes
    :align: left
 
    * - :py:obj:`PluginVersionProvider <aiida.plugins.utils.PluginVersionProvider>`
-     - Utility class that determines version information about a given plugin resource.
+     - .. autodoc2-docstring:: aiida.plugins.utils.PluginVersionProvider
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -30,37 +34,69 @@ Functions
    :align: left
 
    * - :py:obj:`BaseFactory <aiida.plugins.factories.BaseFactory>`
-     - Return the plugin class registered under a given entry point group and name.
+     - .. autodoc2-docstring:: aiida.plugins.factories.BaseFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalcJobImporterFactory <aiida.plugins.factories.CalcJobImporterFactory>`
-     - Return the plugin registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.CalcJobImporterFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`CalculationFactory <aiida.plugins.factories.CalculationFactory>`
-     - Return the `CalcJob` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.CalculationFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`DataFactory <aiida.plugins.factories.DataFactory>`
-     - Return the `Data` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.DataFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`DbImporterFactory <aiida.plugins.factories.DbImporterFactory>`
-     - Return the `DbImporter` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.DbImporterFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`GroupFactory <aiida.plugins.factories.GroupFactory>`
-     - Return the `Group` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.GroupFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`OrbitalFactory <aiida.plugins.factories.OrbitalFactory>`
-     - Return the `Orbital` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.OrbitalFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`ParserFactory <aiida.plugins.factories.ParserFactory>`
-     - Return the `Parser` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.ParserFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`SchedulerFactory <aiida.plugins.factories.SchedulerFactory>`
-     - Return the `Scheduler` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.SchedulerFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`StorageFactory <aiida.plugins.factories.StorageFactory>`
-     - Return the ``StorageBackend`` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.StorageFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`TransportFactory <aiida.plugins.factories.TransportFactory>`
-     - Return the `Transport` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.TransportFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`WorkflowFactory <aiida.plugins.factories.WorkflowFactory>`
-     - Return the `WorkChain` sub class registered under the given entry point.
+     - .. autodoc2-docstring:: aiida.plugins.factories.WorkflowFactory
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_entry_points <aiida.plugins.entry_point.get_entry_points>`
-     - Return a list of all the entry points within a specific group
+     - .. autodoc2-docstring:: aiida.plugins.entry_point.get_entry_points
+          :renderer: rst
+          :summary:
    * - :py:obj:`load_entry_point <aiida.plugins.entry_point.load_entry_point>`
-     - Load the class registered under the entry point for a given name and group
+     - .. autodoc2-docstring:: aiida.plugins.entry_point.load_entry_point
+          :renderer: rst
+          :summary:
    * - :py:obj:`load_entry_point_from_string <aiida.plugins.entry_point.load_entry_point_from_string>`
-     - Load the class registered for a given entry point string that determines group and name
+     - .. autodoc2-docstring:: aiida.plugins.entry_point.load_entry_point_from_string
+          :renderer: rst
+          :summary:
    * - :py:obj:`parse_entry_point <aiida.plugins.entry_point.parse_entry_point>`
-     - Return an entry point, given its group and spec (as formatted in the setup)
+     - .. autodoc2-docstring:: aiida.plugins.entry_point.parse_entry_point
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -68,187 +104,119 @@ API
 .. py:function:: BaseFactory(group: str, name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Any]
    :canonical: aiida.plugins.factories.BaseFactory
 
-   Return the plugin class registered under a given entry point group and name.
-
-   :param group: entry point group
-   :param name: entry point name
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: the plugin class
-   :raises aiida.common.MissingEntryPointError: entry point was not registered
-   :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
-   :raises aiida.common.LoadingEntryPointError: entry point could not be loaded
+   .. autodoc2-docstring:: aiida.plugins.factories.BaseFactory
+      :renderer: rst
 
 .. py:function:: CalcJobImporterFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.engine.CalcJobImporter]]
    :canonical: aiida.plugins.factories.CalcJobImporterFactory
 
-   Return the plugin registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :return: the loaded :class:`~aiida.engine.processes.calcjobs.importer.CalcJobImporter` plugin.
-   :raises ``aiida.common.InvalidEntryPointTypeError``: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.CalcJobImporterFactory
+      :renderer: rst
 
 .. py:function:: CalculationFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.engine.CalcJob], typing.Callable]
    :canonical: aiida.plugins.factories.CalculationFactory
 
-   Return the `CalcJob` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: sub class of :py:class:`~aiida.engine.processes.calcjobs.calcjob.CalcJob`
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.CalculationFactory
+      :renderer: rst
 
 .. py:function:: DataFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.orm.Data]]
    :canonical: aiida.plugins.factories.DataFactory
 
-   Return the `Data` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: sub class of :py:class:`~aiida.orm.nodes.data.data.Data`
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.DataFactory
+      :renderer: rst
 
 .. py:function:: DbImporterFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.tools.dbimporters.DbImporter]]
    :canonical: aiida.plugins.factories.DbImporterFactory
 
-   Return the `DbImporter` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: sub class of :py:class:`~aiida.tools.dbimporters.baseclasses.DbImporter`
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.DbImporterFactory
+      :renderer: rst
 
 .. py:function:: GroupFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.orm.Group]]
    :canonical: aiida.plugins.factories.GroupFactory
 
-   Return the `Group` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: sub class of :py:class:`~aiida.orm.groups.Group`
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.GroupFactory
+      :renderer: rst
 
 .. py:function:: OrbitalFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.tools.data.orbital.Orbital]]
    :canonical: aiida.plugins.factories.OrbitalFactory
 
-   Return the `Orbital` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: sub class of :py:class:`~aiida.tools.data.orbital.orbital.Orbital`
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.OrbitalFactory
+      :renderer: rst
 
 .. py:function:: ParserFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.parsers.Parser]]
    :canonical: aiida.plugins.factories.ParserFactory
 
-   Return the `Parser` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: sub class of :py:class:`~aiida.parsers.parser.Parser`
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.ParserFactory
+      :renderer: rst
 
 .. py:class:: PluginVersionProvider()
    :canonical: aiida.plugins.utils.PluginVersionProvider
 
-   Utility class that determines version information about a given plugin resource.
+   .. autodoc2-docstring:: aiida.plugins.utils.PluginVersionProvider
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.plugins.utils.PluginVersionProvider.__init__
+      :renderer: rst
 
    .. py:property:: logger
       :canonical: aiida.plugins.utils.PluginVersionProvider.logger
       :type: logging.Logger
 
+      .. autodoc2-docstring:: aiida.plugins.utils.PluginVersionProvider.logger
+         :renderer: rst
+
    .. py:method:: get_version_info(plugin: str | type) -> dict[typing.Any, dict[typing.Any, typing.Any]]
       :canonical: aiida.plugins.utils.PluginVersionProvider.get_version_info
 
-      Get the version information for a given plugin.
-
-      .. note::
-
-          This container will keep a cache, so if this method was already called for the given ``plugin`` before for
-          this instance, the result computed at the last invocation will be returned.
-
-      :param plugin: A class, function, or an entry point string. If the type is string, it will be assumed to be an
-          entry point string and the class will attempt to load it first. It should be a full entry point string,
-          including the entry point group.
-      :return: Dictionary with the `version.core` and optionally `version.plugin` if it could be determined.
-      :raises EntryPointError: If ``plugin`` is a string but could not be loaded as a valid entry point.
-      :raises TypeError: If ``plugin`` (or the resource pointed to it in the case of an entry point) is not a class
-          or a function.
+      .. autodoc2-docstring:: aiida.plugins.utils.PluginVersionProvider.get_version_info
+         :renderer: rst
 
 .. py:function:: SchedulerFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.schedulers.Scheduler]]
    :canonical: aiida.plugins.factories.SchedulerFactory
 
-   Return the `Scheduler` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: sub class of :py:class:`~aiida.schedulers.scheduler.Scheduler`
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.SchedulerFactory
+      :renderer: rst
 
 .. py:function:: StorageFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.orm.implementation.StorageBackend]]
    :canonical: aiida.plugins.factories.StorageFactory
 
-   Return the ``StorageBackend`` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: sub class of :py:class:`~aiida.orm.implementation.storage_backend.StorageBackend`.
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.StorageFactory
+      :renderer: rst
 
 .. py:function:: TransportFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.transports.Transport]]
    :canonical: aiida.plugins.factories.TransportFactory
 
-   Return the `Transport` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.TransportFactory
+      :renderer: rst
 
 .. py:function:: WorkflowFactory(entry_point_name: str, load: bool = True) -> typing.Union[importlib_metadata.EntryPoint, typing.Type[aiida.engine.WorkChain], typing.Callable]
    :canonical: aiida.plugins.factories.WorkflowFactory
 
-   Return the `WorkChain` sub class registered under the given entry point.
-
-   :param entry_point_name: the entry point name.
-   :param load: if True, load the matched entry point and return the loaded resource instead of the entry point itself.
-   :return: sub class of :py:class:`~aiida.engine.processes.workchains.workchain.WorkChain` or a `workfunction`
-   :raises aiida.common.InvalidEntryPointTypeError: if the type of the loaded entry point is invalid.
+   .. autodoc2-docstring:: aiida.plugins.factories.WorkflowFactory
+      :renderer: rst
 
 .. py:function:: get_entry_points(group: str) -> importlib_metadata.EntryPoints
    :canonical: aiida.plugins.entry_point.get_entry_points
 
-   Return a list of all the entry points within a specific group
-
-   :param group: the entry point group
-   :return: a list of entry points
+   .. autodoc2-docstring:: aiida.plugins.entry_point.get_entry_points
+      :renderer: rst
 
 .. py:function:: load_entry_point(group: str, name: str) -> typing.Any
    :canonical: aiida.plugins.entry_point.load_entry_point
 
-   Load the class registered under the entry point for a given name and group
-
-   :param group: the entry point group
-   :param name: the name of the entry point
-   :return: class registered at the given entry point
-   :raises TypeError: if the entry_point_string is not a string type
-   :raises ValueError: if the entry_point_string cannot be split into two parts on the entry point string separator
-   :raises aiida.common.MissingEntryPointError: entry point was not registered
-   :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
-   :raises aiida.common.LoadingEntryPointError: entry point could not be loaded
+   .. autodoc2-docstring:: aiida.plugins.entry_point.load_entry_point
+      :renderer: rst
 
 .. py:function:: load_entry_point_from_string(entry_point_string: str) -> typing.Any
    :canonical: aiida.plugins.entry_point.load_entry_point_from_string
 
-   Load the class registered for a given entry point string that determines group and name
-
-   :param entry_point_string: the entry point string
-   :return: class registered at the given entry point
-   :raises TypeError: if the entry_point_string is not a string type
-   :raises ValueError: if the entry_point_string cannot be split into two parts on the entry point string separator
-   :raises aiida.common.MissingEntryPointError: entry point was not registered
-   :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
-   :raises aiida.common.LoadingEntryPointError: entry point could not be loaded
+   .. autodoc2-docstring:: aiida.plugins.entry_point.load_entry_point_from_string
+      :renderer: rst
 
 .. py:function:: parse_entry_point(group: str, spec: str) -> importlib_metadata.EntryPoint
    :canonical: aiida.plugins.entry_point.parse_entry_point
 
-   Return an entry point, given its group and spec (as formatted in the setup)
+   .. autodoc2-docstring:: aiida.plugins.entry_point.parse_entry_point
+      :renderer: rst

--- a/docs/apidocs/aiida/aiida.repository.rst
+++ b/docs/apidocs/aiida/aiida.repository.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Module with resources dealing with the file repository.
+.. autodoc2-docstring:: aiida.repository
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -20,17 +22,29 @@ Classes
    :align: left
 
    * - :py:obj:`AbstractRepositoryBackend <aiida.repository.backend.abstract.AbstractRepositoryBackend>`
-     - Class that defines the abstract interface for an object repository.
+     - .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend
+          :renderer: rst
+          :summary:
    * - :py:obj:`DiskObjectStoreRepositoryBackend <aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend>`
-     - Implementation of the ``AbstractRepositoryBackend`` using the ``disk-object-store`` as the backend.
+     - .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend
+          :renderer: rst
+          :summary:
    * - :py:obj:`File <aiida.repository.common.File>`
-     - Data class representing a file object.
+     - .. autodoc2-docstring:: aiida.repository.common.File
+          :renderer: rst
+          :summary:
    * - :py:obj:`FileType <aiida.repository.common.FileType>`
-     - Enumeration to represent the type of a file object.
+     - .. autodoc2-docstring:: aiida.repository.common.FileType
+          :renderer: rst
+          :summary:
    * - :py:obj:`Repository <aiida.repository.repository.Repository>`
-     - File repository.
+     - .. autodoc2-docstring:: aiida.repository.repository.Repository
+          :renderer: rst
+          :summary:
    * - :py:obj:`SandboxRepositoryBackend <aiida.repository.backend.sandbox.SandboxRepositoryBackend>`
-     - Implementation of the ``AbstractRepositoryBackend`` using a sandbox folder on disk as the backend.
+     - .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -38,921 +52,681 @@ API
 .. py:class:: AbstractRepositoryBackend
    :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend
 
-   Class that defines the abstract interface for an object repository.
-
-   The repository backend only deals with raw bytes, both when creating new objects as well as when returning a stream
-   or the content of an existing object. The encoding and decoding of the byte content should be done by the client
-   upstream. The file repository backend is also not expected to keep any kind of file hierarchy but must be assumed
-   to be a simple flat data store. When files are created in the file object repository, the implementation will return
-   a string-based key with which the content of the stored object can be addressed. This key is guaranteed to be unique
-   and persistent. Persisting the key or mapping it onto a virtual file hierarchy is again up to the client upstream.
+   .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend
+      :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.uuid
       :abstractmethod:
       :type: typing.Optional[str]
 
-      Return the unique identifier of the repository.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.uuid
+         :renderer: rst
 
    .. py:property:: key_format
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.key_format
       :abstractmethod:
       :type: typing.Optional[str]
 
-      Return the format for the keys of the repository.
-
-      Important for when migrating between backends (e.g. archive -> main), as if they are not equal then it is
-      necessary to re-compute all the `Node.base.repository.metadata` before importing (otherwise they will not match
-      with the repository).
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.key_format
+         :renderer: rst
 
    .. py:method:: initialise(**kwargs) -> None
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.initialise
       :abstractmethod:
 
-      Initialise the repository if it hasn't already been initialised.
-
-      :param kwargs: parameters for the initialisation.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.initialise
+         :renderer: rst
 
    .. py:property:: is_initialised
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.is_initialised
       :abstractmethod:
       :type: bool
 
-      Return whether the repository has been initialised.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.is_initialised
+         :renderer: rst
 
    .. py:method:: erase() -> None
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.erase
       :abstractmethod:
 
-      Delete the repository itself and all its contents.
-
-      .. note:: This should not merely delete the contents of the repository but any resources it created. For
-          example, if the repository is essentially a folder on disk, the folder itself should also be deleted, not
-          just its contents.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.erase
+         :renderer: rst
 
    .. py:method:: is_readable_byte_stream(handle) -> bool
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.is_readable_byte_stream
       :staticmethod:
 
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.is_readable_byte_stream
+         :renderer: rst
+
    .. py:method:: put_object_from_filelike(handle: typing.BinaryIO) -> str
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.put_object_from_filelike
 
-      Store the byte contents of a file in the repository.
-
-      :param handle: filelike object with the byte content to be stored.
-      :return: the generated fully qualified identifier for the object within the repository.
-      :raises TypeError: if the handle is not a byte stream.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.put_object_from_filelike
+         :renderer: rst
 
    .. py:method:: _put_object_from_filelike(handle: typing.BinaryIO) -> str
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend._put_object_from_filelike
       :abstractmethod:
 
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend._put_object_from_filelike
+         :renderer: rst
+
    .. py:method:: put_object_from_file(filepath: typing.Union[str, pathlib.Path]) -> str
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.put_object_from_file
 
-      Store a new object with contents of the file located at `filepath` on this file system.
-
-      :param filepath: absolute path of file whose contents to copy to the repository.
-      :return: the generated fully qualified identifier for the object within the repository.
-      :raises TypeError: if the handle is not a byte stream.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.put_object_from_file
+         :renderer: rst
 
    .. py:method:: has_objects(keys: typing.List[str]) -> typing.List[bool]
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.has_objects
       :abstractmethod:
 
-      Return whether the repository has an object with the given key.
-
-      :param keys:
-          list of fully qualified identifiers for objects within the repository.
-      :return:
-          list of logicals, in the same order as the keys provided, with value True if the respective
-          object exists and False otherwise.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.has_objects
+         :renderer: rst
 
    .. py:method:: has_object(key: str) -> bool
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.has_object
 
-      Return whether the repository has an object with the given key.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :return: True if the object exists, False otherwise.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.has_object
+         :renderer: rst
 
    .. py:method:: list_objects() -> typing.Iterable[str]
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.list_objects
       :abstractmethod:
 
-      Return iterable that yields all available objects by key.
-
-      :return: An iterable for all the available object keys.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.list_objects
+         :renderer: rst
 
    .. py:method:: get_info(detailed: bool = False, **kwargs) -> dict
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.get_info
       :abstractmethod:
 
-      Returns relevant information about the content of the repository.
-
-      :param detailed:
-          flag to enable extra information (detailed=False by default, only returns basic information).
-
-      :return: a dictionary with the information.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.get_info
+         :renderer: rst
 
    .. py:method:: maintain(dry_run: bool = False, live: bool = True, **kwargs) -> None
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.maintain
       :abstractmethod:
 
-      Performs maintenance operations.
-
-      :param dry_run:
-          flag to only print the actions that would be taken without actually executing them.
-
-      :param live:
-          flag to indicate to the backend whether AiiDA is live or not (i.e. if the profile of the
-          backend is currently being used/accessed). The backend is expected then to only allow (and
-          thus set by default) the operations that are safe to perform in this state.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.maintain
+         :renderer: rst
 
    .. py:method:: open(key: str) -> typing.Iterator[typing.BinaryIO]
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.open
 
-      Open a file handle to an object stored under the given key.
-
-      .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
-          ``put_object_from_filelike`` instead.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :return: yield a byte stream object.
-      :raise FileNotFoundError: if the file does not exist.
-      :raise OSError: if the file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.open
+         :renderer: rst
 
    .. py:method:: get_object_content(key: str) -> bytes
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.get_object_content
 
-      Return the content of a object identified by key.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :raise FileNotFoundError: if the file does not exist.
-      :raise OSError: if the file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.get_object_content
+         :renderer: rst
 
    .. py:method:: iter_object_streams(keys: typing.List[str]) -> typing.Iterator[typing.Tuple[str, typing.BinaryIO]]
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.iter_object_streams
       :abstractmethod:
 
-      Return an iterator over the (read-only) byte streams of objects identified by key.
-
-      .. note:: handles should only be read within the context of this iterator.
-
-      :param keys: fully qualified identifiers for the objects within the repository.
-      :return: an iterator over the object byte streams.
-      :raise FileNotFoundError: if the file does not exist.
-      :raise OSError: if a file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.iter_object_streams
+         :renderer: rst
 
    .. py:method:: get_object_hash(key: str) -> str
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.get_object_hash
 
-      Return the SHA-256 hash of an object stored under the given key.
-
-      .. important::
-          A SHA-256 hash should always be returned,
-          to ensure consistency across different repository implementations.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :raise FileNotFoundError: if the file does not exist.
-      :raise OSError: if the file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.get_object_hash
+         :renderer: rst
 
    .. py:method:: delete_objects(keys: typing.List[str]) -> None
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.delete_objects
       :abstractmethod:
 
-      Delete the objects from the repository.
-
-      :param keys: list of fully qualified identifiers for the objects within the repository.
-      :raise FileNotFoundError: if any of the files does not exist.
-      :raise OSError: if any of the files could not be deleted.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.delete_objects
+         :renderer: rst
 
    .. py:method:: delete_object(key: str) -> None
       :canonical: aiida.repository.backend.abstract.AbstractRepositoryBackend.delete_object
 
-      Delete the object from the repository.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :raise FileNotFoundError: if the file does not exist.
-      :raise OSError: if the file could not be deleted.
+      .. autodoc2-docstring:: aiida.repository.backend.abstract.AbstractRepositoryBackend.delete_object
+         :renderer: rst
 
 .. py:class:: DiskObjectStoreRepositoryBackend(container: disk_objectstore.Container)
    :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend
 
    Bases: :py:obj:`aiida.repository.backend.abstract.AbstractRepositoryBackend`
 
-   Implementation of the ``AbstractRepositoryBackend`` using the ``disk-object-store`` as the backend.
+   .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend
+      :renderer: rst
 
-   .. note:: For certain methods, the container may create a sessions which should be closed after the operation is
-       done to make sure the connection to the underlying sqlite database is closed. The best way is to accomplish this
-       is by using the container as a context manager, which will automatically call the ``close`` method when it exits
-       which ensures the session being closed. Note that not all methods may open the session and so need closing it,
-       but to be on the safe side, we put every use of the container in a context manager. If no session is created,
-       the ``close`` method is essentially a no-op.
+   .. rubric:: Initialization
 
+   .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.__init__
+      :renderer: rst
 
    .. py:method:: __str__() -> str
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.__str__
 
-      Return the string representation of this repository.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.__str__
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.uuid
       :type: typing.Optional[str]
 
-      Return the unique identifier of the repository.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.uuid
+         :renderer: rst
 
    .. py:property:: key_format
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.key_format
       :type: typing.Optional[str]
 
-      Return the format for the keys of the repository.
-
-      Important for when migrating between backends (e.g. archive -> main), as if they are not equal then it is
-      necessary to re-compute all the `Node.base.repository.metadata` before importing (otherwise they will not match
-      with the repository).
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.key_format
+         :renderer: rst
 
    .. py:method:: initialise(**kwargs) -> None
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.initialise
 
-      Initialise the repository if it hasn't already been initialised.
-
-      :param kwargs: parameters for the initialisation.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.initialise
+         :renderer: rst
 
    .. py:property:: is_initialised
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.is_initialised
       :type: bool
 
-      Return whether the repository has been initialised.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.is_initialised
+         :renderer: rst
 
    .. py:method:: erase()
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.erase
 
-      Delete the repository itself and all its contents.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.erase
+         :renderer: rst
 
    .. py:method:: _put_object_from_filelike(handle: typing.BinaryIO) -> str
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend._put_object_from_filelike
 
-      Store the byte contents of a file in the repository.
-
-      :param handle: filelike object with the byte content to be stored.
-      :return: the generated fully qualified identifier for the object within the repository.
-      :raises TypeError: if the handle is not a byte stream.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend._put_object_from_filelike
+         :renderer: rst
 
    .. py:method:: has_objects(keys: typing.List[str]) -> typing.List[bool]
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.has_objects
 
-      Return whether the repository has an object with the given key.
-
-      :param keys:
-          list of fully qualified identifiers for objects within the repository.
-      :return:
-          list of logicals, in the same order as the keys provided, with value True if the respective
-          object exists and False otherwise.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.has_objects
+         :renderer: rst
 
    .. py:method:: open(key: str) -> typing.Iterator[typing.BinaryIO]
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.open
 
-      Open a file handle to an object stored under the given key.
-
-      .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
-          ``put_object_from_filelike`` instead.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :return: yield a byte stream object.
-      :raise FileNotFoundError: if the file does not exist.
-      :raise OSError: if the file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.open
+         :renderer: rst
 
    .. py:method:: iter_object_streams(keys: typing.List[str]) -> typing.Iterator[typing.Tuple[str, typing.BinaryIO]]
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.iter_object_streams
 
-      Return an iterator over the (read-only) byte streams of objects identified by key.
-
-      .. note:: handles should only be read within the context of this iterator.
-
-      :param keys: fully qualified identifiers for the objects within the repository.
-      :return: an iterator over the object byte streams.
-      :raise FileNotFoundError: if the file does not exist.
-      :raise OSError: if a file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.iter_object_streams
+         :renderer: rst
 
    .. py:method:: delete_objects(keys: typing.List[str]) -> None
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.delete_objects
 
-      Delete the objects from the repository.
-
-      :param keys: list of fully qualified identifiers for the objects within the repository.
-      :raise FileNotFoundError: if any of the files does not exist.
-      :raise OSError: if any of the files could not be deleted.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.delete_objects
+         :renderer: rst
 
    .. py:method:: list_objects() -> typing.Iterable[str]
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.list_objects
 
-      Return iterable that yields all available objects by key.
-
-      :return: An iterable for all the available object keys.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.list_objects
+         :renderer: rst
 
    .. py:method:: get_object_hash(key: str) -> str
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.get_object_hash
 
-      Return the SHA-256 hash of an object stored under the given key.
-
-      .. important::
-          A SHA-256 hash should always be returned,
-          to ensure consistency across different repository implementations.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :raise FileNotFoundError: if the file does not exist.
-
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.get_object_hash
+         :renderer: rst
 
    .. py:method:: maintain(dry_run: bool = False, live: bool = True, pack_loose: bool = None, do_repack: bool = None, clean_storage: bool = None, do_vacuum: bool = None) -> dict
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.maintain
 
-      Performs maintenance operations.
-
-      :param live:if True, will only perform operations that are safe to do while the repository is in use.
-      :param pack_loose:flag for forcing the packing of loose files.
-      :param do_repack:flag for forcing the re-packing of already packed files.
-      :param clean_storage:flag for forcing the cleaning of soft-deleted files from the repository.
-      :param do_vacuum:flag for forcing the vacuuming of the internal database when cleaning the repository.
-      :return:a dictionary with information on the operations performed.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.maintain
+         :renderer: rst
 
    .. py:method:: get_info(detailed=False) -> typing.Dict[str, typing.Union[int, str, typing.Dict[str, int], typing.Dict[str, float]]]
       :canonical: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.get_info
 
-      Return information on configuration and content of the repository.
+      .. autodoc2-docstring:: aiida.repository.backend.disk_object_store.DiskObjectStoreRepositoryBackend.get_info
+         :renderer: rst
 
 .. py:class:: File(name: str = '', file_type: aiida.repository.common.FileType = FileType.DIRECTORY, key: typing.Union[str, None] = None, objects: typing.Optional[typing.Dict[str, aiida.repository.common.File]] = None)
    :canonical: aiida.repository.common.File
 
-   Data class representing a file object.
+   .. autodoc2-docstring:: aiida.repository.common.File
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance.
-
-   :param name: The final element of the file path
-   :param file_type: Identifies whether the File is a file or a directory
-   :param key: A key to map the file to its contents in the backend repository (file only)
-   :param objects: Mapping of child names to child Files (directory only)
-
-   :raises ValueError: If a key is defined for a directory,
-       or objects are defined for a file
+   .. autodoc2-docstring:: aiida.repository.common.File.__init__
+      :renderer: rst
 
    .. py:method:: from_serialized(serialized: dict, name='') -> aiida.repository.common.File
       :canonical: aiida.repository.common.File.from_serialized
       :classmethod:
 
-      Construct a new instance from a serialized instance.
-
-      :param serialized: the serialized instance.
-      :return: the reconstructed file object.
+      .. autodoc2-docstring:: aiida.repository.common.File.from_serialized
+         :renderer: rst
 
    .. py:method:: serialize() -> dict
       :canonical: aiida.repository.common.File.serialize
 
-      Serialize the metadata into a JSON-serializable format.
-
-      .. note:: the serialization format is optimized to reduce the size in bytes.
-
-      :return: dictionary with the content metadata.
+      .. autodoc2-docstring:: aiida.repository.common.File.serialize
+         :renderer: rst
 
    .. py:property:: name
       :canonical: aiida.repository.common.File.name
       :type: str
 
-      Return the name of the file object.
+      .. autodoc2-docstring:: aiida.repository.common.File.name
+         :renderer: rst
 
    .. py:property:: file_type
       :canonical: aiida.repository.common.File.file_type
       :type: aiida.repository.common.FileType
 
-      Return the file type of the file object.
+      .. autodoc2-docstring:: aiida.repository.common.File.file_type
+         :renderer: rst
 
    .. py:method:: is_file() -> bool
       :canonical: aiida.repository.common.File.is_file
 
-      Return whether this instance is a file object.
+      .. autodoc2-docstring:: aiida.repository.common.File.is_file
+         :renderer: rst
 
    .. py:method:: is_dir() -> bool
       :canonical: aiida.repository.common.File.is_dir
 
-      Return whether this instance is a directory object.
+      .. autodoc2-docstring:: aiida.repository.common.File.is_dir
+         :renderer: rst
 
    .. py:property:: key
       :canonical: aiida.repository.common.File.key
       :type: typing.Union[str, None]
 
-      Return the key of the file object.
+      .. autodoc2-docstring:: aiida.repository.common.File.key
+         :renderer: rst
 
    .. py:property:: objects
       :canonical: aiida.repository.common.File.objects
       :type: typing.Dict[str, aiida.repository.common.File]
 
-      Return the objects of the file object.
+      .. autodoc2-docstring:: aiida.repository.common.File.objects
+         :renderer: rst
 
    .. py:method:: __eq__(other) -> bool
       :canonical: aiida.repository.common.File.__eq__
 
-      Return whether this instance is equal to another file object instance.
+      .. autodoc2-docstring:: aiida.repository.common.File.__eq__
+         :renderer: rst
 
    .. py:method:: __repr__()
       :canonical: aiida.repository.common.File.__repr__
 
-      Return repr(self).
+      .. autodoc2-docstring:: aiida.repository.common.File.__repr__
+         :renderer: rst
 
 .. py:class:: FileType
    :canonical: aiida.repository.common.FileType
 
    Bases: :py:obj:`enum.Enum`
 
-   Enumeration to represent the type of a file object.
+   .. autodoc2-docstring:: aiida.repository.common.FileType
+      :renderer: rst
 
    .. py:attribute:: DIRECTORY
       :canonical: aiida.repository.common.FileType.DIRECTORY
       :value: 0
 
+      .. autodoc2-docstring:: aiida.repository.common.FileType.DIRECTORY
+         :renderer: rst
+
    .. py:attribute:: FILE
       :canonical: aiida.repository.common.FileType.FILE
       :value: 1
 
+      .. autodoc2-docstring:: aiida.repository.common.FileType.FILE
+         :renderer: rst
+
 .. py:class:: Repository(backend: typing.Optional[aiida.repository.backend.AbstractRepositoryBackend] = None)
    :canonical: aiida.repository.repository.Repository
 
-   File repository.
-
-   This class provides an interface to a backend file repository instance, but unlike the backend repository, this
-   class keeps a reference of the virtual file hierarchy. This means that through this interface, a client can create
-   files and directories with a file hierarchy, just as they would on a local file system, except it is completely
-   virtual as the files are stored by the backend which can store them in a completely flat structure. This also means
-   that the internal virtual hierarchy of a ``Repository`` instance does not necessarily represent all the files that
-   are stored by repository backend. The repository exposes a mere subset of all the file objects stored in the
-   backend. This is why object deletion is also implemented as a soft delete, by default, where the files are just
-   removed from the internal virtual hierarchy, but not in the actual backend. This is because those objects can be
-   referenced by other instances.
+   .. autodoc2-docstring:: aiida.repository.repository.Repository
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance with empty metadata.
-
-   :param backend: instance of repository backend to use to actually store the file objects. By default, an
-       instance of the ``SandboxRepositoryBackend`` will be created.
+   .. autodoc2-docstring:: aiida.repository.repository.Repository.__init__
+      :renderer: rst
 
    .. py:attribute:: _file_cls
       :canonical: aiida.repository.repository.Repository._file_cls
       :value: None
 
+      .. autodoc2-docstring:: aiida.repository.repository.Repository._file_cls
+         :renderer: rst
+
    .. py:method:: __str__() -> str
       :canonical: aiida.repository.repository.Repository.__str__
 
-      Return the string representation of this repository.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.__str__
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.repository.repository.Repository.uuid
       :type: typing.Optional[str]
 
-      Return the unique identifier of the repository backend or ``None`` if it doesn't have one.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.uuid
+         :renderer: rst
 
    .. py:property:: is_initialised
       :canonical: aiida.repository.repository.Repository.is_initialised
       :type: bool
 
-      Return whether the repository backend has been initialised.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.is_initialised
+         :renderer: rst
 
    .. py:method:: from_serialized(backend: aiida.repository.backend.AbstractRepositoryBackend, serialized: typing.Dict[str, typing.Any]) -> aiida.repository.repository.Repository
       :canonical: aiida.repository.repository.Repository.from_serialized
       :classmethod:
 
-      Construct an instance where the metadata is initialized from the serialized content.
-
-      :param backend: instance of repository backend to use to actually store the file objects.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.from_serialized
+         :renderer: rst
 
    .. py:method:: reset() -> None
       :canonical: aiida.repository.repository.Repository.reset
 
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.reset
+         :renderer: rst
+
    .. py:method:: serialize() -> typing.Dict[str, typing.Any]
       :canonical: aiida.repository.repository.Repository.serialize
 
-      Serialize the metadata into a JSON-serializable format.
-
-      :return: dictionary with the content metadata.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.serialize
+         :renderer: rst
 
    .. py:method:: flatten(serialized=Optional[Dict[str, Any]], delimiter: str = '/') -> typing.Dict[str, typing.Optional[str]]
       :canonical: aiida.repository.repository.Repository.flatten
       :classmethod:
 
-      Flatten the serialized content of a repository into a mapping of path -> key or None (if folder).
-
-      Note, all folders are represented in the flattened output, and their path is suffixed with the delimiter.
-
-      :param serialized: the serialized content of the repository.
-      :param delimiter: the delimiter to use to separate the path elements.
-      :return: dictionary with the flattened content.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.flatten
+         :renderer: rst
 
    .. py:method:: hash() -> str
       :canonical: aiida.repository.repository.Repository.hash
 
-      Generate a hash of the repository's contents.
-
-      .. warning:: this will read the content of all file objects contained within the virtual hierarchy into memory.
-
-      :return: the hash representing the contents of the repository.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.hash
+         :renderer: rst
 
    .. py:method:: _pre_process_path(path: typing.Optional[aiida.repository.repository.FilePath] = None) -> pathlib.PurePosixPath
       :canonical: aiida.repository.repository.Repository._pre_process_path
       :staticmethod:
 
-      Validate and convert the path to instance of ``pathlib.PurePosixPath``.
-
-      This should be called by every method of this class before doing anything, such that it can safely assume that
-      the path is a ``pathlib.PurePosixPath`` object, which makes path manipulation a lot easier.
-
-      :param path: the path as a ``pathlib.PurePosixPath`` object or `None`.
-      :raises TypeError: if the type of path was not a str nor a ``pathlib.PurePosixPath`` instance.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository._pre_process_path
+         :renderer: rst
 
    .. py:property:: backend
       :canonical: aiida.repository.repository.Repository.backend
       :type: aiida.repository.backend.AbstractRepositoryBackend
 
-      Return the current repository backend.
-
-      :return: the repository backend.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.backend
+         :renderer: rst
 
    .. py:method:: set_backend(backend: aiida.repository.backend.AbstractRepositoryBackend) -> None
       :canonical: aiida.repository.repository.Repository.set_backend
 
-      Set the backend for this repository.
-
-      :param backend: the repository backend.
-      :raises TypeError: if the type of the backend is invalid.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.set_backend
+         :renderer: rst
 
    .. py:method:: _insert_file(path: pathlib.PurePosixPath, key: str) -> None
       :canonical: aiida.repository.repository.Repository._insert_file
 
-      Insert a new file object in the object mapping.
-
-      .. note:: this assumes the path is a valid relative path, so should be checked by the caller.
-
-      :param path: the relative path where to store the object in the repository.
-      :param key: fully qualified identifier for the object within the repository.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository._insert_file
+         :renderer: rst
 
    .. py:method:: create_directory(path: aiida.repository.repository.FilePath) -> aiida.repository.common.File
       :canonical: aiida.repository.repository.Repository.create_directory
 
-      Create a new directory with the given path.
-
-      :param path: the relative path of the directory.
-      :return: the created directory.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.create_directory
+         :renderer: rst
 
    .. py:method:: get_file_keys() -> typing.List[str]
       :canonical: aiida.repository.repository.Repository.get_file_keys
 
-      Return the keys of all file objects contained within this repository.
-
-      :return: list of keys, which map a file to its content in the backend repository.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.get_file_keys
+         :renderer: rst
 
    .. py:method:: get_object(path: typing.Optional[aiida.repository.repository.FilePath] = None) -> aiida.repository.common.File
       :canonical: aiida.repository.repository.Repository.get_object
 
-      Return the object at the given path.
-
-      :param path: the relative path where to store the object in the repository.
-      :return: the `File` representing the object located at the given relative path.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
-      :raises FileNotFoundError: if no object exists for the given path.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.get_object
+         :renderer: rst
 
    .. py:method:: get_directory(path: typing.Optional[aiida.repository.repository.FilePath] = None) -> aiida.repository.common.File
       :canonical: aiida.repository.repository.Repository.get_directory
 
-      Return the directory object at the given path.
-
-      :param path: the relative path of the directory.
-      :return: the `File` representing the object located at the given relative path.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
-      :raises FileNotFoundError: if no object exists for the given path.
-      :raises NotADirectoryError: if the object at the given path is not a directory.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.get_directory
+         :renderer: rst
 
    .. py:method:: get_file(path: aiida.repository.repository.FilePath) -> aiida.repository.common.File
       :canonical: aiida.repository.repository.Repository.get_file
 
-      Return the file object at the given path.
-
-      :param path: the relative path of the file object.
-      :return: the `File` representing the object located at the given relative path.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
-      :raises FileNotFoundError: if no object exists for the given path.
-      :raises IsADirectoryError: if the object at the given path is not a directory.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.get_file
+         :renderer: rst
 
    .. py:method:: list_objects(path: typing.Optional[aiida.repository.repository.FilePath] = None) -> typing.List[aiida.repository.common.File]
       :canonical: aiida.repository.repository.Repository.list_objects
 
-      Return a list of the objects contained in this repository sorted by name, optionally in given sub directory.
-
-      :param path: the relative path of the directory.
-      :return: a list of `File` named tuples representing the objects present in directory with the given path.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
-      :raises FileNotFoundError: if no object exists for the given path.
-      :raises NotADirectoryError: if the object at the given path is not a directory.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.list_objects
+         :renderer: rst
 
    .. py:method:: list_object_names(path: typing.Optional[aiida.repository.repository.FilePath] = None) -> typing.List[str]
       :canonical: aiida.repository.repository.Repository.list_object_names
 
-      Return a sorted list of the object names contained in this repository, optionally in the given sub directory.
-
-      :param path: the relative path of the directory.
-      :return: a list of `File` named tuples representing the objects present in directory with the given path.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
-      :raises FileNotFoundError: if no object exists for the given path.
-      :raises NotADirectoryError: if the object at the given path is not a directory.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.list_object_names
+         :renderer: rst
 
    .. py:method:: put_object_from_filelike(handle: typing.BinaryIO, path: aiida.repository.repository.FilePath) -> None
       :canonical: aiida.repository.repository.Repository.put_object_from_filelike
 
-      Store the byte contents of a file in the repository.
-
-      :param handle: filelike object with the byte content to be stored.
-      :param path: the relative path where to store the object in the repository.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.put_object_from_filelike
+         :renderer: rst
 
    .. py:method:: put_object_from_file(filepath: aiida.repository.repository.FilePath, path: aiida.repository.repository.FilePath) -> None
       :canonical: aiida.repository.repository.Repository.put_object_from_file
 
-      Store a new object under `path` with contents of the file located at `filepath` on the local file system.
-
-      :param filepath: absolute path of file whose contents to copy to the repository
-      :param path: the relative path where to store the object in the repository.
-      :raises TypeError: if the path is not a string and relative path, or the handle is not a byte stream.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.put_object_from_file
+         :renderer: rst
 
    .. py:method:: put_object_from_tree(filepath: aiida.repository.repository.FilePath, path: typing.Optional[aiida.repository.repository.FilePath] = None) -> None
       :canonical: aiida.repository.repository.Repository.put_object_from_tree
 
-      Store the entire contents of `filepath` on the local file system in the repository with under given `path`.
-
-      :param filepath: absolute path of the directory whose contents to copy to the repository.
-      :param path: the relative path where to store the objects in the repository.
-      :raises TypeError: if the filepath is not a string or ``Path``, or is a relative path.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.put_object_from_tree
+         :renderer: rst
 
    .. py:method:: is_empty() -> bool
       :canonical: aiida.repository.repository.Repository.is_empty
 
-      Return whether the repository is empty.
-
-      :return: True if the repository contains no file objects.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.is_empty
+         :renderer: rst
 
    .. py:method:: has_object(path: aiida.repository.repository.FilePath) -> bool
       :canonical: aiida.repository.repository.Repository.has_object
 
-      Return whether the repository has an object with the given path.
-
-      :param path: the relative path of the object within the repository.
-      :return: True if the object exists, False otherwise.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.has_object
+         :renderer: rst
 
    .. py:method:: open(path: aiida.repository.repository.FilePath) -> typing.Iterator[typing.BinaryIO]
       :canonical: aiida.repository.repository.Repository.open
 
-      Open a file handle to an object stored under the given path.
-
-      .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
-          ``put_object_from_filelike`` instead.
-
-      :param path: the relative path of the object within the repository.
-      :return: yield a byte stream object.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
-      :raises FileNotFoundError: if the file does not exist.
-      :raises IsADirectoryError: if the object is a directory and not a file.
-      :raises OSError: if the file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.open
+         :renderer: rst
 
    .. py:method:: get_object_content(path: aiida.repository.repository.FilePath) -> bytes
       :canonical: aiida.repository.repository.Repository.get_object_content
 
-      Return the content of a object identified by path.
-
-      :param path: the relative path of the object within the repository.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
-      :raises FileNotFoundError: if the file does not exist.
-      :raises IsADirectoryError: if the object is a directory and not a file.
-      :raises OSError: if the file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.get_object_content
+         :renderer: rst
 
    .. py:method:: delete_object(path: aiida.repository.repository.FilePath, hard_delete: bool = False) -> None
       :canonical: aiida.repository.repository.Repository.delete_object
 
-      Soft delete the object from the repository.
-
-      .. note:: can only delete file objects, but not directories.
-
-      :param path: the relative path of the object within the repository.
-      :param hard_delete: when true, not only remove the file from the internal mapping but also call through to the
-          ``delete_object`` method of the actual repository backend.
-      :raises TypeError: if the path is not a string or ``Path``, or is an absolute path.
-      :raises FileNotFoundError: if the file does not exist.
-      :raises IsADirectoryError: if the object is a directory and not a file.
-      :raises OSError: if the file could not be deleted.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.delete_object
+         :renderer: rst
 
    .. py:method:: erase() -> None
       :canonical: aiida.repository.repository.Repository.erase
 
-      Delete all objects from the repository.
-
-      .. important: this intentionally does not call through to any ``erase`` method of the backend, because unlike
-          this class, the backend does not just store the objects of a single node, but potentially of a lot of other
-          nodes. Therefore, we manually delete all file objects and then simply reset the internal file hierarchy.
-
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.erase
+         :renderer: rst
 
    .. py:method:: clone(source: aiida.repository.repository.Repository) -> None
       :canonical: aiida.repository.repository.Repository.clone
 
-      Clone the contents of another repository instance.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.clone
+         :renderer: rst
 
    .. py:method:: walk(path: typing.Optional[aiida.repository.repository.FilePath] = None) -> typing.Iterable[typing.Tuple[pathlib.PurePosixPath, typing.List[str], typing.List[str]]]
       :canonical: aiida.repository.repository.Repository.walk
 
-      Walk over the directories and files contained within this repository.
-
-      .. note:: the order of the dirname and filename lists that are returned is not necessarily sorted. This is in
-          line with the ``os.walk`` implementation where the order depends on the underlying file system used.
-
-      :param path: the relative path of the directory within the repository whose contents to walk.
-      :return: tuples of root, dirnames and filenames just like ``os.walk``, with the exception that the root path is
-          always relative with respect to the repository root, instead of an absolute path and it is an instance of
-          ``pathlib.PurePosixPath`` instead of a normal string
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.walk
+         :renderer: rst
 
    .. py:method:: copy_tree(target: typing.Union[str, pathlib.Path], path: typing.Optional[aiida.repository.repository.FilePath] = None) -> None
       :canonical: aiida.repository.repository.Repository.copy_tree
 
-      Copy the contents of the entire node repository to another location on the local file system.
-
-      .. note:: If ``path`` is specified, only its contents are copied, and the relative path with respect to the
-          root is discarded. For example, if ``path`` is ``relative/sub``, the contents of ``sub`` will be copied
-          directly to the target, without the ``relative/sub`` directory.
-
-      :param target: absolute path of the directory where to copy the contents to.
-      :param path: optional relative path whose contents to copy.
-      :raises TypeError: if ``target`` is of incorrect type or not absolute.
-      :raises NotADirectoryError: if ``path`` does not reference a directory.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.copy_tree
+         :renderer: rst
 
    .. py:method:: initialise(**kwargs: typing.Any) -> None
       :canonical: aiida.repository.repository.Repository.initialise
 
-      Initialise the repository if it hasn't already been initialised.
-
-      :param kwargs: keyword argument that will be passed to the ``initialise`` call of the backend.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.initialise
+         :renderer: rst
 
    .. py:method:: delete() -> None
       :canonical: aiida.repository.repository.Repository.delete
 
-      Delete the repository.
-
-      .. important:: This will not just delete the contents of the repository but also the repository itself and all
-          of its assets. For example, if the repository is stored inside a folder on disk, the folder may be deleted.
+      .. autodoc2-docstring:: aiida.repository.repository.Repository.delete
+         :renderer: rst
 
 .. py:class:: SandboxRepositoryBackend(filepath: str | None = None)
    :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend
 
    Bases: :py:obj:`aiida.repository.backend.abstract.AbstractRepositoryBackend`
 
-   Implementation of the ``AbstractRepositoryBackend`` using a sandbox folder on disk as the backend.
+   .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Construct a new instance.
-
-   :param filepath: The path to the directory in which the sandbox folder should be created.
+   .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.__init__
+      :renderer: rst
 
    .. py:method:: __str__() -> str
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.__str__
 
-      Return the string representation of this repository.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.__str__
+         :renderer: rst
 
    .. py:method:: __del__()
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.__del__
 
-      Delete the entire sandbox folder if it was instantiated and still exists.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.__del__
+         :renderer: rst
 
    .. py:property:: uuid
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.uuid
       :type: str | None
 
-      Return the unique identifier of the repository.
-
-      .. note:: A sandbox folder does not have the concept of a unique identifier and so always returns ``None``.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.uuid
+         :renderer: rst
 
    .. py:property:: key_format
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.key_format
       :type: str | None
 
-      Return the format for the keys of the repository.
-
-      Important for when migrating between backends (e.g. archive -> main), as if they are not equal then it is
-      necessary to re-compute all the `Node.base.repository.metadata` before importing (otherwise they will not match
-      with the repository).
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.key_format
+         :renderer: rst
 
    .. py:method:: initialise(**kwargs) -> None
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.initialise
 
-      Initialise the repository if it hasn't already been initialised.
-
-      :param kwargs: parameters for the initialisation.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.initialise
+         :renderer: rst
 
    .. py:property:: is_initialised
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.is_initialised
       :type: bool
 
-      Return whether the repository has been initialised.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.is_initialised
+         :renderer: rst
 
    .. py:property:: sandbox
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.sandbox
 
-      Return the sandbox instance of this repository.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.sandbox
+         :renderer: rst
 
    .. py:method:: erase()
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.erase
 
-      Delete the repository itself and all its contents.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.erase
+         :renderer: rst
 
    .. py:method:: _put_object_from_filelike(handle: typing.BinaryIO) -> str
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend._put_object_from_filelike
 
-      Store the byte contents of a file in the repository.
-
-      :param handle: filelike object with the byte content to be stored.
-      :return: the generated fully qualified identifier for the object within the repository.
-      :raises TypeError: if the handle is not a byte stream.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend._put_object_from_filelike
+         :renderer: rst
 
    .. py:method:: has_objects(keys: list[str]) -> list[bool]
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.has_objects
 
-      Return whether the repository has an object with the given key.
-
-      :param keys:
-          list of fully qualified identifiers for objects within the repository.
-      :return:
-          list of logicals, in the same order as the keys provided, with value True if the respective
-          object exists and False otherwise.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.has_objects
+         :renderer: rst
 
    .. py:method:: open(key: str) -> typing.Iterator[typing.BinaryIO]
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.open
 
-      Open a file handle to an object stored under the given key.
-
-      .. note:: this should only be used to open a handle to read an existing file. To write a new file use the method
-          ``put_object_from_filelike`` instead.
-
-      :param key: fully qualified identifier for the object within the repository.
-      :return: yield a byte stream object.
-      :raise FileNotFoundError: if the file does not exist.
-      :raise OSError: if the file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.open
+         :renderer: rst
 
    .. py:method:: iter_object_streams(keys: list[str]) -> typing.Iterator[tuple[str, typing.BinaryIO]]
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.iter_object_streams
 
-      Return an iterator over the (read-only) byte streams of objects identified by key.
-
-      .. note:: handles should only be read within the context of this iterator.
-
-      :param keys: fully qualified identifiers for the objects within the repository.
-      :return: an iterator over the object byte streams.
-      :raise FileNotFoundError: if the file does not exist.
-      :raise OSError: if a file could not be opened.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.iter_object_streams
+         :renderer: rst
 
    .. py:method:: delete_objects(keys: list[str]) -> None
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.delete_objects
 
-      Delete the objects from the repository.
-
-      :param keys: list of fully qualified identifiers for the objects within the repository.
-      :raise FileNotFoundError: if any of the files does not exist.
-      :raise OSError: if any of the files could not be deleted.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.delete_objects
+         :renderer: rst
 
    .. py:method:: list_objects() -> typing.Iterable[str]
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.list_objects
 
-      Return iterable that yields all available objects by key.
-
-      :return: An iterable for all the available object keys.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.list_objects
+         :renderer: rst
 
    .. py:method:: maintain(dry_run: bool = False, live: bool = True, **kwargs) -> None
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.maintain
       :abstractmethod:
 
-      Performs maintenance operations.
-
-      :param dry_run:
-          flag to only print the actions that would be taken without actually executing them.
-
-      :param live:
-          flag to indicate to the backend whether AiiDA is live or not (i.e. if the profile of the
-          backend is currently being used/accessed). The backend is expected then to only allow (and
-          thus set by default) the operations that are safe to perform in this state.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.maintain
+         :renderer: rst
 
    .. py:method:: get_info(detailed: bool = False, **kwargs) -> dict
       :canonical: aiida.repository.backend.sandbox.SandboxRepositoryBackend.get_info
       :abstractmethod:
 
-      Returns relevant information about the content of the repository.
-
-      :param detailed:
-          flag to enable extra information (detailed=False by default, only returns basic information).
-
-      :return: a dictionary with the information.
+      .. autodoc2-docstring:: aiida.repository.backend.sandbox.SandboxRepositoryBackend.get_info
+         :renderer: rst

--- a/docs/apidocs/aiida/aiida.rst
+++ b/docs/apidocs/aiida/aiida.rst
@@ -7,17 +7,9 @@
 Description
 -----------
 
-AiiDA is a flexible and scalable informatics' infrastructure to manage,
-preserve, and disseminate the simulations, data, and workflows of
-modern-day computational science.
-
-Able to store the full provenance of each object, and based on a
-tailored database built for efficient data mining of heterogeneous results,
-AiiDA gives the user the ability to interact seamlessly with any number of
-remote HPC resources and codes, thanks to its flexible plugin interface
-and workflow engine for the automation of complex sequences of simulations.
-
-More information at http://www.aiida.net
+.. autodoc2-docstring:: aiida
+   :renderer: rst
+   :allowtitles:
 
 Subpackages
 -----------
@@ -49,15 +41,25 @@ Functions
    :align: left
 
    * - :py:obj:`get_strict_version <aiida.get_strict_version>`
-     - Return a distutils StrictVersion instance with the current distribution version
+     - .. autodoc2-docstring:: aiida.get_strict_version
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_version <aiida.get_version>`
-     - Return the current AiiDA distribution version
+     - .. autodoc2-docstring:: aiida.get_version
+          :renderer: rst
+          :summary:
    * - :py:obj:`_get_raw_file_header <aiida._get_raw_file_header>`
-     - Get the default header for source AiiDA source code files. Note: is not preceded by comment character.
+     - .. autodoc2-docstring:: aiida._get_raw_file_header
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_file_header <aiida.get_file_header>`
-     - Get the default header for source AiiDA source code files.
+     - .. autodoc2-docstring:: aiida.get_file_header
+          :renderer: rst
+          :summary:
    * - :py:obj:`load_ipython_extension <aiida.load_ipython_extension>`
-     - Load the AiiDA IPython extension, using ``%load_ext aiida``.
+     - .. autodoc2-docstring:: aiida.load_ipython_extension
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -67,17 +69,29 @@ Data
    :align: left
 
    * - :py:obj:`__copyright__ <aiida.__copyright__>`
-     - 
+     - .. autodoc2-docstring:: aiida.__copyright__
+          :renderer: rst
+          :summary:
    * - :py:obj:`__license__ <aiida.__license__>`
-     - 
+     - .. autodoc2-docstring:: aiida.__license__
+          :renderer: rst
+          :summary:
    * - :py:obj:`__version__ <aiida.__version__>`
-     - 
+     - .. autodoc2-docstring:: aiida.__version__
+          :renderer: rst
+          :summary:
    * - :py:obj:`__authors__ <aiida.__authors__>`
-     - 
+     - .. autodoc2-docstring:: aiida.__authors__
+          :renderer: rst
+          :summary:
    * - :py:obj:`__paper__ <aiida.__paper__>`
-     - 
+     - .. autodoc2-docstring:: aiida.__paper__
+          :renderer: rst
+          :summary:
    * - :py:obj:`__paper_short__ <aiida.__paper_short__>`
-     - 
+     - .. autodoc2-docstring:: aiida.__paper_short__
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -86,63 +100,70 @@ API
    :canonical: aiida.__copyright__
    :value: 'Copyright (c), This file is part of the AiiDA platform. For further information please visit http://...'
 
+   .. autodoc2-docstring:: aiida.__copyright__
+      :renderer: rst
+
 .. py:data:: __license__
    :canonical: aiida.__license__
    :value: 'MIT license, see LICENSE.txt file.'
+
+   .. autodoc2-docstring:: aiida.__license__
+      :renderer: rst
 
 .. py:data:: __version__
    :canonical: aiida.__version__
    :value: '2.2.2'
 
+   .. autodoc2-docstring:: aiida.__version__
+      :renderer: rst
+
 .. py:data:: __authors__
    :canonical: aiida.__authors__
    :value: 'The AiiDA team.'
+
+   .. autodoc2-docstring:: aiida.__authors__
+      :renderer: rst
 
 .. py:data:: __paper__
    :canonical: aiida.__paper__
    :value: 'S. P. Huber et al., "AiiDA 1.0, a scalable computational infrastructure for automated reproducible w...'
 
+   .. autodoc2-docstring:: aiida.__paper__
+      :renderer: rst
+
 .. py:data:: __paper_short__
    :canonical: aiida.__paper_short__
    :value: 'S. P. Huber et al., Scientific Data 7, 300 (2020).'
 
+   .. autodoc2-docstring:: aiida.__paper_short__
+      :renderer: rst
+
 .. py:function:: get_strict_version()
    :canonical: aiida.get_strict_version
 
-   Return a distutils StrictVersion instance with the current distribution version
-
-   :returns: StrictVersion instance with the current version
-   :rtype: :class:`!distutils.version.StrictVersion`
+   .. autodoc2-docstring:: aiida.get_strict_version
+      :renderer: rst
 
 .. py:function:: get_version() -> str
    :canonical: aiida.get_version
 
-   Return the current AiiDA distribution version
-
-   :returns: the current version
+   .. autodoc2-docstring:: aiida.get_version
+      :renderer: rst
 
 .. py:function:: _get_raw_file_header() -> str
    :canonical: aiida._get_raw_file_header
 
-   Get the default header for source AiiDA source code files.
-   Note: is not preceded by comment character.
-
-   :return: default AiiDA source file header
+   .. autodoc2-docstring:: aiida._get_raw_file_header
+      :renderer: rst
 
 .. py:function:: get_file_header(comment_char: str = '# ') -> str
    :canonical: aiida.get_file_header
 
-   Get the default header for source AiiDA source code files.
-
-   .. note::
-
-       Prepend by comment character.
-
-   :param comment_char: string put in front of each line
-
-   :return: default AiiDA source file header
+   .. autodoc2-docstring:: aiida.get_file_header
+      :renderer: rst
 
 .. py:function:: load_ipython_extension(ipython)
    :canonical: aiida.load_ipython_extension
 
-   Load the AiiDA IPython extension, using ``%load_ext aiida``.
+   .. autodoc2-docstring:: aiida.load_ipython_extension
+      :renderer: rst

--- a/docs/apidocs/aiida/aiida.schedulers.rst
+++ b/docs/apidocs/aiida/aiida.schedulers.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Module for classes and utilities to interact with cluster schedulers.
+.. autodoc2-docstring:: aiida.schedulers
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -20,25 +22,45 @@ Classes
    :align: left
 
    * - :py:obj:`JobInfo <aiida.schedulers.datastructures.JobInfo>`
-     - Contains properties for a job in the queue. Most of the fields are taken from DRMAA v.2.
+     - .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo
+          :renderer: rst
+          :summary:
    * - :py:obj:`JobResource <aiida.schedulers.datastructures.JobResource>`
-     - Data structure to store job resources.
+     - .. autodoc2-docstring:: aiida.schedulers.datastructures.JobResource
+          :renderer: rst
+          :summary:
    * - :py:obj:`JobState <aiida.schedulers.datastructures.JobState>`
-     - Enumeration of possible scheduler states of a CalcJob.
+     - .. autodoc2-docstring:: aiida.schedulers.datastructures.JobState
+          :renderer: rst
+          :summary:
    * - :py:obj:`JobTemplate <aiida.schedulers.datastructures.JobTemplate>`
-     - A template for submitting jobs to a scheduler.
+     - .. autodoc2-docstring:: aiida.schedulers.datastructures.JobTemplate
+          :renderer: rst
+          :summary:
    * - :py:obj:`MachineInfo <aiida.schedulers.datastructures.MachineInfo>`
-     - Similarly to what is defined in the DRMAA v.2 as SlotInfo; this identifies each machine (also called 'node' on some schedulers) on which a job is running, and how many CPUs are being used. (Some of them could be undefined)
+     - .. autodoc2-docstring:: aiida.schedulers.datastructures.MachineInfo
+          :renderer: rst
+          :summary:
    * - :py:obj:`NodeNumberJobResource <aiida.schedulers.datastructures.NodeNumberJobResource>`
-     - `JobResource` for schedulers that support the specification of a number of nodes and cpus per node.
+     - .. autodoc2-docstring:: aiida.schedulers.datastructures.NodeNumberJobResource
+          :renderer: rst
+          :summary:
    * - :py:obj:`ParEnvJobResource <aiida.schedulers.datastructures.ParEnvJobResource>`
-     - `JobResource` for schedulers that support the specification of a parallel environment and number of MPI procs.
+     - .. autodoc2-docstring:: aiida.schedulers.datastructures.ParEnvJobResource
+          :renderer: rst
+          :summary:
    * - :py:obj:`Scheduler <aiida.schedulers.scheduler.Scheduler>`
-     - Base class for a job scheduler.
+     - .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler
+          :renderer: rst
+          :summary:
    * - :py:obj:`SchedulerError <aiida.schedulers.scheduler.SchedulerError>`
-     - 
+     - .. autodoc2-docstring:: aiida.schedulers.scheduler.SchedulerError
+          :renderer: rst
+          :summary:
    * - :py:obj:`SchedulerParsingError <aiida.schedulers.scheduler.SchedulerParsingError>`
-     - 
+     - .. autodoc2-docstring:: aiida.schedulers.scheduler.SchedulerParsingError
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -48,712 +70,549 @@ API
 
    Bases: :py:obj:`aiida.common.extendeddicts.DefaultFieldsAttributeDict`
 
-   Contains properties for a job in the queue.
-   Most of the fields are taken from DRMAA v.2.
-
-   Note that default fields may be undefined. This
-   is an expected behavior and the application must cope with this
-   case. An example for instance is the exit_status for jobs that have
-   not finished yet; or features not supported by the given scheduler.
-
-   Fields:
-
-      * ``job_id``: the job ID on the scheduler
-      * ``title``: the job title, as known by the scheduler
-      * ``exit_status``: the exit status of the job as reported by the operating
-        system on the execution host
-      * ``terminating_signal``: the UNIX signal that was responsible for the end
-        of the job.
-      * ``annotation``: human-readable description of the reason for the job
-        being in the current state or substate.
-      * ``job_state``: the job state (one of those defined in
-        ``aiida.schedulers.datastructures.JobState``)
-      * ``job_substate``: a string with the implementation-specific sub-state
-      * ``allocated_machines``: a list of machines used for the current job.
-        This is a list of :py:class:`aiida.schedulers.datastructures.MachineInfo` objects.
-      * ``job_owner``: the job owner as reported by the scheduler
-      * ``num_mpiprocs``: the *total* number of requested MPI procs
-      * ``num_cpus``: the *total* number of requested CPUs (cores) [may be undefined]
-      * ``num_machines``: the number of machines (i.e., nodes), required by the
-        job. If ``allocated_machines`` is not None, this number must be equal to
-        ``len(allocated_machines)``. Otherwise, for schedulers not supporting
-        the retrieval of the full list of allocated machines, this
-        attribute can be used to know at least the number of machines.
-      * ``queue_name``: The name of the queue in which the job is queued or
-        running.
-      * ``account``: The account/projectid in which the job is queued or
-        running in.
-      * ``qos``: The quality of service in which the job is queued or
-        running in.
-      * ``wallclock_time_seconds``: the accumulated wallclock time, in seconds
-      * ``requested_wallclock_time_seconds``: the requested wallclock time,
-        in seconds
-      * ``cpu_time``: the accumulated cpu time, in seconds
-      * ``submission_time``: the absolute time at which the job was submitted,
-        of type datetime.datetime
-      * ``dispatch_time``: the absolute time at which the job first entered the
-        'started' state, of type datetime.datetime
-      * ``finish_time``: the absolute time at which the job first entered the
-        'finished' state, of type datetime.datetime
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo.__init__
+      :renderer: rst
 
    .. py:attribute:: _default_fields
       :canonical: aiida.schedulers.datastructures.JobInfo._default_fields
       :value: ('job_id', 'title', 'exit_status', 'terminating_signal', 'annotation', 'job_state', 'job_substate', ...
 
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo._default_fields
+         :renderer: rst
+
    .. py:attribute:: _special_serializers
       :canonical: aiida.schedulers.datastructures.JobInfo._special_serializers
       :value: None
+
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo._special_serializers
+         :renderer: rst
 
    .. py:method:: _serialize_job_state(job_state)
       :canonical: aiida.schedulers.datastructures.JobInfo._serialize_job_state
       :staticmethod:
 
-      Return the serialized value of the JobState instance.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo._serialize_job_state
+         :renderer: rst
 
    .. py:method:: _deserialize_job_state(job_state)
       :canonical: aiida.schedulers.datastructures.JobInfo._deserialize_job_state
       :staticmethod:
 
-      Return an instance of JobState from the job_state string.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo._deserialize_job_state
+         :renderer: rst
 
    .. py:method:: _serialize_date(value)
       :canonical: aiida.schedulers.datastructures.JobInfo._serialize_date
       :staticmethod:
 
-      Serialise a data value
-      :param value: The value to serialise
-      :return: The serialised value
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo._serialize_date
+         :renderer: rst
 
    .. py:method:: _deserialize_date(value)
       :canonical: aiida.schedulers.datastructures.JobInfo._deserialize_date
       :staticmethod:
 
-      Deserialise a date
-      :param value: The date vlue
-      :return: The deserialised date
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo._deserialize_date
+         :renderer: rst
 
    .. py:method:: serialize_field(value, field_type)
       :canonical: aiida.schedulers.datastructures.JobInfo.serialize_field
       :classmethod:
 
-      Serialise a particular field value
-
-      :param value: The value to serialise
-      :param field_type: The field type
-      :return: The serialised value
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo.serialize_field
+         :renderer: rst
 
    .. py:method:: deserialize_field(value, field_type)
       :canonical: aiida.schedulers.datastructures.JobInfo.deserialize_field
       :classmethod:
 
-      Deserialise the value of a particular field with a type
-      :param value: The value
-      :param field_type: The field type
-      :return: The deserialised value
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo.deserialize_field
+         :renderer: rst
 
    .. py:method:: serialize()
       :canonical: aiida.schedulers.datastructures.JobInfo.serialize
 
-      Serialize the current data (as obtained by ``self.get_dict()``) into a JSON string.
-
-      :return: A string with serialised representation of the current data.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo.serialize
+         :renderer: rst
 
    .. py:method:: get_dict()
       :canonical: aiida.schedulers.datastructures.JobInfo.get_dict
 
-      Serialise the current data into a dictionary that is JSON-serializable.
-
-      :return: A dictionary
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo.get_dict
+         :renderer: rst
 
    .. py:method:: load_from_dict(data)
       :canonical: aiida.schedulers.datastructures.JobInfo.load_from_dict
       :classmethod:
 
-      Create a new instance loading the values from serialised data in dictionary form
-
-      :param data: The dictionary with the data to load from
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo.load_from_dict
+         :renderer: rst
 
    .. py:method:: load_from_serialized(data)
       :canonical: aiida.schedulers.datastructures.JobInfo.load_from_serialized
       :classmethod:
 
-      Create a new instance loading the values from JSON-serialised data as a string
-
-      :param data: The string with the JSON-serialised data to load from
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobInfo.load_from_serialized
+         :renderer: rst
 
 .. py:class:: JobResource(dictionary=None)
    :canonical: aiida.schedulers.datastructures.JobResource
 
    Bases: :py:obj:`aiida.common.extendeddicts.DefaultFieldsAttributeDict`
 
-   Data structure to store job resources.
-
-   Each `Scheduler` implementation must define the `_job_resource_class` attribute to be a subclass of this class.
-   It should at least define the `get_tot_num_mpiprocs` method, plus a constructor to accept its set of variables.
-
-   Typical attributes are:
-
-   * ``num_machines``
-   * ``num_mpiprocs_per_machine``
-
-   or (e.g. for SGE)
-
-   * ``tot_num_mpiprocs``
-   * ``parallel_env``
-
-   The constructor should take care of checking the values.
-   The init should raise only ValueError or TypeError on invalid parameters.
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.JobResource
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.JobResource.__init__
+      :renderer: rst
 
    .. py:attribute:: _default_fields
       :canonical: aiida.schedulers.datastructures.JobResource._default_fields
       :value: None
+
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobResource._default_fields
+         :renderer: rst
 
    .. py:method:: validate_resources(**kwargs)
       :canonical: aiida.schedulers.datastructures.JobResource.validate_resources
       :abstractmethod:
       :classmethod:
 
-      Validate the resources against the job resource class of this scheduler.
-
-      :param kwargs: dictionary of values to define the job resources
-      :raises ValueError: if the resources are invalid or incomplete
-      :return: optional tuple of parsed resource settings
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobResource.validate_resources
+         :renderer: rst
 
    .. py:method:: get_valid_keys()
       :canonical: aiida.schedulers.datastructures.JobResource.get_valid_keys
       :classmethod:
 
-      Return a list of valid keys to be passed to the constructor.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobResource.get_valid_keys
+         :renderer: rst
 
    .. py:method:: accepts_default_mpiprocs_per_machine()
       :canonical: aiida.schedulers.datastructures.JobResource.accepts_default_mpiprocs_per_machine
       :abstractmethod:
       :classmethod:
 
-      Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobResource.accepts_default_mpiprocs_per_machine
+         :renderer: rst
 
    .. py:method:: accepts_default_memory_per_machine()
       :canonical: aiida.schedulers.datastructures.JobResource.accepts_default_memory_per_machine
       :classmethod:
 
-      Return True if this subclass accepts a `default_memory_per_machine` key, False otherwise.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobResource.accepts_default_memory_per_machine
+         :renderer: rst
 
    .. py:method:: get_tot_num_mpiprocs()
       :canonical: aiida.schedulers.datastructures.JobResource.get_tot_num_mpiprocs
       :abstractmethod:
 
-      Return the total number of cpus of this job resource.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobResource.get_tot_num_mpiprocs
+         :renderer: rst
 
 .. py:class:: JobState
    :canonical: aiida.schedulers.datastructures.JobState
 
    Bases: :py:obj:`enum.Enum`
 
-   Enumeration of possible scheduler states of a CalcJob.
-
-   There is no FAILED state as every completed job is put in DONE, regardless of success.
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.JobState
+      :renderer: rst
 
    .. py:attribute:: UNDETERMINED
       :canonical: aiida.schedulers.datastructures.JobState.UNDETERMINED
       :value: 'undetermined'
 
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobState.UNDETERMINED
+         :renderer: rst
+
    .. py:attribute:: QUEUED
       :canonical: aiida.schedulers.datastructures.JobState.QUEUED
       :value: 'queued'
+
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobState.QUEUED
+         :renderer: rst
 
    .. py:attribute:: QUEUED_HELD
       :canonical: aiida.schedulers.datastructures.JobState.QUEUED_HELD
       :value: 'queued held'
 
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobState.QUEUED_HELD
+         :renderer: rst
+
    .. py:attribute:: RUNNING
       :canonical: aiida.schedulers.datastructures.JobState.RUNNING
       :value: 'running'
+
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobState.RUNNING
+         :renderer: rst
 
    .. py:attribute:: SUSPENDED
       :canonical: aiida.schedulers.datastructures.JobState.SUSPENDED
       :value: 'suspended'
 
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobState.SUSPENDED
+         :renderer: rst
+
    .. py:attribute:: DONE
       :canonical: aiida.schedulers.datastructures.JobState.DONE
       :value: 'done'
+
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobState.DONE
+         :renderer: rst
 
 .. py:class:: JobTemplate(dictionary=None)
    :canonical: aiida.schedulers.datastructures.JobTemplate
 
    Bases: :py:obj:`aiida.common.extendeddicts.DefaultFieldsAttributeDict`
 
-   A template for submitting jobs to a scheduler.
-
-   This contains all required information to create the job header.
-
-   The required fields are: working_directory, job_name, num_machines, num_mpiprocs_per_machine, argv.
-
-   Fields:
-
-     * ``shebang line``: The first line of the submission script
-     * ``submit_as_hold``: if set, the job will be in a 'hold' status right
-       after the submission
-     * ``rerunnable``: if the job is rerunnable (boolean)
-     * ``job_environment``: a dictionary with environment variables to set
-       before the execution of the code.
-     * ``environment_variables_double_quotes``: if set to True, use double quotes
-       instead of single quotes to escape the environment variables specified
-       in ``environment_variables``.
-     * ``working_directory``: the working directory for this job. During
-       submission, the transport will first do a 'chdir' to this directory,
-       and then possibly set a scheduler parameter, if this is supported
-       by the scheduler.
-     * ``email``: an email address for sending emails on job events.
-     * ``email_on_started``: if True, ask the scheduler to send an email when the
-       job starts.
-     * ``email_on_terminated``: if True, ask the scheduler to send an email when
-       the job ends. This should also send emails on job failure, when
-       possible.
-     * ``job_name``: the name of this job. The actual name of the job can be
-       different from the one specified here, e.g. if there are unsupported
-       characters, or the name is too long.
-     * ``sched_output_path``: a (relative) file name for the stdout of this job
-     * ``sched_error_path``: a (relative) file name for the stdout of this job
-     * ``sched_join_files``: if True, write both stdout and stderr on the same
-       file (the one specified for stdout)
-     * ``queue_name``: the name of the scheduler queue (sometimes also called
-       partition), on which the job will be submitted.
-     * ``account``: the name of the scheduler account (sometimes also called
-       projectid), on which the job will be submitted.
-     * ``qos``: the quality of service of the scheduler account,
-       on which the job will be submitted.
-     * ``job_resource``: a suitable :py:class:`JobResource`
-       subclass with information on how many
-       nodes and cpus it should use. It must be an instance of the
-       ``aiida.schedulers.Scheduler.job_resource_class`` class.
-       Use the Scheduler.create_job_resource method to create it.
-     * ``num_machines``: how many machines (or nodes) should be used
-     * ``num_mpiprocs_per_machine``: how many MPI procs should be used on each
-       machine (or node).
-     * ``priority``: a priority for this job. Should be in the format accepted
-       by the specific scheduler.
-     * ``max_memory_kb``: The maximum amount of memory the job is allowed
-       to allocate ON EACH NODE, in kilobytes
-     * ``max_wallclock_seconds``: The maximum wall clock time that all processes
-       of a job are allowed to exist, in seconds
-     * ``custom_scheduler_commands``: a string that will be inserted right
-       after the last scheduler command, and before any other non-scheduler
-       command; useful if some specific flag needs to be added and is not
-       supported by the plugin
-     * ``prepend_text``: a (possibly multi-line) string to be inserted
-       in the scheduler script before the main execution line
-     * ``append_text``: a (possibly multi-line) string to be inserted
-       in the scheduler script after the main execution line
-     * ``import_sys_environment``: import the system environment variables
-     * ``codes_info``: a list of aiida.scheduler.datastructures.JobTemplateCodeInfo objects.
-       Each contains the information necessary to run a single code. At the
-       moment, it can contain:
-
-       * ``cmdline_parameters``: a list of strings with the command line arguments
-         of the program to run. This is the main program to be executed.
-         NOTE: The first one is the executable name.
-         For MPI runs, this will probably be "mpirun" or a similar program;
-         this has to be chosen at a upper level.
-       * ``stdin_name``: the (relative) file name to be used as stdin for the
-         program specified with argv.
-       * ``stdout_name``: the (relative) file name to be used as stdout for the
-         program specified with argv.
-       * ``stderr_name``: the (relative) file name to be used as stderr for the
-         program specified with argv.
-       * ``join_files``: if True, stderr is redirected on the same file
-         specified for stdout.
-
-     * ``codes_run_mode``: sets the run_mode with which the (multiple) codes
-       have to be executed. For example, parallel execution::
-
-         mpirun -np 8 a.x &
-         mpirun -np 8 b.x &
-         wait
-
-       The serial execution would be without the &'s.
-       Values are given by aiida.common.datastructures.CodeRunMode.
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.JobTemplate
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.JobTemplate.__init__
+      :renderer: rst
 
    .. py:attribute:: _default_fields
       :canonical: aiida.schedulers.datastructures.JobTemplate._default_fields
       :value: ('shebang', 'submit_as_hold', 'rerunnable', 'job_environment', 'environment_variables_double_quotes'...
+
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.JobTemplate._default_fields
+         :renderer: rst
 
 .. py:class:: MachineInfo(dictionary=None)
    :canonical: aiida.schedulers.datastructures.MachineInfo
 
    Bases: :py:obj:`aiida.common.extendeddicts.DefaultFieldsAttributeDict`
 
-   Similarly to what is defined in the DRMAA v.2 as SlotInfo; this identifies
-   each machine (also called 'node' on some schedulers)
-   on which a job is running, and how many CPUs are being used. (Some of them
-   could be undefined)
-
-   * ``name``: name of the machine
-   * ``num_cpus``: number of cores used by the job on this machine
-   * ``num_mpiprocs``: number of MPI processes used by the job on this machine
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.MachineInfo
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Recursively turn the `dict` and all its nested dictionaries into `AttributeDict` instance.
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.MachineInfo.__init__
+      :renderer: rst
 
    .. py:attribute:: _default_fields
       :canonical: aiida.schedulers.datastructures.MachineInfo._default_fields
       :value: ('name', 'num_mpiprocs', 'num_cpus')
+
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.MachineInfo._default_fields
+         :renderer: rst
 
 .. py:class:: NodeNumberJobResource(**kwargs)
    :canonical: aiida.schedulers.datastructures.NodeNumberJobResource
 
    Bases: :py:obj:`aiida.schedulers.datastructures.JobResource`
 
-   `JobResource` for schedulers that support the specification of a number of nodes and cpus per node.
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.NodeNumberJobResource
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize the job resources from the passed arguments.
-
-   :raises ValueError: if the resources are invalid or incomplete
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.NodeNumberJobResource.__init__
+      :renderer: rst
 
    .. py:attribute:: _default_fields
       :canonical: aiida.schedulers.datastructures.NodeNumberJobResource._default_fields
       :value: ('num_machines', 'num_mpiprocs_per_machine', 'num_cores_per_machine', 'num_cores_per_mpiproc')
 
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.NodeNumberJobResource._default_fields
+         :renderer: rst
+
    .. py:method:: validate_resources(**kwargs)
       :canonical: aiida.schedulers.datastructures.NodeNumberJobResource.validate_resources
       :classmethod:
 
-      Validate the resources against the job resource class of this scheduler.
-
-      :param kwargs: dictionary of values to define the job resources
-      :return: attribute dictionary with the parsed parameters populated
-      :raises ValueError: if the resources are invalid or incomplete
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.NodeNumberJobResource.validate_resources
+         :renderer: rst
 
    .. py:method:: get_valid_keys()
       :canonical: aiida.schedulers.datastructures.NodeNumberJobResource.get_valid_keys
       :classmethod:
 
-      Return a list of valid keys to be passed to the constructor.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.NodeNumberJobResource.get_valid_keys
+         :renderer: rst
 
    .. py:method:: accepts_default_mpiprocs_per_machine()
       :canonical: aiida.schedulers.datastructures.NodeNumberJobResource.accepts_default_mpiprocs_per_machine
       :classmethod:
 
-      Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.NodeNumberJobResource.accepts_default_mpiprocs_per_machine
+         :renderer: rst
 
    .. py:method:: get_tot_num_mpiprocs()
       :canonical: aiida.schedulers.datastructures.NodeNumberJobResource.get_tot_num_mpiprocs
 
-      Return the total number of cpus of this job resource.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.NodeNumberJobResource.get_tot_num_mpiprocs
+         :renderer: rst
 
 .. py:class:: ParEnvJobResource(**kwargs)
    :canonical: aiida.schedulers.datastructures.ParEnvJobResource
 
    Bases: :py:obj:`aiida.schedulers.datastructures.JobResource`
 
-   `JobResource` for schedulers that support the specification of a parallel environment and number of MPI procs.
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.ParEnvJobResource
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize the job resources from the passed arguments (the valid keys can be
-   obtained with the function self.get_valid_keys()).
-
-   :raises ValueError: if the resources are invalid or incomplete
+   .. autodoc2-docstring:: aiida.schedulers.datastructures.ParEnvJobResource.__init__
+      :renderer: rst
 
    .. py:attribute:: _default_fields
       :canonical: aiida.schedulers.datastructures.ParEnvJobResource._default_fields
       :value: ('parallel_env', 'tot_num_mpiprocs')
 
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.ParEnvJobResource._default_fields
+         :renderer: rst
+
    .. py:method:: validate_resources(**kwargs)
       :canonical: aiida.schedulers.datastructures.ParEnvJobResource.validate_resources
       :classmethod:
 
-      Validate the resources against the job resource class of this scheduler.
-
-      :param kwargs: dictionary of values to define the job resources
-      :return: attribute dictionary with the parsed parameters populated
-      :raises ValueError: if the resources are invalid or incomplete
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.ParEnvJobResource.validate_resources
+         :renderer: rst
 
    .. py:method:: accepts_default_mpiprocs_per_machine()
       :canonical: aiida.schedulers.datastructures.ParEnvJobResource.accepts_default_mpiprocs_per_machine
       :classmethod:
 
-      Return True if this subclass accepts a `default_mpiprocs_per_machine` key, False otherwise.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.ParEnvJobResource.accepts_default_mpiprocs_per_machine
+         :renderer: rst
 
    .. py:method:: get_tot_num_mpiprocs()
       :canonical: aiida.schedulers.datastructures.ParEnvJobResource.get_tot_num_mpiprocs
 
-      Return the total number of cpus of this job resource.
+      .. autodoc2-docstring:: aiida.schedulers.datastructures.ParEnvJobResource.get_tot_num_mpiprocs
+         :renderer: rst
 
 .. py:class:: Scheduler()
    :canonical: aiida.schedulers.scheduler.Scheduler
 
-   Base class for a job scheduler.
+   .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.__init__
+      :renderer: rst
 
    .. py:attribute:: _logger
       :canonical: aiida.schedulers.scheduler.Scheduler._logger
       :value: None
+
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._logger
+         :renderer: rst
 
    .. py:attribute:: _features
       :canonical: aiida.schedulers.scheduler.Scheduler._features
       :type: typing.Dict[str, bool]
       :value: None
 
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._features
+         :renderer: rst
+
    .. py:attribute:: _job_resource_class
       :canonical: aiida.schedulers.scheduler.Scheduler._job_resource_class
       :type: typing.Type[aiida.schedulers.datastructures.JobResource]
       :value: None
 
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._job_resource_class
+         :renderer: rst
+
    .. py:method:: __str__()
       :canonical: aiida.schedulers.scheduler.Scheduler.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.__str__
+         :renderer: rst
 
    .. py:method:: preprocess_resources(resources, default_mpiprocs_per_machine=None)
       :canonical: aiida.schedulers.scheduler.Scheduler.preprocess_resources
       :classmethod:
 
-      Pre process the resources.
-
-      Add the `num_mpiprocs_per_machine` key to the `resources` if it is not already defined and it cannot be deduced
-      from the `num_machines` and `tot_num_mpiprocs` being defined. The value is also not added if the job resource
-      class of this scheduler does not accept the `num_mpiprocs_per_machine` keyword. Note that the changes are made
-      in place to the `resources` argument passed.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.preprocess_resources
+         :renderer: rst
 
    .. py:method:: validate_resources(**resources)
       :canonical: aiida.schedulers.scheduler.Scheduler.validate_resources
       :classmethod:
 
-      Validate the resources against the job resource class of this scheduler.
-
-      :param resources: keyword arguments to define the job resources
-      :raises ValueError: if the resources are invalid or incomplete
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.validate_resources
+         :renderer: rst
 
    .. py:method:: get_short_doc()
       :canonical: aiida.schedulers.scheduler.Scheduler.get_short_doc
       :classmethod:
 
-      Return the first non-empty line of the class docstring, if available.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.get_short_doc
+         :renderer: rst
 
    .. py:method:: get_feature(feature_name: str) -> bool
       :canonical: aiida.schedulers.scheduler.Scheduler.get_feature
 
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.get_feature
+         :renderer: rst
+
    .. py:property:: logger
       :canonical: aiida.schedulers.scheduler.Scheduler.logger
 
-      Return the internal logger.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.logger
+         :renderer: rst
 
    .. py:method:: job_resource_class() -> typing.Type[aiida.schedulers.datastructures.JobResource]
       :canonical: aiida.schedulers.scheduler.Scheduler.job_resource_class
+
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.job_resource_class
+         :renderer: rst
 
    .. py:method:: create_job_resource(**kwargs)
       :canonical: aiida.schedulers.scheduler.Scheduler.create_job_resource
       :classmethod:
 
-      Create a suitable job resource from the kwargs specified.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.create_job_resource
+         :renderer: rst
 
    .. py:method:: get_submit_script(job_tmpl)
       :canonical: aiida.schedulers.scheduler.Scheduler.get_submit_script
 
-      Return the submit script as a string.
-
-      :parameter job_tmpl: a `aiida.schedulers.datastrutures.JobTemplate` instance.
-
-      The plugin returns something like
-
-      #!/bin/bash <- this shebang line is configurable to some extent
-      scheduler_dependent stuff to choose numnodes, numcores, walltime, ...
-      prepend_computer [also from calcinfo, joined with the following?]
-      prepend_code [from calcinfo]
-      output of _get_script_main_content
-      postpend_code
-      postpend_computer
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.get_submit_script
+         :renderer: rst
 
    .. py:method:: _get_submit_script_environment_variables(template)
       :canonical: aiida.schedulers.scheduler.Scheduler._get_submit_script_environment_variables
 
-      Return the part of the submit script header that defines environment variables.
-
-      :parameter template: a `aiida.schedulers.datastrutures.JobTemplate` instance.
-      :return: string containing environment variable declarations.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._get_submit_script_environment_variables
+         :renderer: rst
 
    .. py:method:: _get_submit_script_header(job_tmpl)
       :canonical: aiida.schedulers.scheduler.Scheduler._get_submit_script_header
       :abstractmethod:
 
-      Return the submit script header, using the parameters from the job template.
-
-      :param job_tmpl: a `JobTemplate` instance with relevant parameters set.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._get_submit_script_header
+         :renderer: rst
 
    .. py:method:: _get_submit_script_footer(job_tmpl)
       :canonical: aiida.schedulers.scheduler.Scheduler._get_submit_script_footer
 
-      Return the submit script final part, using the parameters from the job template.
-
-      :param job_tmpl: a `JobTemplate` instance with relevant parameters set.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._get_submit_script_footer
+         :renderer: rst
 
    .. py:method:: _get_run_line(codes_info, codes_run_mode)
       :canonical: aiida.schedulers.scheduler.Scheduler._get_run_line
 
-      Return a string with the line to execute a specific code with specific arguments.
-
-      :parameter codes_info: a list of `aiida.scheduler.datastructures.JobTemplateCodeInfo` objects.
-          Each contains the information needed to run the code. I.e. `cmdline_params`, `stdin_name`,
-          `stdout_name`, `stderr_name`, `join_files`. See
-          the documentation of `JobTemplate` and `JobTemplateCodeInfo`.
-      :parameter codes_run_mode: instance of `aiida.common.datastructures.CodeRunMode` contains the information on how
-          to launch the multiple codes.
-      :return: string with format: [executable] [args] {[ < stdin ]} {[ < stdout ]} {[2>&1 | 2> stderr]}
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._get_run_line
+         :renderer: rst
 
    .. py:method:: _get_joblist_command(jobs=None, user=None)
       :canonical: aiida.schedulers.scheduler.Scheduler._get_joblist_command
       :abstractmethod:
 
-      Return the command to get the most complete description possible of currently active jobs.
-
-      .. note::
-
-          Typically one can pass only either jobs or user, depending on the specific plugin. The choice can be done
-          according to the value returned by `self.get_feature('can_query_by_user')`
-
-      :param jobs: either None to get a list of all jobs in the machine, or a list of jobs.
-      :param user: either None, or a string with the username (to show only jobs of the specific user).
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._get_joblist_command
+         :renderer: rst
 
    .. py:method:: _get_detailed_job_info_command(job_id)
       :canonical: aiida.schedulers.scheduler.Scheduler._get_detailed_job_info_command
 
-      Return the command to run to get detailed information for a given job.
-
-      This is typically called after the job has finished, to retrieve the most detailed information possible about
-      the job. This is done because most schedulers just make finished jobs disappear from the `qstat` command, and
-      instead sometimes it is useful to know some more detailed information about the job exit status, etc.
-
-      :raises: :class:`aiida.common.exceptions.FeatureNotAvailable`
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._get_detailed_job_info_command
+         :renderer: rst
 
    .. py:method:: get_detailed_job_info(job_id)
       :canonical: aiida.schedulers.scheduler.Scheduler.get_detailed_job_info
 
-      Return the detailed job info.
-
-      This will be a dictionary with the return value, stderr and stdout content returned by calling the command that
-      is returned by `_get_detailed_job_info_command`.
-
-      :param job_id: the job identifier
-      :return: dictionary with `retval`, `stdout` and `stderr`.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.get_detailed_job_info
+         :renderer: rst
 
    .. py:method:: _parse_joblist_output(retval, stdout, stderr)
       :canonical: aiida.schedulers.scheduler.Scheduler._parse_joblist_output
       :abstractmethod:
 
-      Parse the joblist output as returned by executing the command returned by `_get_joblist_command` method.
-
-      :return: list of `JobInfo` objects, one of each job each with at least its default params implemented.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._parse_joblist_output
+         :renderer: rst
 
    .. py:method:: get_jobs(jobs=None, user=None, as_dict=False)
       :canonical: aiida.schedulers.scheduler.Scheduler.get_jobs
 
-      Return the list of currently active jobs.
-
-      .. note:: typically, only either jobs or user can be specified. See also comments in `_get_joblist_command`.
-
-      :param list jobs: a list of jobs to check; only these are checked
-      :param str user: a string with a user: only jobs of this user are checked
-      :param list as_dict: if False (default), a list of JobInfo objects is returned. If True, a dictionary is
-          returned, having as key the job_id and as value the JobInfo object.
-      :return: list of active jobs
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.get_jobs
+         :renderer: rst
 
    .. py:property:: transport
       :canonical: aiida.schedulers.scheduler.Scheduler.transport
 
-      Return the transport set for this scheduler.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.transport
+         :renderer: rst
 
    .. py:method:: set_transport(transport)
       :canonical: aiida.schedulers.scheduler.Scheduler.set_transport
 
-      Set the transport to be used to query the machine or to submit scripts.
-
-      This class assumes that the transport is open and active.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.set_transport
+         :renderer: rst
 
    .. py:method:: _get_submit_command(submit_script)
       :canonical: aiida.schedulers.scheduler.Scheduler._get_submit_command
       :abstractmethod:
 
-      Return the string to execute to submit a given script.
-
-      .. warning:: the `submit_script` should already have been bash-escaped
-
-      :param submit_script: the path of the submit script relative to the working directory.
-      :return: the string to execute to submit a given script.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._get_submit_command
+         :renderer: rst
 
    .. py:method:: _parse_submit_output(retval, stdout, stderr)
       :canonical: aiida.schedulers.scheduler.Scheduler._parse_submit_output
       :abstractmethod:
 
-      Parse the output of the submit command returned by calling the `_get_submit_command` command.
-
-      :return: a string with the job ID.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._parse_submit_output
+         :renderer: rst
 
    .. py:method:: submit_from_script(working_directory, submit_script)
       :canonical: aiida.schedulers.scheduler.Scheduler.submit_from_script
 
-      Submit the submission script to the scheduler.
-
-      :return: return a string with the job ID in a valid format to be used for querying.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.submit_from_script
+         :renderer: rst
 
    .. py:method:: kill(jobid)
       :canonical: aiida.schedulers.scheduler.Scheduler.kill
 
-      Kill a remote job and parse the return value of the scheduler to check if the command succeeded.
-
-      ..note::
-
-          On some schedulers, even if the command is accepted, it may take some seconds for the job to actually
-          disappear from the queue.
-
-      :param jobid: the job ID to be killed
-      :return: True if everything seems ok, False otherwise.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.kill
+         :renderer: rst
 
    .. py:method:: _get_kill_command(jobid)
       :canonical: aiida.schedulers.scheduler.Scheduler._get_kill_command
       :abstractmethod:
 
-      Return the command to kill the job with specified jobid.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._get_kill_command
+         :renderer: rst
 
    .. py:method:: _parse_kill_output(retval, stdout, stderr)
       :canonical: aiida.schedulers.scheduler.Scheduler._parse_kill_output
       :abstractmethod:
 
-      Parse the output of the kill command.
-
-      :return: True if everything seems ok, False otherwise.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler._parse_kill_output
+         :renderer: rst
 
    .. py:method:: parse_output(detailed_job_info=None, stdout=None, stderr=None)
       :canonical: aiida.schedulers.scheduler.Scheduler.parse_output
 
-      Parse the output of the scheduler.
-
-      :param detailed_job_info: dictionary with the output returned by the `Scheduler.get_detailed_job_info` command.
-          This should contain the keys `retval`, `stdout` and `stderr` corresponding to the return value, stdout and
-          stderr returned by the accounting command executed for a specific job id.
-      :param stdout: string with the output written by the scheduler to stdout.
-      :param stderr: string with the output written by the scheduler to stderr.
-      :return: None or an instance of :class:`aiida.engine.processes.exit_code.ExitCode`.
+      .. autodoc2-docstring:: aiida.schedulers.scheduler.Scheduler.parse_output
+         :renderer: rst
 
 .. py:class:: SchedulerError
    :canonical: aiida.schedulers.scheduler.SchedulerError
 
    Bases: :py:obj:`aiida.common.exceptions.AiidaException`
 
+   .. autodoc2-docstring:: aiida.schedulers.scheduler.SchedulerError
+      :renderer: rst
+
 .. py:class:: SchedulerParsingError
    :canonical: aiida.schedulers.scheduler.SchedulerParsingError
 
    Bases: :py:obj:`aiida.schedulers.scheduler.SchedulerError`
+
+   .. autodoc2-docstring:: aiida.schedulers.scheduler.SchedulerParsingError
+      :renderer: rst

--- a/docs/apidocs/aiida/aiida.tools.rst
+++ b/docs/apidocs/aiida/aiida.tools.rst
@@ -7,15 +7,9 @@
 Description
 -----------
 
-Tools to operate on AiiDA ORM class instances
-
-What functionality should go directly in the ORM class in `aiida.orm` and what in `aiida.tools`?
-
-    - The ORM class should define basic functions to set and get data from the object
-    - More advanced functionality to operate on the ORM class instances can be placed in `aiida.tools`
-        to prevent the ORM namespace from getting too cluttered.
-
-.. note:: Modules in this sub package may require the database environment to be loaded
+.. autodoc2-docstring:: aiida.tools
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -28,15 +22,25 @@ Classes
    :align: left
 
    * - :py:obj:`CalculationTools <aiida.tools.calculations.base.CalculationTools>`
-     - Base class for CalculationTools.
+     - .. autodoc2-docstring:: aiida.tools.calculations.base.CalculationTools
+          :renderer: rst
+          :summary:
    * - :py:obj:`Graph <aiida.tools.visualization.graph.Graph>`
-     - a class to create graphviz graphs of the AiiDA node provenance
+     - .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph
+          :renderer: rst
+          :summary:
    * - :py:obj:`GroupPath <aiida.tools.groups.paths.GroupPath>`
-     - A class to provide label delimited access to groups.
+     - .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath
+          :renderer: rst
+          :summary:
    * - :py:obj:`Orbital <aiida.tools.data.orbital.orbital.Orbital>`
-     - Base class for Orbitals. Can handle certain basic fields, their setting and validation. More complex Orbital objects should then inherit from this class
+     - .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital
+          :renderer: rst
+          :summary:
    * - :py:obj:`RealhydrogenOrbital <aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital>`
-     - Orbitals for hydrogen, largely follows the conventions used by wannier90 Object to handle the generation of real hydrogen orbitals and their hybrids, has methods for producing s, p, d, f, and sp, sp2, sp3, sp3d, sp3d2 hybrids. This method does not deal with the cannonical hydrogen orbitals which contain imaginary components.
+     - .. autodoc2-docstring:: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -46,25 +50,45 @@ Functions
    :align: left
 
    * - :py:obj:`default_link_styles <aiida.tools.visualization.graph.default_link_styles>`
-     - map link_pair to a graphviz edge style
+     - .. autodoc2-docstring:: aiida.tools.visualization.graph.default_link_styles
+          :renderer: rst
+          :summary:
    * - :py:obj:`default_node_styles <aiida.tools.visualization.graph.default_node_styles>`
-     - map a node to a graphviz node style
+     - .. autodoc2-docstring:: aiida.tools.visualization.graph.default_node_styles
+          :renderer: rst
+          :summary:
    * - :py:obj:`default_node_sublabels <aiida.tools.visualization.graph.default_node_sublabels>`
-     - function mapping nodes to a sublabel (e.g. specifying some attribute values)
+     - .. autodoc2-docstring:: aiida.tools.visualization.graph.default_node_sublabels
+          :renderer: rst
+          :summary:
    * - :py:obj:`delete_group_nodes <aiida.tools.graph.deletions.delete_group_nodes>`
-     - Delete nodes contained in a list of groups (not the groups themselves!).
+     - .. autodoc2-docstring:: aiida.tools.graph.deletions.delete_group_nodes
+          :renderer: rst
+          :summary:
    * - :py:obj:`delete_nodes <aiida.tools.graph.deletions.delete_nodes>`
-     - Delete nodes given a list of "starting" PKs.
+     - .. autodoc2-docstring:: aiida.tools.graph.deletions.delete_nodes
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_explicit_kpoints_path <aiida.tools.data.array.kpoints.main.get_explicit_kpoints_path>`
-     - Returns a dictionary whose contents depend on the method but includes at least the following keys
+     - .. autodoc2-docstring:: aiida.tools.data.array.kpoints.main.get_explicit_kpoints_path
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_kpoints_path <aiida.tools.data.array.kpoints.main.get_kpoints_path>`
-     - Returns a dictionary whose contents depend on the method but includes at least the following keys
+     - .. autodoc2-docstring:: aiida.tools.data.array.kpoints.main.get_kpoints_path
+          :renderer: rst
+          :summary:
    * - :py:obj:`pstate_node_styles <aiida.tools.visualization.graph.pstate_node_styles>`
-     - map a process node to a graphviz node style
+     - .. autodoc2-docstring:: aiida.tools.visualization.graph.pstate_node_styles
+          :renderer: rst
+          :summary:
    * - :py:obj:`spglib_tuple_to_structure <aiida.tools.data.structure.spglib_tuple_to_structure>`
-     - Convert a tuple of the format (cell, scaled_positions, element_numbers) to an AiiDA structure.
+     - .. autodoc2-docstring:: aiida.tools.data.structure.spglib_tuple_to_structure
+          :renderer: rst
+          :summary:
    * - :py:obj:`structure_to_spglib_tuple <aiida.tools.data.structure.structure_to_spglib_tuple>`
-     - Convert an AiiDA structure to a tuple of the format (cell, scaled_positions, element_numbers).
+     - .. autodoc2-docstring:: aiida.tools.data.structure.structure_to_spglib_tuple
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -74,7 +98,9 @@ Data
    :align: left
 
    * - :py:obj:`DELETE_LOGGER <aiida.tools.graph.deletions.DELETE_LOGGER>`
-     - 
+     - .. autodoc2-docstring:: aiida.tools.graph.deletions.DELETE_LOGGER
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -82,762 +108,500 @@ API
 .. py:class:: CalculationTools(node)
    :canonical: aiida.tools.calculations.base.CalculationTools
 
-   Base class for CalculationTools.
+   .. autodoc2-docstring:: aiida.tools.calculations.base.CalculationTools
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.tools.calculations.base.CalculationTools.__init__
+      :renderer: rst
 
 .. py:data:: DELETE_LOGGER
    :canonical: aiida.tools.graph.deletions.DELETE_LOGGER
    :value: None
 
+   .. autodoc2-docstring:: aiida.tools.graph.deletions.DELETE_LOGGER
+      :renderer: rst
+
 .. py:class:: Graph(engine=None, graph_attr=None, global_node_style=None, global_edge_style=None, include_sublabels=True, link_style_fn=None, node_style_fn=None, node_sublabel_fn=None, node_id_type='pk', backend: typing.Optional[aiida.orm.implementation.StorageBackend] = None)
    :canonical: aiida.tools.visualization.graph.Graph
 
-   a class to create graphviz graphs of the AiiDA node provenance
+   .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   a class to create graphviz graphs of the AiiDA node provenance
-
-   Nodes and edges, are cached, so that they are only created once
-
-   :param engine: the graphviz engine, e.g. dot, circo (Default value = None)
-   :type engine: str or None
-   :param graph_attr: attributes for the graphviz graph (Default value = None)
-   :type graph_attr: dict or None
-   :param global_node_style: styles which will be added to all nodes.
-       Note this will override any builtin attributes (Default value = None)
-   :type global_node_style: dict or None
-   :param global_edge_style: styles which will be added to all edges.
-       Note this will override any builtin attributes (Default value = None)
-   :type global_edge_style: dict or None
-   :param include_sublabels: if True, the note text will include node dependant sub-labels (Default value = True)
-   :type include_sublabels: bool
-   :param link_style_fn: callable mapping LinkType to graphviz style dict;
-       link_style_fn(link_type) -> dict (Default value = None)
-   :param node_sublabel_fn: callable mapping nodes to a graphviz style dict;
-       node_sublabel_fn(node) -> dict (Default value = None)
-   :param node_sublabel_fn: callable mapping data node to a sublabel (e.g. specifying some attribute values)
-       node_sublabel_fn(node) -> str (Default value = None)
-   :param node_id_type: the type of identifier to within the node text ('pk', 'uuid' or 'label')
-   :type node_id_type: str
+   .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.__init__
+      :renderer: rst
 
    .. py:property:: backend
       :canonical: aiida.tools.visualization.graph.Graph.backend
       :type: aiida.orm.implementation.StorageBackend
 
-      The backend used to create the graph
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.backend
+         :renderer: rst
 
    .. py:property:: graphviz
       :canonical: aiida.tools.visualization.graph.Graph.graphviz
 
-      return a copy of the graphviz.Digraph
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.graphviz
+         :renderer: rst
 
    .. py:property:: nodes
       :canonical: aiida.tools.visualization.graph.Graph.nodes
 
-      return a copy of the nodes
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.nodes
+         :renderer: rst
 
    .. py:property:: edges
       :canonical: aiida.tools.visualization.graph.Graph.edges
 
-      return a copy of the edges
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.edges
+         :renderer: rst
 
    .. py:method:: _load_node(node)
       :canonical: aiida.tools.visualization.graph.Graph._load_node
 
-      load a node (if not already loaded)
-
-      :param node: node or node pk/uuid
-      :type node: int or str or aiida.orm.nodes.node.Node
-      :returns: aiida.orm.nodes.node.Node
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph._load_node
+         :renderer: rst
 
    .. py:method:: _default_link_types(link_types)
       :canonical: aiida.tools.visualization.graph.Graph._default_link_types
       :staticmethod:
 
-      If link_types is empty, it will return all the links_types
-
-      :param links: iterable with the link_types ()
-      :returns: list of :py:class:`aiida.common.links.LinkType`
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph._default_link_types
+         :renderer: rst
 
    .. py:method:: add_node(node, style_override=None, overwrite=False)
       :canonical: aiida.tools.visualization.graph.Graph.add_node
 
-      add single node to the graph
-
-      :param node: node or node pk/uuid
-      :type node: int or str or aiida.orm.nodes.node.Node
-      :param style_override: graphviz style parameters that will override default values
-      :type style_override: dict or None
-      :param overwrite: whether to overrite an existing node (Default value = False)
-      :type overwrite: bool
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.add_node
+         :renderer: rst
 
    .. py:method:: add_edge(in_node, out_node, link_pair=None, style=None, overwrite=False)
       :canonical: aiida.tools.visualization.graph.Graph.add_edge
 
-      add single node to the graph
-
-      :param in_node: node or node pk/uuid
-      :type in_node: int or aiida.orm.nodes.node.Node
-      :param out_node: node or node pk/uuid
-      :type out_node: int or str or aiida.orm.nodes.node.Node
-      :param link_pair: defining the relationship between the nodes
-      :type link_pair: None or aiida.orm.utils.links.LinkPair
-      :param style: graphviz style parameters (Default value = None)
-      :type style: dict or None
-      :param overwrite: whether to overrite existing edge (Default value = False)
-      :type overwrite: bool
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.add_edge
+         :renderer: rst
 
    .. py:method:: _convert_link_types(link_types)
       :canonical: aiida.tools.visualization.graph.Graph._convert_link_types
       :staticmethod:
 
-      convert link types, which may be strings, to a member of LinkType
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph._convert_link_types
+         :renderer: rst
 
    .. py:method:: add_incoming(node, link_types=(), annotate_links=None, return_pks=True)
       :canonical: aiida.tools.visualization.graph.Graph.add_incoming
 
-      add nodes and edges for incoming links to a node
-
-      :param node: node or node pk/uuid
-      :type node: aiida.orm.nodes.node.Node or int
-      :param link_types: filter by link types (Default value = ())
-      :type link_types: str or tuple[str] or aiida.common.links.LinkType or tuple[aiida.common.links.LinkType]
-      :param annotate_links: label edges with the link 'label', 'type' or 'both' (Default value = None)
-      :type annotate_links: bool or str
-      :param return_pks: whether to return a list of nodes, or list of node pks (Default value = True)
-      :type return_pks: bool
-      :returns: list of nodes or node pks
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.add_incoming
+         :renderer: rst
 
    .. py:method:: add_outgoing(node, link_types=(), annotate_links=None, return_pks=True)
       :canonical: aiida.tools.visualization.graph.Graph.add_outgoing
 
-      add nodes and edges for outgoing links to a node
-
-      :param node: node or node pk
-      :type node: aiida.orm.nodes.node.Node or int
-      :param link_types: filter by link types (Default value = ())
-      :type link_types: str or tuple[str] or aiida.common.links.LinkType or tuple[aiida.common.links.LinkType]
-      :param annotate_links: label edges with the link 'label', 'type' or 'both' (Default value = None)
-      :type annotate_links: bool or str
-      :param return_pks: whether to return a list of nodes, or list of node pks (Default value = True)
-      :type return_pks: bool
-      :returns: list of nodes or node pks
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.add_outgoing
+         :renderer: rst
 
    .. py:method:: recurse_descendants(origin, depth=None, link_types=(), annotate_links=False, origin_style=MappingProxyType(_OVERRIDE_STYLES_DICT['origin_node']), include_process_inputs=False, highlight_classes=None)
       :canonical: aiida.tools.visualization.graph.Graph.recurse_descendants
 
-      add nodes and edges from an origin recursively,
-      following outgoing links
-
-      :param origin: node or node pk/uuid
-      :type origin: aiida.orm.nodes.node.Node or int
-      :param depth: if not None, stop after travelling a certain depth into the graph (Default value = None)
-      :type depth: None or int
-      :param link_types: filter by subset of link types (Default value = ())
-      :type link_types: tuple or str
-      :param annotate_links: label edges with the link 'label', 'type' or 'both' (Default value = False)
-      :type annotate_links: bool or str
-      :param origin_style: node style map for origin node (Default value = None)
-      :type origin_style: None or dict
-      :param include_calculation_inputs: include incoming links for all processes (Default value = False)
-      :type include_calculation_inputs: bool
-      :param highlight_classes: target class in exported graph expected to be highlight and
-          other nodes are decolorized (Default value = None)
-      :typle highlight_classes: tuple of class or class
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.recurse_descendants
+         :renderer: rst
 
    .. py:method:: recurse_ancestors(origin, depth=None, link_types=(), annotate_links=False, origin_style=MappingProxyType(_OVERRIDE_STYLES_DICT['origin_node']), include_process_outputs=False, highlight_classes=None)
       :canonical: aiida.tools.visualization.graph.Graph.recurse_ancestors
 
-      add nodes and edges from an origin recursively,
-      following incoming links
-
-      :param origin: node or node pk/uuid
-      :type origin: aiida.orm.nodes.node.Node or int
-      :param depth: if not None, stop after travelling a certain depth into the graph (Default value = None)
-      :type depth: None or int
-      :param link_types: filter by subset of link types (Default value = ())
-      :type link_types: tuple or str
-      :param annotate_links: label edges with the link 'label', 'type' or 'both' (Default value = False)
-      :type annotate_links: bool
-      :param origin_style: node style map for origin node (Default value = None)
-      :type origin_style: None or dict
-      :param include_process_outputs:  include outgoing links for all processes (Default value = False)
-      :type include_process_outputs: bool
-      :param highlight_classes:  class label (as displayed in the graph, e.g. 'StructureData', 'FolderData', etc.)
-          to be highlight and other nodes are decolorized (Default value = None)
-      :typle highlight_classes: list or tuple of str
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.recurse_ancestors
+         :renderer: rst
 
    .. py:method:: add_origin_to_targets(origin, target_cls, target_filters=None, include_target_inputs=False, include_target_outputs=False, origin_style=(), annotate_links=False)
       :canonical: aiida.tools.visualization.graph.Graph.add_origin_to_targets
 
-      Add nodes and edges from an origin node to all nodes of a target node class.
-
-      :param origin: node or node pk/uuid
-      :type origin: aiida.orm.nodes.node.Node or int
-      :param target_cls: target node class
-      :param target_filters:  (Default value = None)
-      :type target_filters: dict or None
-      :param include_target_inputs:  (Default value = False)
-      :type include_target_inputs: bool
-      :param include_target_outputs:  (Default value = False)
-      :type include_target_outputs: bool
-      :param origin_style: node style map for origin node (Default value = ())
-      :type origin_style: dict or tuple
-      :param annotate_links: label edges with the link 'label', 'type' or 'both' (Default value = False)
-      :type annotate_links: bool
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.add_origin_to_targets
+         :renderer: rst
 
    .. py:method:: add_origins_to_targets(origin_cls, target_cls, origin_filters=None, target_filters=None, include_target_inputs=False, include_target_outputs=False, origin_style=(), annotate_links=False)
       :canonical: aiida.tools.visualization.graph.Graph.add_origins_to_targets
 
-      Add nodes and edges from all nodes of an origin class to all node of a target node class.
-
-      :param origin_cls: origin node class
-      :param target_cls: target node class
-      :param origin_filters:  (Default value = None)
-      :type origin_filters: dict or None
-      :param target_filters:  (Default value = None)
-      :type target_filters: dict or None
-      :param include_target_inputs:  (Default value = False)
-      :type include_target_inputs: bool
-      :param include_target_outputs:  (Default value = False)
-      :type include_target_outputs: bool
-      :param origin_style: node style map for origin node (Default value = ())
-      :type origin_style: dict or tuple
-      :param annotate_links: label edges with the link 'label', 'type' or 'both' (Default value = False)
-      :type annotate_links: bool
+      .. autodoc2-docstring:: aiida.tools.visualization.graph.Graph.add_origins_to_targets
+         :renderer: rst
 
 .. py:exception:: GroupNotFoundError(grouppath)
    :canonical: aiida.tools.groups.paths.GroupNotFoundError
 
    Bases: :py:obj:`Exception`
 
-   An exception raised when a path does not have an associated group.
+   .. autodoc2-docstring:: aiida.tools.groups.paths.GroupNotFoundError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.tools.groups.paths.GroupNotFoundError.__init__
+      :renderer: rst
 
 .. py:exception:: GroupNotUniqueError(grouppath)
    :canonical: aiida.tools.groups.paths.GroupNotUniqueError
 
    Bases: :py:obj:`Exception`
 
-   An exception raised when a path has multiple associated groups.
+   .. autodoc2-docstring:: aiida.tools.groups.paths.GroupNotUniqueError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.tools.groups.paths.GroupNotUniqueError.__init__
+      :renderer: rst
 
 .. py:class:: GroupPath(path: str = '', cls: aiida.orm.groups.GroupMeta = orm.Group, warn_invalid_child: bool = True)
    :canonical: aiida.tools.groups.paths.GroupPath
 
-   A class to provide label delimited access to groups.
-
-   See tests for usage examples.
+   .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Instantiate the class.
-
-   :param path: The initial path of the group.
-   :param cls: The subclass of `Group` to operate on.
-   :param warn_invalid_child: Issue a warning, when iterating children, if a child path is invalid.
-
+   .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.__init__
+      :renderer: rst
 
    .. py:method:: _validate_path(path)
       :canonical: aiida.tools.groups.paths.GroupPath._validate_path
 
-      Validate the supplied path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath._validate_path
+         :renderer: rst
 
    .. py:method:: __repr__() -> str
       :canonical: aiida.tools.groups.paths.GroupPath.__repr__
 
-      Represent the instantiated class.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.__repr__
+         :renderer: rst
 
    .. py:method:: __eq__(other: typing.Any) -> bool
       :canonical: aiida.tools.groups.paths.GroupPath.__eq__
 
-      Compare equality of path and ``Group`` subclass to another ``GroupPath`` object.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.__eq__
+         :renderer: rst
 
    .. py:method:: __lt__(other: typing.Any) -> bool
       :canonical: aiida.tools.groups.paths.GroupPath.__lt__
 
-      Compare less-than operator of path and ``Group`` subclass to another ``GroupPath`` object.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.__lt__
+         :renderer: rst
 
    .. py:property:: path
       :canonical: aiida.tools.groups.paths.GroupPath.path
       :type: str
 
-      Return the path string.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.path
+         :renderer: rst
 
    .. py:property:: path_list
       :canonical: aiida.tools.groups.paths.GroupPath.path_list
       :type: typing.List[str]
 
-      Return a list of the path components.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.path_list
+         :renderer: rst
 
    .. py:property:: key
       :canonical: aiida.tools.groups.paths.GroupPath.key
       :type: typing.Optional[str]
 
-      Return the final component of the the path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.key
+         :renderer: rst
 
    .. py:property:: delimiter
       :canonical: aiida.tools.groups.paths.GroupPath.delimiter
       :type: str
 
-      Return the delimiter used to split path into components.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.delimiter
+         :renderer: rst
 
    .. py:property:: cls
       :canonical: aiida.tools.groups.paths.GroupPath.cls
       :type: aiida.orm.groups.GroupMeta
 
-      Return the cls used to query for and instantiate a ``Group`` with.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.cls
+         :renderer: rst
 
    .. py:property:: parent
       :canonical: aiida.tools.groups.paths.GroupPath.parent
       :type: typing.Optional[aiida.tools.groups.paths.GroupPath]
 
-      Return the parent path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.parent
+         :renderer: rst
 
    .. py:method:: __truediv__(path: str) -> aiida.tools.groups.paths.GroupPath
       :canonical: aiida.tools.groups.paths.GroupPath.__truediv__
 
-      Return a child ``GroupPath``, with a new path formed by appending ``path`` to the current path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.__truediv__
+         :renderer: rst
 
    .. py:method:: __getitem__(path: str) -> aiida.tools.groups.paths.GroupPath
       :canonical: aiida.tools.groups.paths.GroupPath.__getitem__
 
-      Return a child ``GroupPath``, with a new path formed by appending ``path`` to the current path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.__getitem__
+         :renderer: rst
 
    .. py:method:: get_group() -> typing.Optional[aiida.tools.groups.paths.GroupPath]
       :canonical: aiida.tools.groups.paths.GroupPath.get_group
 
-      Return the concrete group associated with this path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.get_group
+         :renderer: rst
 
    .. py:property:: group_ids
       :canonical: aiida.tools.groups.paths.GroupPath.group_ids
       :type: typing.List[int]
 
-      Return all the UUID associated with this GroupPath.
-
-      :returns: and empty list, if no group associated with this label,
-          or can be multiple if cls was None
-
-      This is an efficient method for checking existence,
-      which does not require the (slow) loading of the ORM entity.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.group_ids
+         :renderer: rst
 
    .. py:property:: is_virtual
       :canonical: aiida.tools.groups.paths.GroupPath.is_virtual
       :type: bool
 
-      Return whether there is one or more concrete groups associated with this path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.is_virtual
+         :renderer: rst
 
    .. py:method:: get_or_create_group() -> typing.Tuple[aiida.orm.Group, bool]
       :canonical: aiida.tools.groups.paths.GroupPath.get_or_create_group
 
-      Return the concrete group associated with this path or, create it, if it does not already exist.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.get_or_create_group
+         :renderer: rst
 
    .. py:method:: delete_group()
       :canonical: aiida.tools.groups.paths.GroupPath.delete_group
 
-      Delete the concrete group associated with this path.
-
-      :raises: GroupNotFoundError, GroupNotUniqueError
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.delete_group
+         :renderer: rst
 
    .. py:property:: children
       :canonical: aiida.tools.groups.paths.GroupPath.children
       :type: typing.Iterator[aiida.tools.groups.paths.GroupPath]
 
-      Iterate through all (direct) children of this path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.children
+         :renderer: rst
 
    .. py:method:: __iter__() -> typing.Iterator[aiida.tools.groups.paths.GroupPath]
       :canonical: aiida.tools.groups.paths.GroupPath.__iter__
 
-      Iterate through all (direct) children of this path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.__iter__
+         :renderer: rst
 
    .. py:method:: __len__() -> int
       :canonical: aiida.tools.groups.paths.GroupPath.__len__
 
-      Return the number of children for this path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.__len__
+         :renderer: rst
 
    .. py:method:: __contains__(key: str) -> bool
       :canonical: aiida.tools.groups.paths.GroupPath.__contains__
 
-      Return whether a child exists for this key.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.__contains__
+         :renderer: rst
 
    .. py:method:: walk(return_virtual: bool = True) -> typing.Iterator[aiida.tools.groups.paths.GroupPath]
       :canonical: aiida.tools.groups.paths.GroupPath.walk
 
-      Recursively iterate through all children of this path.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.walk
+         :renderer: rst
 
    .. py:method:: walk_nodes(filters: typing.Optional[dict] = None, node_class: typing.Optional[aiida.orm.Node] = None, query_batch: typing.Optional[int] = None) -> typing.Iterator[aiida.tools.groups.paths.WalkNodeResult]
       :canonical: aiida.tools.groups.paths.GroupPath.walk_nodes
 
-      Recursively iterate through all nodes of this path and its children.
-
-      :param filters: filters to apply to the node query
-      :param node_class: return only nodes of a certain class (or list of classes)
-      :param query_batch: The size of the batches to ask the backend to batch results in subcollections.
-          You can optimize the speed of the query by tuning this parameter.
-          Be aware though that is only safe if no commit will take place during this transaction.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.walk_nodes
+         :renderer: rst
 
    .. py:property:: browse
       :canonical: aiida.tools.groups.paths.GroupPath.browse
 
-      Return a ``GroupAttr`` instance, for attribute access to children.
+      .. autodoc2-docstring:: aiida.tools.groups.paths.GroupPath.browse
+         :renderer: rst
 
 .. py:exception:: InvalidPath()
    :canonical: aiida.tools.groups.paths.InvalidPath
 
    Bases: :py:obj:`Exception`
 
-   An exception to indicate that a path is not valid.
+   .. autodoc2-docstring:: aiida.tools.groups.paths.InvalidPath
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.tools.groups.paths.InvalidPath.__init__
+      :renderer: rst
 
 .. py:exception:: NoGroupsInPathError(grouppath)
    :canonical: aiida.tools.groups.paths.NoGroupsInPathError
 
    Bases: :py:obj:`Exception`
 
-   An exception raised when a path has multiple associated groups.
+   .. autodoc2-docstring:: aiida.tools.groups.paths.NoGroupsInPathError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: aiida.tools.groups.paths.NoGroupsInPathError.__init__
+      :renderer: rst
 
 .. py:class:: Orbital(**kwargs)
    :canonical: aiida.tools.data.orbital.orbital.Orbital
 
-   Base class for Orbitals. Can handle certain basic fields, their setting
-   and validation. More complex Orbital objects should then inherit from
-   this class
+   .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital
+      :renderer: rst
 
-   :param position: the absolute position (three floats) units in angstrom
-   :param x_orientation: x,y,z unit vector defining polar angle theta
-                         in spherical coordinates unitless
-   :param z_orientation: x,y,z unit vector defining azimuthal angle phi
-                         in spherical coordinates unitless
-   :param orientation_spin: x,y,z unit vector defining the spin orientation
-                            unitless
-   :param diffusivity: Float controls the radial term in orbital equation
-                       units are reciprocal Angstrom.
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital.__init__
+      :renderer: rst
 
    .. py:attribute:: _base_fields_required
       :canonical: aiida.tools.data.orbital.orbital.Orbital._base_fields_required
       :value: (('position',),)
 
+      .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital._base_fields_required
+         :renderer: rst
+
    .. py:attribute:: _base_fields_optional
       :canonical: aiida.tools.data.orbital.orbital.Orbital._base_fields_optional
       :value: None
 
+      .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital._base_fields_optional
+         :renderer: rst
+
    .. py:method:: __repr__()
       :canonical: aiida.tools.data.orbital.orbital.Orbital.__repr__
 
-      Return repr(self).
+      .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital.__repr__
+         :renderer: rst
 
    .. py:method:: __str__() -> str
       :canonical: aiida.tools.data.orbital.orbital.Orbital.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital.__str__
+         :renderer: rst
 
    .. py:method:: _validate_keys(input_dict)
       :canonical: aiida.tools.data.orbital.orbital.Orbital._validate_keys
 
-      Checks all the input_dict and tries to validate them, to ensure
-      that they have been properly set raises Exceptions indicating any
-      problems that should arise during the validation
-
-      :param input_dict: a dictionary of inputs
-      :return: input_dict: the original dictionary with all validated kyes
-               now removed
-      :return: validated_dict: a dictionary containing all the input keys
-               which have now been validated.
+      .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital._validate_keys
+         :renderer: rst
 
    .. py:method:: set_orbital_dict(init_dict)
       :canonical: aiida.tools.data.orbital.orbital.Orbital.set_orbital_dict
 
-      Sets the orbital_dict, which can vary depending on the particular
-      implementation of this base class.
-
-      :param init_dict: the initialization dictionary
+      .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital.set_orbital_dict
+         :renderer: rst
 
    .. py:method:: get_orbital_dict()
       :canonical: aiida.tools.data.orbital.orbital.Orbital.get_orbital_dict
 
-      returns the internal keys as a dictionary
+      .. autodoc2-docstring:: aiida.tools.data.orbital.orbital.Orbital.get_orbital_dict
+         :renderer: rst
 
 .. py:class:: RealhydrogenOrbital
    :canonical: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital
 
    Bases: :py:obj:`aiida.tools.data.orbital.orbital.Orbital`
 
-   Orbitals for hydrogen, largely follows the conventions used by wannier90
-   Object to handle the generation of real hydrogen orbitals and their
-   hybrids, has methods for producing s, p, d, f, and sp, sp2, sp3, sp3d,
-   sp3d2 hybrids. This method does not deal with the cannonical hydrogen
-   orbitals which contain imaginary components.
-
-   The orbitals described here are chiefly concerned with the symmetric
-   aspects of the oribitals without the context of space. Therefore
-   diffusitivity, position and atomic labels should be handled in the
-   OrbitalData class.
-
-   Following the notation of table 3.1, 3.2 of Wannier90 user guide
-   (which can be downloaded from http://www.wannier.org/support/)
-   A brief description of what is meant by each of these labels:
-
-   :param radial_nodes: the number of radial nodes (or inflections) if no
-                        radial nodes are supplied, defaults to 0
-   :param angular_momentum: Angular quantum number, using real orbitals
-   :param magnetic_number: Magnetic quantum number, using real orbitals
-   :param spin: spin, up (1) down (-1) or unspecified (0)
-
-   The conventions regarding L and M correpsond to those used in
-   wannier90 for all L greater than 0 the orbital is not hyrbridized
-   see table 3.1 and for L less than 0 the orbital is hybridized see
-   table 3.2. M then indexes all the possible orbitals from 0 to 2L for
-   L > 0 and from 0 to (-L) for L < 0.
+   .. autodoc2-docstring:: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital
+      :renderer: rst
 
    .. py:attribute:: _base_fields_required
       :canonical: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital._base_fields_required
       :value: None
 
+      .. autodoc2-docstring:: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital._base_fields_required
+         :renderer: rst
+
    .. py:attribute:: _base_fields_optional
       :canonical: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital._base_fields_optional
       :value: None
 
+      .. autodoc2-docstring:: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital._base_fields_optional
+         :renderer: rst
+
    .. py:method:: __str__()
       :canonical: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital.__str__
+
+      .. autodoc2-docstring:: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital.__str__
+         :renderer: rst
 
    .. py:method:: _validate_keys(input_dict)
       :canonical: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital._validate_keys
 
-      Validates the keys otherwise raise ValidationError. Does basic
-      validation from the parent followed by validations for the
-      quantum numbers. Raises exceptions should the input_dict fail the
-      valiation or if it contains any unsupported keywords.
-
-      :param input_dict: the dictionary of keys to be validated
-      :return validated_dict: a validated dictionary
+      .. autodoc2-docstring:: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital._validate_keys
+         :renderer: rst
 
    .. py:method:: get_name_from_quantum_numbers(angular_momentum, magnetic_number=None)
       :canonical: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital.get_name_from_quantum_numbers
       :classmethod:
 
-      Returns the orbital_name correponding to the angular_momentum alone,
-      or to both angular_number with magnetic_number. For example using
-      angular_momentum=1 and magnetic_number=1 will return "Px"
+      .. autodoc2-docstring:: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital.get_name_from_quantum_numbers
+         :renderer: rst
 
    .. py:method:: get_quantum_numbers_from_name(name)
       :canonical: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital.get_quantum_numbers_from_name
       :classmethod:
 
-      Returns all the angular and magnetic numbers corresponding to name.
-      For example, using "P" as name will return all quantum numbers
-      associated with a "P" orbital, while "Px" will return only one set
-      of quantum numbers, the ones associated with "Px"
+      .. autodoc2-docstring:: aiida.tools.data.orbital.realhydrogen.RealhydrogenOrbital.get_quantum_numbers_from_name
+         :renderer: rst
 
 .. py:function:: default_link_styles(link_pair: aiida.orm.utils.links.LinkPair, add_label: bool, add_type: bool) -> dict
    :canonical: aiida.tools.visualization.graph.default_link_styles
 
-   map link_pair to a graphviz edge style
-
-   :param link_type: a LinkPair attribute
-   :type link_type: aiida.orm.utils.links.LinkPair
-   :param add_label: include link label
-   :type add_label: bool
-   :param add_type: include link type
-   :type add_type: bool
-   :rtype: dict
+   .. autodoc2-docstring:: aiida.tools.visualization.graph.default_link_styles
+      :renderer: rst
 
 .. py:function:: default_node_styles(node)
    :canonical: aiida.tools.visualization.graph.default_node_styles
 
-   map a node to a graphviz node style
-
-   :param node: the node to map
-   :type node: aiida.orm.nodes.node.Node
-   :rtype: dict
+   .. autodoc2-docstring:: aiida.tools.visualization.graph.default_node_styles
+      :renderer: rst
 
 .. py:function:: default_node_sublabels(node)
    :canonical: aiida.tools.visualization.graph.default_node_sublabels
 
-   function mapping nodes to a sublabel
-   (e.g. specifying some attribute values)
-
-   :param node: the node to map
-   :type node: aiida.orm.nodes.node.Node
-   :rtype: str
+   .. autodoc2-docstring:: aiida.tools.visualization.graph.default_node_sublabels
+      :renderer: rst
 
 .. py:function:: delete_group_nodes(pks: typing.Iterable[int], dry_run: typing.Union[bool, typing.Callable[[typing.Set[int]], bool]] = True, backend=None, **traversal_rules: bool) -> typing.Tuple[typing.Set[int], bool]
    :canonical: aiida.tools.graph.deletions.delete_group_nodes
 
-   Delete nodes contained in a list of groups (not the groups themselves!).
-
-   This command will delete not only the nodes, but also the ones that are
-   linked to these and should be also deleted in order to keep a consistent provenance
-   according to the rules explained in the concepts section of the documentation.
-   In summary:
-
-   1. If a DATA node is deleted, any process nodes linked to it will also be deleted.
-
-   2. If a CALC node is deleted, any incoming WORK node (callers) will be deleted as
-   well whereas any incoming DATA node (inputs) will be kept. Outgoing DATA nodes
-   (outputs) will be deleted by default but this can be disabled.
-
-   3. If a WORK node is deleted, any incoming WORK node (callers) will be deleted as
-   well, but all DATA nodes will be kept. Outgoing WORK or CALC nodes will be kept by
-   default, but deletion of either of both kind of connected nodes can be enabled.
-
-   These rules are 'recursive', so if a CALC node is deleted, then its output DATA
-   nodes will be deleted as well, and then any CALC node that may have those as
-   inputs, and so on.
-
-   :param pks: a list of the groups
-
-   :param dry_run:
-       If True, return the pks to delete without deleting anything.
-       If False, delete the pks without confirmation
-       If callable, a function that return True/False, based on the pks, e.g. ``dry_run=lambda pks: True``
-
-   :param traversal_rules: graph traversal rules. See :const:`aiida.common.links.GraphTraversalRules` what rule names
-       are toggleable and what the defaults are.
-
-   :returns: (node pks to delete, whether they were deleted)
-
+   .. autodoc2-docstring:: aiida.tools.graph.deletions.delete_group_nodes
+      :renderer: rst
 
 .. py:function:: delete_nodes(pks: typing.Iterable[int], dry_run: typing.Union[bool, typing.Callable[[typing.Set[int]], bool]] = True, backend=None, **traversal_rules: bool) -> typing.Tuple[typing.Set[int], bool]
    :canonical: aiida.tools.graph.deletions.delete_nodes
 
-   Delete nodes given a list of "starting" PKs.
-
-   This command will delete not only the specified nodes, but also the ones that are
-   linked to these and should be also deleted in order to keep a consistent provenance
-   according to the rules explained in the Topics - Provenance section of the documentation.
-   In summary:
-
-   1. If a DATA node is deleted, any process nodes linked to it will also be deleted.
-
-   2. If a CALC node is deleted, any incoming WORK node (callers) will be deleted as
-   well whereas any incoming DATA node (inputs) will be kept. Outgoing DATA nodes
-   (outputs) will be deleted by default but this can be disabled.
-
-   3. If a WORK node is deleted, any incoming WORK node (callers) will be deleted as
-   well, but all DATA nodes will be kept. Outgoing WORK or CALC nodes will be kept by
-   default, but deletion of either of both kind of connected nodes can be enabled.
-
-   These rules are 'recursive', so if a CALC node is deleted, then its output DATA
-   nodes will be deleted as well, and then any CALC node that may have those as
-   inputs, and so on.
-
-   :param pks: a list of starting PKs of the nodes to delete
-       (the full set will be based on the traversal rules)
-
-   :param dry_run:
-       If True, return the pks to delete without deleting anything.
-       If False, delete the pks without confirmation
-       If callable, a function that return True/False, based on the pks, e.g. ``dry_run=lambda pks: True``
-
-   :param traversal_rules: graph traversal rules.
-       See :const:`aiida.common.links.GraphTraversalRules` for what rule names
-       are toggleable and what the defaults are.
-
-   :returns: (pks to delete, whether they were deleted)
-
+   .. autodoc2-docstring:: aiida.tools.graph.deletions.delete_nodes
+      :renderer: rst
 
 .. py:function:: get_explicit_kpoints_path(structure, method='seekpath', **kwargs)
    :canonical: aiida.tools.data.array.kpoints.main.get_explicit_kpoints_path
 
-   Returns a dictionary whose contents depend on the method but includes at least the following keys
-
-       * parameters: Dict node
-       * explicit_kpoints: KpointsData node with explicit kpoints path
-
-   The contents of the parameters depends on the method but contains at least the keys
-
-       * 'point_coords': a dictionary with 'kpoints-label': [float coordinates]
-       * 'path': a list of length-2 tuples, with the labels of the starting
-           and ending point of each label section
-
-   The 'seekpath' method which is the default also returns the following additional nodes
-
-       * primitive_structure: StructureData with the primitive cell
-       * conv_structure: StructureData with the conventional cell
-
-   Note that the generated kpoints for the seekpath method only apply on the returned primitive_structure
-   and not on the input structure that was provided
-
-   :param structure: a StructureData node
-   :param method: the method to use for kpoint generation, options are 'seekpath' and 'legacy'.
-       It is strongly advised to use the default 'seekpath' as the 'legacy' implementation is known to have
-       bugs for certain structure cells
-   :param kwargs: optional keyword arguments that depend on the selected method
-   :returns: dictionary as described above in the docstring
+   .. autodoc2-docstring:: aiida.tools.data.array.kpoints.main.get_explicit_kpoints_path
+      :renderer: rst
 
 .. py:function:: get_kpoints_path(structure, method='seekpath', **kwargs)
    :canonical: aiida.tools.data.array.kpoints.main.get_kpoints_path
 
-   Returns a dictionary whose contents depend on the method but includes at least the following keys
-
-       * parameters: Dict node
-
-   The contents of the parameters depends on the method but contains at least the keys
-
-       * 'point_coords': a dictionary with 'kpoints-label': [float coordinates]
-       * 'path': a list of length-2 tuples, with the labels of the starting
-           and ending point of each label section
-
-   The 'seekpath' method which is the default also returns the following additional nodes
-
-       * primitive_structure: StructureData with the primitive cell
-       * conv_structure: StructureData with the conventional cell
-
-   Note that the generated kpoints for the seekpath method only apply on the returned primitive_structure
-   and not on the input structure that was provided
-
-   :param structure: a StructureData node
-   :param method: the method to use for kpoint generation, options are 'seekpath' and 'legacy'.
-       It is strongly advised to use the default 'seekpath' as the 'legacy' implementation is known to have
-       bugs for certain structure cells
-   :param kwargs: optional keyword arguments that depend on the selected method
-   :returns: dictionary as described above in the docstring
+   .. autodoc2-docstring:: aiida.tools.data.array.kpoints.main.get_kpoints_path
+      :renderer: rst
 
 .. py:function:: pstate_node_styles(node)
    :canonical: aiida.tools.visualization.graph.pstate_node_styles
 
-   map a process node to a graphviz node style
-
-   :param node: the node to map
-   :type node: aiida.orm.nodes.node.Node
-   :rtype: dict
+   .. autodoc2-docstring:: aiida.tools.visualization.graph.pstate_node_styles
+      :renderer: rst
 
 .. py:function:: spglib_tuple_to_structure(structure_tuple, kind_info=None, kinds=None)
    :canonical: aiida.tools.data.structure.spglib_tuple_to_structure
 
-   Convert a tuple of the format (cell, scaled_positions, element_numbers) to an AiiDA structure.
-
-   Unless the element_numbers are identical to the Z number of the atoms,
-   you should pass both kind_info and kinds, with the same format as returned
-   by get_tuple_from_aiida_structure.
-
-   :param structure_tuple: the structure in format (structure_tuple, kind_info)
-   :param kind_info: a dictionary mapping the kind_names to
-      the numbers used in element_numbers. If not provided, assumes {element_name: element_Z}
-   :param kinds: a list of the kinds of the structure.
+   .. autodoc2-docstring:: aiida.tools.data.structure.spglib_tuple_to_structure
+      :renderer: rst
 
 .. py:function:: structure_to_spglib_tuple(structure)
    :canonical: aiida.tools.data.structure.structure_to_spglib_tuple
 
-   Convert an AiiDA structure to a tuple of the format (cell, scaled_positions, element_numbers).
-
-   :param structure: the AiiDA structure
-   :return: (structure_tuple, kind_info, kinds) where structure_tuple
-       is a tuple of format (cell, scaled_positions, element_numbers);
-       kind_info is a dictionary mapping the kind_names to
-       the numbers used in element_numbers. When possible, it uses
-       the Z number of the element, otherwise it uses numbers > 1000;
-       kinds is a list of the kinds of the structure.
+   .. autodoc2-docstring:: aiida.tools.data.structure.structure_to_spglib_tuple
+      :renderer: rst

--- a/docs/apidocs/aiida/aiida.transports.rst
+++ b/docs/apidocs/aiida/aiida.transports.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Module for classes and utilities to define transports to other machines.
+.. autodoc2-docstring:: aiida.transports
+   :renderer: rst
+   :allowtitles:
 
 Package Contents
 ----------------
@@ -20,9 +22,13 @@ Classes
    :align: left
 
    * - :py:obj:`SshTransport <aiida.transports.plugins.ssh.SshTransport>`
-     - Support connection, command execution and data transfer to remote computers via SSH+SFTP.
+     - .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport
+          :renderer: rst
+          :summary:
    * - :py:obj:`Transport <aiida.transports.transport.Transport>`
-     - Abstract class for a generic transport (ssh, local, ...) contains the set of minimal methods.
+     - .. autodoc2-docstring:: aiida.transports.transport.Transport
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -32,9 +38,13 @@ Functions
    :align: left
 
    * - :py:obj:`convert_to_bool <aiida.transports.plugins.ssh.convert_to_bool>`
-     - Convert a string passed in the CLI to a valid bool.
+     - .. autodoc2-docstring:: aiida.transports.plugins.ssh.convert_to_bool
+          :renderer: rst
+          :summary:
    * - :py:obj:`parse_sshconfig <aiida.transports.plugins.ssh.parse_sshconfig>`
-     - Return the ssh configuration for a given computer name.
+     - .. autodoc2-docstring:: aiida.transports.plugins.ssh.parse_sshconfig
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -44,1174 +54,825 @@ API
 
    Bases: :py:obj:`aiida.transports.transport.Transport`
 
-   Support connection, command execution and data transfer to remote computers via SSH+SFTP.
+   .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize the SshTransport class.
-
-   :param machine: the machine to connect to
-   :param load_system_host_keys: (optional, default False)
-      if False, do not load the system host keys
-   :param key_policy: (optional, default = paramiko.RejectPolicy())
-      the policy to use for unknown keys
-
-   Other parameters valid for the ssh connect function (see the
-   self._valid_connect_params list) are passed to the connect
-   function (as port, username, password, ...); taken from the
-   accepted paramiko.SSHClient.connect() params.
+   .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.__init__
+      :renderer: rst
 
    .. py:attribute:: _valid_connect_options
       :canonical: aiida.transports.plugins.ssh.SshTransport._valid_connect_options
       :value: [('username',), ('port',), ('look_for_keys',), ('key_filename',), ('timeout',), ('allow_agent',), ('...
 
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._valid_connect_options
+         :renderer: rst
+
    .. py:attribute:: _valid_connect_params
       :canonical: aiida.transports.plugins.ssh.SshTransport._valid_connect_params
       :value: None
+
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._valid_connect_params
+         :renderer: rst
 
    .. py:attribute:: _valid_auth_options
       :canonical: aiida.transports.plugins.ssh.SshTransport._valid_auth_options
       :value: None
 
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._valid_auth_options
+         :renderer: rst
+
    .. py:attribute:: _MAX_EXEC_COMMAND_LOG_SIZE
       :canonical: aiida.transports.plugins.ssh.SshTransport._MAX_EXEC_COMMAND_LOG_SIZE
       :value: None
+
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._MAX_EXEC_COMMAND_LOG_SIZE
+         :renderer: rst
 
    .. py:method:: _get_username_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_username_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_username_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_port_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_port_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_port_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_key_filename_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_key_filename_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_key_filename_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_timeout_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_timeout_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
-
-      Provide 60s as a default timeout for connections.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_timeout_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_allow_agent_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_allow_agent_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_allow_agent_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_look_for_keys_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_look_for_keys_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_look_for_keys_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_proxy_command_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_proxy_command_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_proxy_command_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_proxy_jump_suggestion_string(_)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_proxy_jump_suggestion_string
       :classmethod:
 
-      Return an empty suggestion since Paramiko does not parse ProxyJump from the SSH config.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_proxy_jump_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_compress_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_compress_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_compress_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_load_system_host_keys_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_load_system_host_keys_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_load_system_host_keys_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_key_policy_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_key_policy_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_key_policy_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_gss_auth_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_gss_auth_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_gss_auth_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_gss_kex_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_gss_kex_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_gss_kex_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_gss_deleg_creds_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_gss_deleg_creds_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_gss_deleg_creds_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_gss_host_suggestion_string(computer)
       :canonical: aiida.transports.plugins.ssh.SshTransport._get_gss_host_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._get_gss_host_suggestion_string
+         :renderer: rst
 
    .. py:method:: open()
       :canonical: aiida.transports.plugins.ssh.SshTransport.open
 
-      Open a SSHClient to the machine possibly using the parameters given
-      in the __init__.
-
-      Also opens a sftp channel, ready to be used.
-      The current working directory is set explicitly, so it is not None.
-
-      :raise aiida.common.InvalidOperation: if the channel is already open
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.open
+         :renderer: rst
 
    .. py:method:: _close_proxies()
       :canonical: aiida.transports.plugins.ssh.SshTransport._close_proxies
 
-      Close all proxy connections (proxy_jump and proxy_command)
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._close_proxies
+         :renderer: rst
 
    .. py:method:: close()
       :canonical: aiida.transports.plugins.ssh.SshTransport.close
 
-      Close the SFTP channel, and the SSHClient.
-
-      :todo: correctly manage exceptions
-
-      :raise aiida.common.InvalidOperation: if the channel is already open
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.close
+         :renderer: rst
 
    .. py:property:: sshclient
       :canonical: aiida.transports.plugins.ssh.SshTransport.sshclient
 
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.sshclient
+         :renderer: rst
+
    .. py:property:: sftp
       :canonical: aiida.transports.plugins.ssh.SshTransport.sftp
+
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.sftp
+         :renderer: rst
 
    .. py:method:: __str__()
       :canonical: aiida.transports.plugins.ssh.SshTransport.__str__
 
-      Return a useful string.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.__str__
+         :renderer: rst
 
    .. py:method:: chdir(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.chdir
 
-      Change directory of the SFTP session. Emulated internally by paramiko.
-
-      Differently from paramiko, if you pass None to chdir, nothing
-      happens and the cwd is unchanged.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.chdir
+         :renderer: rst
 
    .. py:method:: normalize(path='.')
       :canonical: aiida.transports.plugins.ssh.SshTransport.normalize
 
-      Returns the normalized path (removing double slashes, etc...)
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.normalize
+         :renderer: rst
 
    .. py:method:: stat(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.stat
 
-      Retrieve information about a file on the remote system.  The return
-      value is an object whose attributes correspond to the attributes of
-      Python's ``stat`` structure as returned by ``os.stat``, except that it
-      contains fewer fields.
-      The fields supported are: ``st_mode``, ``st_size``, ``st_uid``,
-      ``st_gid``, ``st_atime``, and ``st_mtime``.
-
-      :param str path: the filename to stat
-
-      :return: a `paramiko.sftp_attr.SFTPAttributes` object containing
-          attributes about the given file.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.stat
+         :renderer: rst
 
    .. py:method:: lstat(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.lstat
 
-      Retrieve information about a file on the remote system, without
-      following symbolic links (shortcuts). This otherwise behaves exactly
-      the same as `stat`.
-
-      :param str path: the filename to stat
-
-      :return: a `paramiko.sftp_attr.SFTPAttributes` object containing
-          attributes about the given file.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.lstat
+         :renderer: rst
 
    .. py:method:: getcwd()
       :canonical: aiida.transports.plugins.ssh.SshTransport.getcwd
 
-      Return the current working directory for this SFTP session, as
-      emulated by paramiko. If no directory has been set with chdir,
-      this method will return None. But in __enter__ this is set explicitly,
-      so this should never happen within this class.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.getcwd
+         :renderer: rst
 
    .. py:method:: makedirs(path, ignore_existing=False)
       :canonical: aiida.transports.plugins.ssh.SshTransport.makedirs
 
-      Super-mkdir; create a leaf directory and all intermediate ones.
-      Works like mkdir, except that any intermediate path segment (not
-      just the rightmost) will be created if it does not exist.
-
-      NOTE: since os.path.split uses the separators as the host system
-      (that could be windows), I assume the remote computer is Linux-based
-      and use '/' as separators!
-
-      :param path: directory to create (string)
-      :param ignore_existing: if set to true, it doesn't give any error
-          if the leaf directory does already exist (bool)
-
-      :raise OSError: If the directory already exists.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.makedirs
+         :renderer: rst
 
    .. py:method:: mkdir(path, ignore_existing=False)
       :canonical: aiida.transports.plugins.ssh.SshTransport.mkdir
 
-      Create a folder (directory) named path.
-
-      :param path: name of the folder to create
-      :param ignore_existing: if True, does not give any error if the directory
-                already exists
-
-      :raise OSError: If the directory already exists.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.mkdir
+         :renderer: rst
 
    .. py:method:: rmtree(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.rmtree
 
-      Remove a file or a directory at path, recursively
-      Flags used: -r: recursive copy; -f: force, makes the command non interactive;
-
-      :param path: remote path to delete
-
-      :raise IOError: if the rm execution failed.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.rmtree
+         :renderer: rst
 
    .. py:method:: rmdir(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.rmdir
 
-      Remove the folder named 'path' if empty.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.rmdir
+         :renderer: rst
 
    .. py:method:: chown(path, uid, gid)
       :canonical: aiida.transports.plugins.ssh.SshTransport.chown
       :abstractmethod:
 
-      Change owner permissions of a file.
-
-      For now, this is not implemented for the SSH transport.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.chown
+         :renderer: rst
 
    .. py:method:: isdir(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.isdir
 
-      Return True if the given path is a directory, False otherwise.
-      Return False also if the path does not exist.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.isdir
+         :renderer: rst
 
    .. py:method:: chmod(path, mode)
       :canonical: aiida.transports.plugins.ssh.SshTransport.chmod
 
-      Change permissions to path
-
-      :param path: path to file
-      :param mode: new permission bits (integer)
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.chmod
+         :renderer: rst
 
    .. py:method:: _os_path_split_asunder(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport._os_path_split_asunder
       :staticmethod:
 
-      Used by makedirs. Takes path (a str)
-      and returns a list deconcatenating the path
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._os_path_split_asunder
+         :renderer: rst
 
    .. py:method:: put(localpath, remotepath, callback=None, dereference=True, overwrite=True, ignore_nonexisting=False)
       :canonical: aiida.transports.plugins.ssh.SshTransport.put
 
-      Put a file or a folder from local to remote.
-      Redirects to putfile or puttree.
-
-      :param localpath: an (absolute) local path
-      :param remotepath: a remote path
-      :param dereference: follow symbolic links (boolean).
-          Default = True (default behaviour in paramiko). False is not implemented.
-      :param  overwrite: if True overwrites files and folders (boolean).
-          Default = False.
-
-      :raise ValueError: if local path is invalid
-      :raise OSError: if the localpath does not exist
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.put
+         :renderer: rst
 
    .. py:method:: putfile(localpath, remotepath, callback=None, dereference=True, overwrite=True)
       :canonical: aiida.transports.plugins.ssh.SshTransport.putfile
 
-      Put a file from local to remote.
-
-      :param localpath: an (absolute) local path
-      :param remotepath: a remote path
-      :param overwrite: if True overwrites files and folders (boolean).
-          Default = True.
-
-      :raise ValueError: if local path is invalid
-      :raise OSError: if the localpath does not exist,
-                  or unintentionally overwriting
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.putfile
+         :renderer: rst
 
    .. py:method:: puttree(localpath, remotepath, callback=None, dereference=True, overwrite=True)
       :canonical: aiida.transports.plugins.ssh.SshTransport.puttree
 
-      Put a folder recursively from local to remote.
-
-      By default, overwrite.
-
-      :param localpath: an (absolute) local path
-      :param remotepath: a remote path
-      :param dereference: follow symbolic links (boolean)
-          Default = True (default behaviour in paramiko). False is not implemented.
-      :param overwrite: if True overwrites files and folders (boolean).
-          Default = True
-
-      :raise ValueError: if local path is invalid
-      :raise OSError: if the localpath does not exist, or trying to overwrite
-      :raise IOError: if remotepath is invalid
-
-      .. note:: setting dereference equal to True could cause infinite loops.
-            see os.walk() documentation
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.puttree
+         :renderer: rst
 
    .. py:method:: get(remotepath, localpath, callback=None, dereference=True, overwrite=True, ignore_nonexisting=False)
       :canonical: aiida.transports.plugins.ssh.SshTransport.get
 
-      Get a file or folder from remote to local.
-      Redirects to getfile or gettree.
-
-      :param remotepath: a remote path
-      :param localpath: an (absolute) local path
-      :param dereference: follow symbolic links.
-          Default = True (default behaviour in paramiko).
-          False is not implemented.
-      :param overwrite: if True overwrites files and folders.
-          Default = False
-
-      :raise ValueError: if local path is invalid
-      :raise IOError: if the remotepath is not found
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.get
+         :renderer: rst
 
    .. py:method:: getfile(remotepath, localpath, callback=None, dereference=True, overwrite=True)
       :canonical: aiida.transports.plugins.ssh.SshTransport.getfile
 
-      Get a file from remote to local.
-
-      :param remotepath: a remote path
-      :param  localpath: an (absolute) local path
-      :param  overwrite: if True overwrites files and folders.
-              Default = False
-
-      :raise ValueError: if local path is invalid
-      :raise OSError: if unintentionally overwriting
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.getfile
+         :renderer: rst
 
    .. py:method:: gettree(remotepath, localpath, callback=None, dereference=True, overwrite=True)
       :canonical: aiida.transports.plugins.ssh.SshTransport.gettree
 
-      Get a folder recursively from remote to local.
-
-      :param remotepath: a remote path
-      :param localpath: an (absolute) local path
-      :param dereference: follow symbolic links.
-          Default = True (default behaviour in paramiko).
-          False is not implemented.
-      :param  overwrite: if True overwrites files and folders.
-          Default = False
-
-      :raise ValueError: if local path is invalid
-      :raise IOError: if the remotepath is not found
-      :raise OSError: if unintentionally overwriting
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.gettree
+         :renderer: rst
 
    .. py:method:: get_attribute(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.get_attribute
 
-      Returns the object Fileattribute, specified in aiida.transports
-      Receives in input the path of a given file.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.get_attribute
+         :renderer: rst
 
    .. py:method:: copyfile(remotesource, remotedestination, dereference=False)
       :canonical: aiida.transports.plugins.ssh.SshTransport.copyfile
 
-      Copy a file from remote source to remote destination
-      (On the same remote machine)
-
-      :param str remotesource: path of the remote source directory / file
-      :param str remotedestination: path of the remote destination directory / file
-      :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
-      :type dereference: bool
-
-      :raises IOError: if one of src or dst does not exist
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.copyfile
+         :renderer: rst
 
    .. py:method:: copytree(remotesource, remotedestination, dereference=False)
       :canonical: aiida.transports.plugins.ssh.SshTransport.copytree
 
-      Copy a folder from remote source to remote destination
-      (On the same remote machine)
-
-      :param str remotesource: path of the remote source directory / file
-      :param str remotedestination: path of the remote destination directory / file
-      :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
-      :type dereference: bool
-
-      :raise IOError: if one of src or dst does not exist
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.copytree
+         :renderer: rst
 
    .. py:method:: copy(remotesource, remotedestination, dereference=False, recursive=True)
       :canonical: aiida.transports.plugins.ssh.SshTransport.copy
 
-      Copy a file or a directory from remote source to remote destination.
-      Flags used: ``-r``: recursive copy; ``-f``: force, makes the command non interactive;
-      ``-L`` follows symbolic links
-
-      :param  remotesource: file to copy from
-      :param remotedestination: file to copy to
-      :param dereference: if True, copy content instead of copying the symlinks only
-          Default = False.
-      :param recursive: if True copy directories recursively, otherwise only copy the specified file(s)
-      :type recursive: bool
-      :raise IOError: if the cp execution failed.
-
-      .. note:: setting dereference equal to True could cause infinite loops.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.copy
+         :renderer: rst
 
    .. py:method:: _exec_cp(cp_exe, cp_flags, src, dst)
       :canonical: aiida.transports.plugins.ssh.SshTransport._exec_cp
 
-      Execute the ``cp`` command on the remote machine.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._exec_cp
+         :renderer: rst
 
    .. py:method:: _local_listdir(path, pattern=None)
       :canonical: aiida.transports.plugins.ssh.SshTransport._local_listdir
       :staticmethod:
 
-      Acts on the local folder, for the rest, same as listdir
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._local_listdir
+         :renderer: rst
 
    .. py:method:: listdir(path='.', pattern=None)
       :canonical: aiida.transports.plugins.ssh.SshTransport.listdir
 
-      Get the list of files at path.
-
-      :param path: default = '.'
-      :param pattern: returns the list of files matching pattern.
-                           Unix only. (Use to emulate ``ls *`` for example)
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.listdir
+         :renderer: rst
 
    .. py:method:: remove(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.remove
 
-      Remove a single file at 'path'
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.remove
+         :renderer: rst
 
    .. py:method:: rename(oldpath, newpath)
       :canonical: aiida.transports.plugins.ssh.SshTransport.rename
 
-      Rename a file or folder from oldpath to newpath.
-
-      :param str oldpath: existing name of the file or folder
-      :param str newpath: new name for the file or folder
-
-      :raises IOError: if oldpath/newpath is not found
-      :raises ValueError: if sroldpathc/newpath is not a valid string
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.rename
+         :renderer: rst
 
    .. py:method:: isfile(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.isfile
 
-      Return True if the given path is a file, False otherwise.
-      Return False also if the path does not exist.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.isfile
+         :renderer: rst
 
    .. py:method:: _exec_command_internal(command, combine_stderr=False, bufsize=-1)
       :canonical: aiida.transports.plugins.ssh.SshTransport._exec_command_internal
 
-      Executes the specified command in bash login shell.
-
-      Before the command is executed, changes directory to the current
-      working directory as returned by self.getcwd().
-
-      For executing commands and waiting for them to finish, use
-      exec_command_wait.
-
-      :param  command: the command to execute. The command is assumed to be
-          already escaped using :py:func:`aiida.common.escaping.escape_for_bash`.
-      :param combine_stderr: (default False) if True, combine stdout and
-              stderr on the same buffer (i.e., stdout).
-              Note: If combine_stderr is True, stderr will always be empty.
-      :param bufsize: same meaning of the one used by paramiko.
-
-      :return: a tuple with (stdin, stdout, stderr, channel),
-          where stdin, stdout and stderr behave as file-like objects,
-          plus the methods provided by paramiko, and channel is a
-          paramiko.Channel object.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._exec_command_internal
+         :renderer: rst
 
    .. py:method:: exec_command_wait_bytes(command, stdin=None, combine_stderr=False, bufsize=-1)
       :canonical: aiida.transports.plugins.ssh.SshTransport.exec_command_wait_bytes
 
-      Executes the specified command and waits for it to finish.
-
-      :param command: the command to execute
-      :param stdin: (optional,default=None) can be a string or a
-                 file-like object.
-      :param combine_stderr: (optional, default=False) see docstring of
-                 self._exec_command_internal()
-      :param bufsize: same meaning of paramiko.
-
-      :return: a tuple with (return_value, stdout, stderr) where stdout and stderr
-          are both bytes and the return_value is an int.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.exec_command_wait_bytes
+         :renderer: rst
 
    .. py:method:: gotocomputer_command(remotedir)
       :canonical: aiida.transports.plugins.ssh.SshTransport.gotocomputer_command
 
-      Specific gotocomputer string to connect to a given remote computer via
-      ssh and directly go to the calculation folder.
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.gotocomputer_command
+         :renderer: rst
 
    .. py:method:: _symlink(source, dest)
       :canonical: aiida.transports.plugins.ssh.SshTransport._symlink
 
-      Wrap SFTP symlink call without breaking API
-
-      :param source: source of link
-      :param dest: link to create
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport._symlink
+         :renderer: rst
 
    .. py:method:: symlink(remotesource, remotedestination)
       :canonical: aiida.transports.plugins.ssh.SshTransport.symlink
 
-      Create a symbolic link between the remote source and the remote
-      destination.
-
-      :param remotesource: remote source. Can contain a pattern.
-      :param remotedestination: remote destination
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.symlink
+         :renderer: rst
 
    .. py:method:: path_exists(path)
       :canonical: aiida.transports.plugins.ssh.SshTransport.path_exists
 
-      Check if path exists
+      .. autodoc2-docstring:: aiida.transports.plugins.ssh.SshTransport.path_exists
+         :renderer: rst
 
 .. py:class:: Transport(*args, **kwargs)
    :canonical: aiida.transports.transport.Transport
 
    Bases: :py:obj:`abc.ABC`
 
-   Abstract class for a generic transport (ssh, local, ...) contains the set of minimal methods.
+   .. autodoc2-docstring:: aiida.transports.transport.Transport
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   __init__ method of the Transport base class.
-
-   :param safe_interval: (optional, default self._DEFAULT_SAFE_OPEN_INTERVAL)
-      Minimum time interval in seconds between opening new connections.
-   :param use_login_shell: (optional, default True)
-      if False, do not use a login shell when executing command
+   .. autodoc2-docstring:: aiida.transports.transport.Transport.__init__
+      :renderer: rst
 
    .. py:attribute:: DEFAULT_MINIMUM_JOB_POLL_INTERVAL
       :canonical: aiida.transports.transport.Transport.DEFAULT_MINIMUM_JOB_POLL_INTERVAL
       :value: 10
 
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.DEFAULT_MINIMUM_JOB_POLL_INTERVAL
+         :renderer: rst
+
    .. py:attribute:: _DEFAULT_SAFE_OPEN_INTERVAL
       :canonical: aiida.transports.transport.Transport._DEFAULT_SAFE_OPEN_INTERVAL
       :value: 30.0
+
+      .. autodoc2-docstring:: aiida.transports.transport.Transport._DEFAULT_SAFE_OPEN_INTERVAL
+         :renderer: rst
 
    .. py:attribute:: _valid_auth_params
       :canonical: aiida.transports.transport.Transport._valid_auth_params
       :value: None
 
+      .. autodoc2-docstring:: aiida.transports.transport.Transport._valid_auth_params
+         :renderer: rst
+
    .. py:attribute:: _MAGIC_CHECK
       :canonical: aiida.transports.transport.Transport._MAGIC_CHECK
       :value: None
+
+      .. autodoc2-docstring:: aiida.transports.transport.Transport._MAGIC_CHECK
+         :renderer: rst
 
    .. py:attribute:: _valid_auth_options
       :canonical: aiida.transports.transport.Transport._valid_auth_options
       :type: list
       :value: []
 
+      .. autodoc2-docstring:: aiida.transports.transport.Transport._valid_auth_options
+         :renderer: rst
+
    .. py:attribute:: _common_auth_options
       :canonical: aiida.transports.transport.Transport._common_auth_options
       :value: [('use_login_shell',), ('safe_interval',)]
 
+      .. autodoc2-docstring:: aiida.transports.transport.Transport._common_auth_options
+         :renderer: rst
+
    .. py:method:: __enter__()
       :canonical: aiida.transports.transport.Transport.__enter__
 
-      For transports that require opening a connection, opens
-      all required channels (used in 'with' statements).
-
-      This object can be used in nested `with` statements and the connection
-      will only be opened once and closed when the final `with` scope
-      finishes e.g.::
-
-          t = Transport()
-          with t:
-              # Connection is now open..
-              with t:
-                  # ..still open..
-                  pass
-              # ..still open..
-          # ...closed
-
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.__enter__
+         :renderer: rst
 
    .. py:method:: __exit__(type_, value, traceback)
       :canonical: aiida.transports.transport.Transport.__exit__
 
-      Closes connections, if needed (used in 'with' statements).
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.__exit__
+         :renderer: rst
 
    .. py:property:: is_open
       :canonical: aiida.transports.transport.Transport.is_open
+
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.is_open
+         :renderer: rst
 
    .. py:method:: open()
       :canonical: aiida.transports.transport.Transport.open
       :abstractmethod:
 
-      Opens a local transport channel
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.open
+         :renderer: rst
 
    .. py:method:: close()
       :canonical: aiida.transports.transport.Transport.close
       :abstractmethod:
 
-      Closes the local transport channel
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.close
+         :renderer: rst
 
    .. py:method:: __repr__()
       :canonical: aiida.transports.transport.Transport.__repr__
 
-      Return repr(self).
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.__repr__
+         :renderer: rst
 
    .. py:method:: __str__()
       :canonical: aiida.transports.transport.Transport.__str__
 
-      Return str(self).
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.__str__
+         :renderer: rst
 
    .. py:method:: set_logger_extra(logger_extra)
       :canonical: aiida.transports.transport.Transport.set_logger_extra
 
-      Pass the data that should be passed automatically to self.logger
-      as 'extra' keyword. This is typically useful if you pass data
-      obtained using get_dblogger_extra in aiida.orm.utils.log, to automatically
-      log also to the DbLog table.
-
-      :param logger_extra: data that you want to pass as extra to the
-        self.logger. To write to DbLog, it should be created by the
-        aiida.orm.utils.log.get_dblogger_extra function. Pass None if you
-        do not want to have extras passed.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.set_logger_extra
+         :renderer: rst
 
    .. py:method:: get_short_doc()
       :canonical: aiida.transports.transport.Transport.get_short_doc
       :classmethod:
 
-      Return the first non-empty line of the class docstring, if available
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.get_short_doc
+         :renderer: rst
 
    .. py:method:: get_valid_auth_params()
       :canonical: aiida.transports.transport.Transport.get_valid_auth_params
       :classmethod:
 
-      Return the internal list of valid auth_params
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.get_valid_auth_params
+         :renderer: rst
 
    .. py:method:: auth_options() -> collections.OrderedDict
       :canonical: aiida.transports.transport.Transport.auth_options
 
-      Return the authentication options to be used for building the CLI.
-
-      :return: `OrderedDict` of tuples, with first element option name and second dictionary of kwargs
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.auth_options
+         :renderer: rst
 
    .. py:method:: _get_safe_interval_suggestion_string(computer)
       :canonical: aiida.transports.transport.Transport._get_safe_interval_suggestion_string
       :classmethod:
 
-      Return as a suggestion the default safe interval of this Transport class.
-
-      This is used to provide a default in ``verdi computer configure``.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport._get_safe_interval_suggestion_string
+         :renderer: rst
 
    .. py:method:: _get_use_login_shell_suggestion_string(computer)
       :canonical: aiida.transports.transport.Transport._get_use_login_shell_suggestion_string
       :classmethod:
 
-      Return a suggestion for the specific field.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport._get_use_login_shell_suggestion_string
+         :renderer: rst
 
    .. py:property:: logger
       :canonical: aiida.transports.transport.Transport.logger
 
-      Return the internal logger.
-      If you have set extra parameters using set_logger_extra(), a
-      suitable LoggerAdapter instance is created, bringing with itself
-      also the extras.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.logger
+         :renderer: rst
 
    .. py:method:: get_safe_open_interval()
       :canonical: aiida.transports.transport.Transport.get_safe_open_interval
 
-      Get an interval (in seconds) that suggests how long the user should wait
-      between consecutive calls to open the transport.  This can be used as
-      a way to get the user to not swamp a limited number of connections, etc.
-      However it is just advisory.
-
-      If returns 0, it is taken that there are no reasons to limit the
-      frequency of open calls.
-
-      In the main class, it returns a default value (>0 for safety), set in
-      the _DEFAULT_SAFE_OPEN_INTERVAL attribute of the class. Plugins should override it.
-
-      :return: The safe interval between calling open, in seconds
-      :rtype: float
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.get_safe_open_interval
+         :renderer: rst
 
    .. py:method:: chdir(path)
       :canonical: aiida.transports.transport.Transport.chdir
       :abstractmethod:
 
-      Change directory to 'path'
-
-      :param str path: path to change working directory into.
-      :raises: IOError, if the requested path does not exist
-      :rtype: str
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.chdir
+         :renderer: rst
 
    .. py:method:: chmod(path, mode)
       :canonical: aiida.transports.transport.Transport.chmod
       :abstractmethod:
 
-      Change permissions of a path.
-
-      :param str path: path to file
-      :param int mode: new permissions
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.chmod
+         :renderer: rst
 
    .. py:method:: chown(path, uid, gid)
       :canonical: aiida.transports.transport.Transport.chown
       :abstractmethod:
 
-      Change the owner (uid) and group (gid) of a file.
-      As with python's os.chown function, you must pass both arguments,
-      so if you only want to change one, use stat first to retrieve the
-      current owner and group.
-
-      :param str path: path to the file to change the owner and group of
-      :param int uid: new owner's uid
-      :param int gid: new group id
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.chown
+         :renderer: rst
 
    .. py:method:: copy(remotesource, remotedestination, dereference=False, recursive=True)
       :canonical: aiida.transports.transport.Transport.copy
       :abstractmethod:
 
-      Copy a file or a directory from remote source to remote destination
-      (On the same remote machine)
-
-      :param str remotesource: path of the remote source directory / file
-      :param str remotedestination: path of the remote destination directory / file
-      :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
-      :type dereference: bool
-      :param recursive: if True copy directories recursively, otherwise only copy the specified file(s)
-      :type recursive: bool
-
-      :raises: IOError, if one of src or dst does not exist
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.copy
+         :renderer: rst
 
    .. py:method:: copyfile(remotesource, remotedestination, dereference=False)
       :canonical: aiida.transports.transport.Transport.copyfile
       :abstractmethod:
 
-      Copy a file from remote source to remote destination
-      (On the same remote machine)
-
-      :param str remotesource: path of the remote source directory / file
-      :param str remotedestination: path of the remote destination directory / file
-      :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
-      :type dereference: bool
-
-      :raises IOError: if one of src or dst does not exist
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.copyfile
+         :renderer: rst
 
    .. py:method:: copytree(remotesource, remotedestination, dereference=False)
       :canonical: aiida.transports.transport.Transport.copytree
       :abstractmethod:
 
-      Copy a folder from remote source to remote destination
-      (On the same remote machine)
-
-      :param str remotesource: path of the remote source directory / file
-      :param str remotedestination: path of the remote destination directory / file
-      :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
-      :type dereference: bool
-
-      :raise IOError: if one of src or dst does not exist
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.copytree
+         :renderer: rst
 
    .. py:method:: copy_from_remote_to_remote(transportdestination, remotesource, remotedestination, **kwargs)
       :canonical: aiida.transports.transport.Transport.copy_from_remote_to_remote
 
-      Copy files or folders from a remote computer to another remote computer.
-
-      :param transportdestination: transport to be used for the destination computer
-      :param str remotesource: path to the remote source directory / file
-      :param str remotedestination: path to the remote destination directory / file
-      :param kwargs: keyword parameters passed to the call to transportdestination.put,
-          except for 'dereference' that is passed to self.get
-
-      .. note:: the keyword 'dereference' SHOULD be set to False for the
-       final put (onto the destination), while it can be set to the
-       value given in kwargs for the get from the source. In that
-       way, a symbolic link would never be followed in the final
-       copy to the remote destination. That way we could avoid getting
-       unknown (potentially malicious) files into the destination computer.
-       HOWEVER, since dereference=False is currently NOT
-       supported by all plugins, we still force it to True for the final put.
-
-      .. note:: the supported keys in kwargs are callback, dereference,
-         overwrite and ignore_nonexisting.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.copy_from_remote_to_remote
+         :renderer: rst
 
    .. py:method:: _exec_command_internal(command, **kwargs)
       :canonical: aiida.transports.transport.Transport._exec_command_internal
       :abstractmethod:
 
-      Execute the command on the shell, similarly to os.system.
-
-      Enforce the execution to be run from the cwd (as given by
-      self.getcwd), if this is not None.
-
-      If possible, use the higher-level
-      exec_command_wait function.
-
-      :param str command: execute the command given as a string
-      :return: stdin, stdout, stderr and the session, when this exists                  (can be None).
+      .. autodoc2-docstring:: aiida.transports.transport.Transport._exec_command_internal
+         :renderer: rst
 
    .. py:method:: exec_command_wait_bytes(command, stdin=None, **kwargs)
       :canonical: aiida.transports.transport.Transport.exec_command_wait_bytes
       :abstractmethod:
 
-      Execute the command on the shell, waits for it to finish,
-      and return the retcode, the stdout and the stderr as bytes.
-
-      Enforce the execution to be run from the pwd (as given by self.getcwd), if this is not None.
-
-      The command implementation can have some additional plugin-specific kwargs.
-
-      :param str command: execute the command given as a string
-      :param stdin: (optional,default=None) can be a string or a file-like object.
-      :return: a tuple: the retcode (int), stdout (bytes) and stderr (bytes).
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.exec_command_wait_bytes
+         :renderer: rst
 
    .. py:method:: exec_command_wait(command, stdin=None, encoding='utf-8', **kwargs)
       :canonical: aiida.transports.transport.Transport.exec_command_wait
 
-      Executes the specified command and waits for it to finish.
-
-      :note: this function also decodes the bytes received into a string with the specified encoding,
-          which is set to be ``utf-8`` by default (for backward-compatibility with earlier versions) of
-          AiiDA.
-          Use this method only if you are sure that you are getting a properly encoded string; otherwise,
-          use the ``exec_command_wait_bytes`` method that returns the undecoded byte stream.
-
-      :note: additional kwargs are passed to the ``exec_command_wait_bytes`` function, that might use them
-          depending on the plugin.
-
-      :param command: the command to execute
-      :param stdin: (optional,default=None) can be a string or a file-like object.
-      :param encoding: the encoding to use to decode the byte stream received from the remote command execution.
-
-      :return: a tuple with (return_value, stdout, stderr) where stdout and stderr are both strings, decoded
-          with the specified encoding.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.exec_command_wait
+         :renderer: rst
 
    .. py:method:: get(remotepath, localpath, *args, **kwargs)
       :canonical: aiida.transports.transport.Transport.get
       :abstractmethod:
 
-      Retrieve a file or folder from remote source to local destination
-      dst must be an absolute path (src not necessarily)
-
-      :param remotepath: (str) remote_folder_path
-      :param localpath: (str) local_folder_path
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.get
+         :renderer: rst
 
    .. py:method:: getfile(remotepath, localpath, *args, **kwargs)
       :canonical: aiida.transports.transport.Transport.getfile
       :abstractmethod:
 
-      Retrieve a file from remote source to local destination
-      dst must be an absolute path (src not necessarily)
-
-      :param str remotepath: remote_folder_path
-      :param str localpath: local_folder_path
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.getfile
+         :renderer: rst
 
    .. py:method:: gettree(remotepath, localpath, *args, **kwargs)
       :canonical: aiida.transports.transport.Transport.gettree
       :abstractmethod:
 
-      Retrieve a folder recursively from remote source to local destination
-      dst must be an absolute path (src not necessarily)
-
-      :param str remotepath: remote_folder_path
-      :param str localpath: local_folder_path
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.gettree
+         :renderer: rst
 
    .. py:method:: getcwd()
       :canonical: aiida.transports.transport.Transport.getcwd
       :abstractmethod:
 
-      Get working directory
-
-      :return: a string identifying the current working directory
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.getcwd
+         :renderer: rst
 
    .. py:method:: get_attribute(path)
       :canonical: aiida.transports.transport.Transport.get_attribute
       :abstractmethod:
 
-      Return an object FixedFieldsAttributeDict for file in a given path,
-      as defined in aiida.common.extendeddicts
-      Each attribute object consists in a dictionary with the following keys:
-
-      * st_size: size of files, in bytes
-
-      * st_uid: user id of owner
-
-      * st_gid: group id of owner
-
-      * st_mode: protection bits
-
-      * st_atime: time of most recent access
-
-      * st_mtime: time of most recent modification
-
-      :param str path: path to file
-      :return: object FixedFieldsAttributeDict
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.get_attribute
+         :renderer: rst
 
    .. py:method:: get_mode(path)
       :canonical: aiida.transports.transport.Transport.get_mode
 
-      Return the portion of the file's mode that can be set by chmod().
-
-      :param str path: path to file
-      :return: the portion of the file's mode that can be set by chmod()
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.get_mode
+         :renderer: rst
 
    .. py:method:: isdir(path)
       :canonical: aiida.transports.transport.Transport.isdir
       :abstractmethod:
 
-      True if path is an existing directory.
-
-      :param str path: path to directory
-      :return: boolean
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.isdir
+         :renderer: rst
 
    .. py:method:: isfile(path)
       :canonical: aiida.transports.transport.Transport.isfile
       :abstractmethod:
 
-      Return True if path is an existing file.
-
-      :param str path: path to file
-      :return: boolean
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.isfile
+         :renderer: rst
 
    .. py:method:: listdir(path='.', pattern=None)
       :canonical: aiida.transports.transport.Transport.listdir
       :abstractmethod:
 
-      Return a list of the names of the entries in the given path.
-      The list is in arbitrary order. It does not include the special
-      entries '.' and '..' even if they are present in the directory.
-
-      :param str path: path to list (default to '.')
-      :param str pattern: if used, listdir returns a list of files matching
-                          filters in Unix style. Unix only.
-      :return: a list of strings
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.listdir
+         :renderer: rst
 
    .. py:method:: listdir_withattributes(path='.', pattern=None)
       :canonical: aiida.transports.transport.Transport.listdir_withattributes
 
-      Return a list of the names of the entries in the given path.
-      The list is in arbitrary order. It does not include the special
-      entries '.' and '..' even if they are present in the directory.
-
-      :param str path: path to list (default to '.')
-      :param str pattern: if used, listdir returns a list of files matching
-                          filters in Unix style. Unix only.
-      :return: a list of dictionaries, one per entry.
-          The schema of the dictionary is
-          the following::
-
-              {
-                 'name': String,
-                 'attributes': FileAttributeObject,
-                 'isdir': Bool
-              }
-
-          where 'name' is the file or folder directory, and any other information is metadata
-          (if the file is a folder, a directory, ...). 'attributes' behaves as the output of
-          transport.get_attribute(); isdir is a boolean indicating if the object is a directory or not.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.listdir_withattributes
+         :renderer: rst
 
    .. py:method:: makedirs(path, ignore_existing=False)
       :canonical: aiida.transports.transport.Transport.makedirs
       :abstractmethod:
 
-      Super-mkdir; create a leaf directory and all intermediate ones.
-      Works like mkdir, except that any intermediate path segment (not
-      just the rightmost) will be created if it does not exist.
-
-      :param str path: directory to create
-      :param bool ignore_existing: if set to true, it doesn't give any error
-                                   if the leaf directory does already exist
-
-      :raises: OSError, if directory at path already exists
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.makedirs
+         :renderer: rst
 
    .. py:method:: mkdir(path, ignore_existing=False)
       :canonical: aiida.transports.transport.Transport.mkdir
       :abstractmethod:
 
-      Create a folder (directory) named path.
-
-      :param str path: name of the folder to create
-      :param bool ignore_existing: if True, does not give any error if the
-                                   directory already exists
-
-      :raises: OSError, if directory at path already exists
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.mkdir
+         :renderer: rst
 
    .. py:method:: normalize(path='.')
       :canonical: aiida.transports.transport.Transport.normalize
       :abstractmethod:
 
-      Return the normalized path (on the server) of a given path.
-      This can be used to quickly resolve symbolic links or determine
-      what the server is considering to be the "current folder".
-
-      :param str path: path to be normalized
-
-      :raise IOError: if the path can't be resolved on the server
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.normalize
+         :renderer: rst
 
    .. py:method:: put(localpath, remotepath, *args, **kwargs)
       :canonical: aiida.transports.transport.Transport.put
       :abstractmethod:
 
-      Put a file or a directory from local src to remote dst.
-      src must be an absolute path (dst not necessarily))
-      Redirects to putfile and puttree.
-
-      :param str localpath: absolute path to local source
-      :param str remotepath: path to remote destination
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.put
+         :renderer: rst
 
    .. py:method:: putfile(localpath, remotepath, *args, **kwargs)
       :canonical: aiida.transports.transport.Transport.putfile
       :abstractmethod:
 
-      Put a file from local src to remote dst.
-      src must be an absolute path (dst not necessarily))
-
-      :param str localpath: absolute path to local file
-      :param str remotepath: path to remote file
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.putfile
+         :renderer: rst
 
    .. py:method:: puttree(localpath, remotepath, *args, **kwargs)
       :canonical: aiida.transports.transport.Transport.puttree
       :abstractmethod:
 
-      Put a folder recursively from local src to remote dst.
-      src must be an absolute path (dst not necessarily))
-
-      :param str localpath: absolute path to local folder
-      :param str remotepath: path to remote folder
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.puttree
+         :renderer: rst
 
    .. py:method:: remove(path)
       :canonical: aiida.transports.transport.Transport.remove
       :abstractmethod:
 
-      Remove the file at the given path. This only works on files;
-      for removing folders (directories), use rmdir.
-
-      :param str path: path to file to remove
-
-      :raise IOError: if the path is a directory
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.remove
+         :renderer: rst
 
    .. py:method:: rename(oldpath, newpath)
       :canonical: aiida.transports.transport.Transport.rename
       :abstractmethod:
 
-      Rename a file or folder from oldpath to newpath.
-
-      :param str oldpath: existing name of the file or folder
-      :param str newpath: new name for the file or folder
-
-      :raises IOError: if oldpath/newpath is not found
-      :raises ValueError: if oldpath/newpath is not a valid string
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.rename
+         :renderer: rst
 
    .. py:method:: rmdir(path)
       :canonical: aiida.transports.transport.Transport.rmdir
       :abstractmethod:
 
-      Remove the folder named path.
-      This works only for empty folders. For recursive remove, use rmtree.
-
-      :param str path: absolute path to the folder to remove
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.rmdir
+         :renderer: rst
 
    .. py:method:: rmtree(path)
       :canonical: aiida.transports.transport.Transport.rmtree
       :abstractmethod:
 
-      Remove recursively the content at path
-
-      :param str path: absolute path to remove
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.rmtree
+         :renderer: rst
 
    .. py:method:: gotocomputer_command(remotedir)
       :canonical: aiida.transports.transport.Transport.gotocomputer_command
       :abstractmethod:
 
-      Return a string to be run using os.system in order to connect
-      via the transport to the remote directory.
-
-      Expected behaviors:
-
-      * A new bash session is opened
-
-      * A reasonable error message is produced if the folder does not exist
-
-      :param str remotedir: the full path of the remote directory
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.gotocomputer_command
+         :renderer: rst
 
    .. py:method:: symlink(remotesource, remotedestination)
       :canonical: aiida.transports.transport.Transport.symlink
       :abstractmethod:
 
-      Create a symbolic link between the remote source and the remote
-      destination.
-
-      :param remotesource: remote source
-      :param remotedestination: remote destination
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.symlink
+         :renderer: rst
 
    .. py:method:: whoami()
       :canonical: aiida.transports.transport.Transport.whoami
 
-      Get the remote username
-
-      :return: list of username (str),
-               retval (int),
-               stderr (str)
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.whoami
+         :renderer: rst
 
    .. py:method:: path_exists(path)
       :canonical: aiida.transports.transport.Transport.path_exists
       :abstractmethod:
 
-      Returns True if path exists, False otherwise.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.path_exists
+         :renderer: rst
 
    .. py:method:: glob(pathname)
       :canonical: aiida.transports.transport.Transport.glob
 
-      Return a list of paths matching a pathname pattern.
-
-      The pattern may contain simple shell-style wildcards a la fnmatch.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.glob
+         :renderer: rst
 
    .. py:method:: iglob(pathname)
       :canonical: aiida.transports.transport.Transport.iglob
 
-      Return an iterator which yields the paths matching a pathname pattern.
-
-      The pattern may contain simple shell-style wildcards a la fnmatch.
-
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.iglob
+         :renderer: rst
 
    .. py:method:: glob1(dirname, pattern)
       :canonical: aiida.transports.transport.Transport.glob1
 
-      Match subpaths of dirname against pattern.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.glob1
+         :renderer: rst
 
    .. py:method:: glob0(dirname, basename)
       :canonical: aiida.transports.transport.Transport.glob0
 
-      Wrap basename i a list if it is empty or if dirname/basename is an existing path, else return empty list.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.glob0
+         :renderer: rst
 
    .. py:method:: has_magic(string)
       :canonical: aiida.transports.transport.Transport.has_magic
 
+      .. autodoc2-docstring:: aiida.transports.transport.Transport.has_magic
+         :renderer: rst
+
    .. py:method:: _gotocomputer_string(remotedir)
       :canonical: aiida.transports.transport.Transport._gotocomputer_string
 
-      command executed when goto computer.
+      .. autodoc2-docstring:: aiida.transports.transport.Transport._gotocomputer_string
+         :renderer: rst
 
 .. py:function:: convert_to_bool(string)
    :canonical: aiida.transports.plugins.ssh.convert_to_bool
 
-   Convert a string passed in the CLI to a valid bool.
-
-   :return: the parsed bool value.
-   :raise ValueError: If the value is not parsable as a bool
+   .. autodoc2-docstring:: aiida.transports.plugins.ssh.convert_to_bool
+      :renderer: rst
 
 .. py:function:: parse_sshconfig(computername)
    :canonical: aiida.transports.plugins.ssh.parse_sshconfig
 
-   Return the ssh configuration for a given computer name.
-
-   This parses the ``.ssh/config`` file in the home directory and
-   returns the part of configuration of the given computer name.
-
-   :param computername: the computer name for which we want the configuration.
+   .. autodoc2-docstring:: aiida.transports.plugins.ssh.parse_sshconfig
+      :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.analysis.rst
+++ b/docs/apidocs/autodoc2/autodoc2.analysis.rst
@@ -7,10 +7,9 @@
 Description
 -----------
 
-Analyse of Python code using astroid.
-
-The core function though `analyse_module` is agnostic to the implementation,
-It simply yields `ItemData` typed-dicts.
+.. autodoc2-docstring:: autodoc2.analysis
+   :renderer: rst
+   :allowtitles:
 
 Module Contents
 ---------------
@@ -23,7 +22,9 @@ Classes
    :align: left
 
    * - :py:obj:`State <autodoc2.analysis.State>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.analysis.State
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -33,27 +34,49 @@ Functions
    :align: left
 
    * - :py:obj:`analyse_module <autodoc2.analysis.analyse_module>`
-     - Analyse the given module and yield items.
+     - .. autodoc2-docstring:: autodoc2.analysis.analyse_module
+          :renderer: rst
+          :summary:
    * - :py:obj:`_get_full_name <autodoc2.analysis._get_full_name>`
-     - Get the full name of a node.
+     - .. autodoc2-docstring:: autodoc2.analysis._get_full_name
+          :renderer: rst
+          :summary:
    * - :py:obj:`_get_parent_name <autodoc2.analysis._get_parent_name>`
-     - Get the parent name of a node.
+     - .. autodoc2-docstring:: autodoc2.analysis._get_parent_name
+          :renderer: rst
+          :summary:
    * - :py:obj:`fix_docstring_indent <autodoc2.analysis.fix_docstring_indent>`
-     - Remove common leading indentation, where the indentation of the first line is ignored.
+     - .. autodoc2-docstring:: autodoc2.analysis.fix_docstring_indent
+          :renderer: rst
+          :summary:
    * - :py:obj:`walk_node <autodoc2.analysis.walk_node>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.analysis.walk_node
+          :renderer: rst
+          :summary:
    * - :py:obj:`yield_module <autodoc2.analysis.yield_module>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.analysis.yield_module
+          :renderer: rst
+          :summary:
    * - :py:obj:`yield_annotation_assign <autodoc2.analysis.yield_annotation_assign>`
-     - Yield data for an annotation assignment node.
+     - .. autodoc2-docstring:: autodoc2.analysis.yield_annotation_assign
+          :renderer: rst
+          :summary:
    * - :py:obj:`yield_assign <autodoc2.analysis.yield_assign>`
-     - Yield data for an assignment node.
+     - .. autodoc2-docstring:: autodoc2.analysis.yield_assign
+          :renderer: rst
+          :summary:
    * - :py:obj:`_yield_assign <autodoc2.analysis._yield_assign>`
-     - Yield data for an assignment node.
+     - .. autodoc2-docstring:: autodoc2.analysis._yield_assign
+          :renderer: rst
+          :summary:
    * - :py:obj:`yield_function_def <autodoc2.analysis.yield_function_def>`
-     - Yield data for a function definition node.
+     - .. autodoc2-docstring:: autodoc2.analysis.yield_function_def
+          :renderer: rst
+          :summary:
    * - :py:obj:`yield_class_def <autodoc2.analysis.yield_class_def>`
-     - Yield data for a class definition node.
+     - .. autodoc2-docstring:: autodoc2.analysis.yield_class_def
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -63,11 +86,17 @@ Data
    :align: left
 
    * - :py:obj:`__all__ <autodoc2.analysis.__all__>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.analysis.__all__
+          :renderer: rst
+          :summary:
    * - :py:obj:`_dc_kwargs <autodoc2.analysis._dc_kwargs>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.analysis._dc_kwargs
+          :renderer: rst
+          :summary:
    * - :py:obj:`_FUNC_MAPPER <autodoc2.analysis._FUNC_MAPPER>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.analysis._FUNC_MAPPER
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -76,95 +105,123 @@ API
    :canonical: autodoc2.analysis.__all__
    :value: ['analyse_module']
 
+   .. autodoc2-docstring:: autodoc2.analysis.__all__
+      :renderer: rst
+
 .. py:function:: analyse_module(file_path: pathlib.Path, name: str, exclude_external_imports: typing.Pattern[str] | None = None) -> typing.Iterable[autodoc2.utils.ItemData]
    :canonical: autodoc2.analysis.analyse_module
 
-   Analyse the given module and yield items.
-
-   :param file_path: The path to the module.
-   :param name: The name of the module, e.g. "foo.bar".
-   :param record_external_imports: If given, record these external imports on the module.
-       These are only used to determine what is exposed by __all__,
-       which is only usually objects in the same package.
-       But if you want to expose objects from other packages,
-       you can use this to record them.
+   .. autodoc2-docstring:: autodoc2.analysis.analyse_module
+      :renderer: rst
 
 .. py:data:: _dc_kwargs
    :canonical: autodoc2.analysis._dc_kwargs
    :type: dict[str, bool]
    :value: None
 
+   .. autodoc2-docstring:: autodoc2.analysis._dc_kwargs
+      :renderer: rst
+
 .. py:class:: State
    :canonical: autodoc2.analysis.State
+
+   .. autodoc2-docstring:: autodoc2.analysis.State
+      :renderer: rst
 
    .. py:attribute:: package_name
       :canonical: autodoc2.analysis.State.package_name
       :type: str
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.analysis.State.package_name
+         :renderer: rst
+
    .. py:attribute:: name_stack
       :canonical: autodoc2.analysis.State.name_stack
       :type: list[str]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.analysis.State.name_stack
+         :renderer: rst
 
    .. py:attribute:: exclude_external_imports
       :canonical: autodoc2.analysis.State.exclude_external_imports
       :type: typing.Pattern[str] | None
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.analysis.State.exclude_external_imports
+         :renderer: rst
+
    .. py:method:: copy(**kwargs: typing.Any) -> autodoc2.analysis.State
       :canonical: autodoc2.analysis.State.copy
 
-      Copy the state and update the given attributes.
+      .. autodoc2-docstring:: autodoc2.analysis.State.copy
+         :renderer: rst
 
 .. py:function:: _get_full_name(name: str, name_stack: list[str]) -> str
    :canonical: autodoc2.analysis._get_full_name
 
-   Get the full name of a node.
+   .. autodoc2-docstring:: autodoc2.analysis._get_full_name
+      :renderer: rst
 
 .. py:function:: _get_parent_name(name: str) -> str
    :canonical: autodoc2.analysis._get_parent_name
 
-   Get the parent name of a node.
+   .. autodoc2-docstring:: autodoc2.analysis._get_parent_name
+      :renderer: rst
 
 .. py:function:: fix_docstring_indent(s: None | str, tabsize: int = 8) -> str
    :canonical: autodoc2.analysis.fix_docstring_indent
 
-   Remove common leading indentation,
-   where the indentation of the first line is ignored.
+   .. autodoc2-docstring:: autodoc2.analysis.fix_docstring_indent
+      :renderer: rst
 
 .. py:function:: walk_node(node: astroid.nodes.NodeNG, state: autodoc2.analysis.State) -> typing.Iterable[autodoc2.utils.ItemData]
    :canonical: autodoc2.analysis.walk_node
 
+   .. autodoc2-docstring:: autodoc2.analysis.walk_node
+      :renderer: rst
+
 .. py:function:: yield_module(node: astroid.nodes.Module, state: autodoc2.analysis.State) -> typing.Iterable[autodoc2.utils.ItemData]
    :canonical: autodoc2.analysis.yield_module
+
+   .. autodoc2-docstring:: autodoc2.analysis.yield_module
+      :renderer: rst
 
 .. py:function:: yield_annotation_assign(node: astroid.nodes.AnnAssign, state: autodoc2.analysis.State) -> typing.Iterable[autodoc2.utils.ItemData]
    :canonical: autodoc2.analysis.yield_annotation_assign
 
-   Yield data for an annotation assignment node.
+   .. autodoc2-docstring:: autodoc2.analysis.yield_annotation_assign
+      :renderer: rst
 
 .. py:function:: yield_assign(node: astroid.nodes.Assign, state: autodoc2.analysis.State) -> typing.Iterable[autodoc2.utils.ItemData]
    :canonical: autodoc2.analysis.yield_assign
 
-   Yield data for an assignment node.
+   .. autodoc2-docstring:: autodoc2.analysis.yield_assign
+      :renderer: rst
 
 .. py:function:: _yield_assign(node: astroid.nodes.Assign | astroid.nodes.AnnAssign, state: autodoc2.analysis.State) -> typing.Iterable[autodoc2.utils.ItemData]
    :canonical: autodoc2.analysis._yield_assign
 
-   Yield data for an assignment node.
+   .. autodoc2-docstring:: autodoc2.analysis._yield_assign
+      :renderer: rst
 
 .. py:function:: yield_function_def(node: astroid.nodes.FunctionDef | astroid.nodes.AsyncFunctionDef, state: autodoc2.analysis.State) -> typing.Iterable[autodoc2.utils.ItemData]
    :canonical: autodoc2.analysis.yield_function_def
 
-   Yield data for a function definition node.
+   .. autodoc2-docstring:: autodoc2.analysis.yield_function_def
+      :renderer: rst
 
 .. py:function:: yield_class_def(node: astroid.nodes.ClassDef, state: autodoc2.analysis.State) -> typing.Iterable[autodoc2.utils.ItemData]
    :canonical: autodoc2.analysis.yield_class_def
 
-   Yield data for a class definition node.
+   .. autodoc2-docstring:: autodoc2.analysis.yield_class_def
+      :renderer: rst
 
 .. py:data:: _FUNC_MAPPER
    :canonical: autodoc2.analysis._FUNC_MAPPER
    :type: dict[astroid.nodes.NodeNG, typing.Callable[[astroid.nodes.NodeNG, autodoc2.analysis.State], typing.Iterable[autodoc2.utils.ItemData]]]
    :value: None
+
+   .. autodoc2-docstring:: autodoc2.analysis._FUNC_MAPPER
+      :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.astroid_utils.rst
+++ b/docs/apidocs/autodoc2/autodoc2.astroid_utils.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Utilities for working with astroid nodes.
+.. autodoc2-docstring:: autodoc2.astroid_utils
+   :renderer: rst
+   :allowtitles:
 
 Module Contents
 ---------------
@@ -20,55 +22,105 @@ Functions
    :align: left
 
    * - :py:obj:`resolve_import_alias <autodoc2.astroid_utils.resolve_import_alias>`
-     - Resolve a name from an aliased import to its original name.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.resolve_import_alias
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_constructor <autodoc2.astroid_utils.is_constructor>`
-     - Check if the function is a constructor.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_constructor
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_full_import_name <autodoc2.astroid_utils.get_full_import_name>`
-     - Get the full path of a name from a ``from x import y`` statement.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.get_full_import_name
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_assign_value <autodoc2.astroid_utils.get_assign_value>`
-     - Get the name and value of the assignment of the given node.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.get_assign_value
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_const_values <autodoc2.astroid_utils.get_const_values>`
-     - Get the value of a constant node.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.get_const_values
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_assign_annotation <autodoc2.astroid_utils.get_assign_annotation>`
-     - Get the type annotation of the assignment of the given node.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.get_assign_annotation
+          :renderer: rst
+          :summary:
    * - :py:obj:`resolve_annotation <autodoc2.astroid_utils.resolve_annotation>`
-     - Resolve a type annotation to a string.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.resolve_annotation
+          :renderer: rst
+          :summary:
    * - :py:obj:`resolve_qualname <autodoc2.astroid_utils.resolve_qualname>`
-     - Resolve where a node is defined to get its fully qualified name.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.resolve_qualname
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_module_all <autodoc2.astroid_utils.get_module_all>`
-     - Get the contents of the ``__all__`` variable from a module.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.get_module_all
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_decorated_with_singledispatch <autodoc2.astroid_utils.is_decorated_with_singledispatch>`
-     - Check if the function is decorated as a singledispatch.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_with_singledispatch
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_singledispatch_decorator <autodoc2.astroid_utils.is_singledispatch_decorator>`
-     - Check if the decorator is a singledispatch.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_singledispatch_decorator
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_decorated_as_singledispatch_register <autodoc2.astroid_utils.is_decorated_as_singledispatch_register>`
-     - Check if the function is decorated as a singledispatch register.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_as_singledispatch_register
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_decorated_with_property <autodoc2.astroid_utils.is_decorated_with_property>`
-     - Check if the function is decorated as a property.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_with_property
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_property_decorator <autodoc2.astroid_utils.is_property_decorator>`
-     - Check if the decorator is a property.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_property_decorator
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_decorated_with_property_setter <autodoc2.astroid_utils.is_decorated_with_property_setter>`
-     - Check if the function is decorated as a property setter.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_with_property_setter
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_class_docstring <autodoc2.astroid_utils.get_class_docstring>`
-     - Get the docstring of a node, using a parent docstring if needed.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.get_class_docstring
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_exception <autodoc2.astroid_utils.is_exception>`
-     - Check if a class is an exception.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_exception
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_decorated_with_overload <autodoc2.astroid_utils.is_decorated_with_overload>`
-     - Check if the function is decorated as an overload definition.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_with_overload
+          :renderer: rst
+          :summary:
    * - :py:obj:`is_overload_decorator <autodoc2.astroid_utils.is_overload_decorator>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.is_overload_decorator
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_func_docstring <autodoc2.astroid_utils.get_func_docstring>`
-     - Get the docstring of a node, using a parent docstring if needed.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.get_func_docstring
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_return_annotation <autodoc2.astroid_utils.get_return_annotation>`
-     - Get the return annotation of a node.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.get_return_annotation
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_args_info <autodoc2.astroid_utils.get_args_info>`
-     - Get the arguments of a function.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils.get_args_info
+          :renderer: rst
+          :summary:
    * - :py:obj:`_iter_args <autodoc2.astroid_utils._iter_args>`
-     - Iterate over arguments.
+     - .. autodoc2-docstring:: autodoc2.astroid_utils._iter_args
+          :renderer: rst
+          :summary:
    * - :py:obj:`_merge_annotations <autodoc2.astroid_utils._merge_annotations>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.astroid_utils._merge_annotations
+          :renderer: rst
+          :summary:
    * - :py:obj:`_is_ellipsis <autodoc2.astroid_utils._is_ellipsis>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.astroid_utils._is_ellipsis
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -76,146 +128,149 @@ API
 .. py:function:: resolve_import_alias(name: str, import_names: list[tuple[str, str | None]]) -> str
    :canonical: autodoc2.astroid_utils.resolve_import_alias
 
-   Resolve a name from an aliased import to its original name.
-
-   :param name: The potentially aliased name to resolve.
-   :param import_names: The pairs of original names and aliases
-       from the import.
-
-   :returns: The original name.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.resolve_import_alias
+      :renderer: rst
 
 .. py:function:: is_constructor(node: astroid.nodes.NodeNG) -> bool
    :canonical: autodoc2.astroid_utils.is_constructor
 
-   Check if the function is a constructor.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_constructor
+      :renderer: rst
 
 .. py:function:: get_full_import_name(import_from: astroid.nodes.ImportFrom, name: str) -> str
    :canonical: autodoc2.astroid_utils.get_full_import_name
 
-   Get the full path of a name from a ``from x import y`` statement.
-
-   :returns: The full import path of the name.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.get_full_import_name
+      :renderer: rst
 
 .. py:function:: get_assign_value(node: astroid.nodes.NodeNG) -> None | tuple[str, typing.Any]
    :canonical: autodoc2.astroid_utils.get_assign_value
 
-   Get the name and value of the assignment of the given node.
-
-   Assignments to multiple names are ignored, as per PEP 257.
-
-   :param node: The node to get the assignment value from.
-
-   :returns: The name that is assigned to,
-       and the value assigned to the name (if it can be converted).
+   .. autodoc2-docstring:: autodoc2.astroid_utils.get_assign_value
+      :renderer: rst
 
 .. py:function:: get_const_values(node: astroid.nodes.NodeNG) -> typing.Any
    :canonical: autodoc2.astroid_utils.get_const_values
 
-   Get the value of a constant node.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.get_const_values
+      :renderer: rst
 
 .. py:function:: get_assign_annotation(node: astroid.nodes.Assign) -> None | str
    :canonical: autodoc2.astroid_utils.get_assign_annotation
 
-   Get the type annotation of the assignment of the given node.
-
-   :returns: The type annotation as a string, or None if one does not exist.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.get_assign_annotation
+      :renderer: rst
 
 .. py:function:: resolve_annotation(annotation: astroid.nodes.NodeNG) -> str
    :canonical: autodoc2.astroid_utils.resolve_annotation
 
-   Resolve a type annotation to a string.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.resolve_annotation
+      :renderer: rst
 
 .. py:function:: resolve_qualname(node: astroid.nodes.NodeNG, basename: str) -> str
    :canonical: autodoc2.astroid_utils.resolve_qualname
 
-   Resolve where a node is defined to get its fully qualified name.
-
-   :param node: The node representing the base name.
-   :param basename: The partial base name to resolve.
-
-   :returns: The fully resolved base name.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.resolve_qualname
+      :renderer: rst
 
 .. py:function:: get_module_all(node: astroid.nodes.Module) -> None | list[str]
    :canonical: autodoc2.astroid_utils.get_module_all
 
-   Get the contents of the ``__all__`` variable from a module.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.get_module_all
+      :renderer: rst
 
 .. py:function:: is_decorated_with_singledispatch(node: astroid.nodes.FunctionDef | astroid.nodes.AsyncFunctionDef) -> bool
    :canonical: autodoc2.astroid_utils.is_decorated_with_singledispatch
 
-   Check if the function is decorated as a singledispatch.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_with_singledispatch
+      :renderer: rst
 
 .. py:function:: is_singledispatch_decorator(decorator: astroid.Name) -> bool
    :canonical: autodoc2.astroid_utils.is_singledispatch_decorator
 
-   Check if the decorator is a singledispatch.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_singledispatch_decorator
+      :renderer: rst
 
 .. py:function:: is_decorated_as_singledispatch_register(node: astroid.nodes.FunctionDef | astroid.nodes.AsyncFunctionDef) -> bool
    :canonical: autodoc2.astroid_utils.is_decorated_as_singledispatch_register
 
-   Check if the function is decorated as a singledispatch register.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_as_singledispatch_register
+      :renderer: rst
 
 .. py:function:: is_decorated_with_property(node: astroid.nodes.FunctionDef | astroid.nodes.AsyncFunctionDef) -> bool
    :canonical: autodoc2.astroid_utils.is_decorated_with_property
 
-   Check if the function is decorated as a property.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_with_property
+      :renderer: rst
 
 .. py:function:: is_property_decorator(decorator: astroid.Name) -> bool
    :canonical: autodoc2.astroid_utils.is_property_decorator
 
-   Check if the decorator is a property.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_property_decorator
+      :renderer: rst
 
 .. py:function:: is_decorated_with_property_setter(node: astroid.nodes.FunctionDef | astroid.nodes.AsyncFunctionDef) -> bool
    :canonical: autodoc2.astroid_utils.is_decorated_with_property_setter
 
-   Check if the function is decorated as a property setter.
-
-   :param node: The node to check.
-
-   :returns: True if the function is a property setter, False otherwise.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_with_property_setter
+      :renderer: rst
 
 .. py:function:: get_class_docstring(node: astroid.nodes.ClassDef) -> str
    :canonical: autodoc2.astroid_utils.get_class_docstring
 
-   Get the docstring of a node, using a parent docstring if needed.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.get_class_docstring
+      :renderer: rst
 
 .. py:function:: is_exception(node: astroid.nodes.ClassDef) -> bool
    :canonical: autodoc2.astroid_utils.is_exception
 
-   Check if a class is an exception.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_exception
+      :renderer: rst
 
 .. py:function:: is_decorated_with_overload(node: astroid.nodes.FunctionDef) -> bool
    :canonical: autodoc2.astroid_utils.is_decorated_with_overload
 
-   Check if the function is decorated as an overload definition.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_decorated_with_overload
+      :renderer: rst
 
 .. py:function:: is_overload_decorator(decorator: astroid.Name | astroid.Attribute) -> bool
    :canonical: autodoc2.astroid_utils.is_overload_decorator
 
+   .. autodoc2-docstring:: autodoc2.astroid_utils.is_overload_decorator
+      :renderer: rst
+
 .. py:function:: get_func_docstring(node: astroid.nodes.FunctionDef) -> str
    :canonical: autodoc2.astroid_utils.get_func_docstring
 
-   Get the docstring of a node, using a parent docstring if needed.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.get_func_docstring
+      :renderer: rst
 
 .. py:function:: get_return_annotation(node: astroid.nodes.FunctionDef) -> None | str
    :canonical: autodoc2.astroid_utils.get_return_annotation
 
-   Get the return annotation of a node.
+   .. autodoc2-docstring:: autodoc2.astroid_utils.get_return_annotation
+      :renderer: rst
 
 .. py:function:: get_args_info(args_node: astroid.Arguments) -> list[tuple[None | str, None | str, None | str, None | str]]
    :canonical: autodoc2.astroid_utils.get_args_info
 
-   Get the arguments of a function.
-
-   :returns: a list of (type, name, annotation, default)
+   .. autodoc2-docstring:: autodoc2.astroid_utils.get_args_info
+      :renderer: rst
 
 .. py:function:: _iter_args(args: list[astroid.nodes.NodeNG], annotations: list[astroid.nodes.NodeNG], defaults: list[astroid.nodes.NodeNG]) -> typing.Iterable[typing.Tuple[str, None | str, str | None]]
    :canonical: autodoc2.astroid_utils._iter_args
 
-   Iterate over arguments.
+   .. autodoc2-docstring:: autodoc2.astroid_utils._iter_args
+      :renderer: rst
 
 .. py:function:: _merge_annotations(annotations: typing.Iterable[typing.Any], comment_annotations: typing.Iterable[typing.Any]) -> typing.Iterable[typing.Any]
    :canonical: autodoc2.astroid_utils._merge_annotations
 
+   .. autodoc2-docstring:: autodoc2.astroid_utils._merge_annotations
+      :renderer: rst
+
 .. py:function:: _is_ellipsis(node: typing.Any) -> bool
    :canonical: autodoc2.astroid_utils._is_ellipsis
+
+   .. autodoc2-docstring:: autodoc2.astroid_utils._is_ellipsis
+      :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.cli.rst
+++ b/docs/apidocs/autodoc2/autodoc2.cli.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-CLI for the package.
+.. autodoc2-docstring:: autodoc2.cli
+   :renderer: rst
+   :allowtitles:
 
 Module Contents
 ---------------
@@ -20,17 +22,29 @@ Functions
    :align: left
 
    * - :py:obj:`version_callback <autodoc2.cli.version_callback>`
-     - Print the version and exit.
+     - .. autodoc2-docstring:: autodoc2.cli.version_callback
+          :renderer: rst
+          :summary:
    * - :py:obj:`main_app <autodoc2.cli.main_app>`
-     - [underline]CLI for sphinx-autodoc2[/underline]
+     - .. autodoc2-docstring:: autodoc2.cli.main_app
+          :renderer: rst
+          :summary:
    * - :py:obj:`list_items <autodoc2.cli.list_items>`
-     - Analyse a python module or package and stream the results to the console.
+     - .. autodoc2-docstring:: autodoc2.cli.list_items
+          :renderer: rst
+          :summary:
    * - :py:obj:`create_db <autodoc2.cli.create_db>`
-     - Create a database for a python module or package.
+     - .. autodoc2-docstring:: autodoc2.cli.create_db
+          :renderer: rst
+          :summary:
    * - :py:obj:`analyse_all <autodoc2.cli.analyse_all>`
-     - Analyse the __all__ of a module and find potential matches
+     - .. autodoc2-docstring:: autodoc2.cli.analyse_all
+          :renderer: rst
+          :summary:
    * - :py:obj:`write <autodoc2.cli.write>`
-     - Create sphinx files for a python module or package.
+     - .. autodoc2-docstring:: autodoc2.cli.write
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -40,9 +54,13 @@ Data
    :align: left
 
    * - :py:obj:`console <autodoc2.cli.console>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.cli.console
+          :renderer: rst
+          :summary:
    * - :py:obj:`app_main <autodoc2.cli.app_main>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.cli.app_main
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -51,36 +69,48 @@ API
    :canonical: autodoc2.cli.console
    :value: None
 
+   .. autodoc2-docstring:: autodoc2.cli.console
+      :renderer: rst
+
 .. py:data:: app_main
    :canonical: autodoc2.cli.app_main
    :value: None
 
+   .. autodoc2-docstring:: autodoc2.cli.app_main
+      :renderer: rst
+
 .. py:function:: version_callback(value: bool) -> None
    :canonical: autodoc2.cli.version_callback
 
-   Print the version and exit.
+   .. autodoc2-docstring:: autodoc2.cli.version_callback
+      :renderer: rst
 
 .. py:function:: main_app(version: typing.Optional[bool] = typer.Option(None, '-v', '--version', callback=version_callback, is_eager=True, help='Show the application version and exit.')) -> None
    :canonical: autodoc2.cli.main_app
 
-   [underline]CLI for sphinx-autodoc2[/underline]
+   .. autodoc2-docstring:: autodoc2.cli.main_app
+      :renderer: rst
 
 .. py:function:: list_items(path: pathlib.Path = typer.Argument(..., exists=True, help='Path to analyse'), module: typing.Optional[str] = typer.Option(None, '-m', '--module', help='The name of the module, otherwise it will be guessed from the path'), inherited: bool = typer.Option(False, '-i', '--inherited', help='Show inherited members'), private: bool = typer.Option(False, '-p', '--private', help='Show private members'), one_line: bool = typer.Option(False, '-o', '--one-line', help='Show only full name and type'), filter_types_str: typing.Optional[str] = typer.Option(None, '-ft', '--filter-types', help='Only show members of types (comma separated)'), skip_types_str: str = typer.Option('import_from', '-st', '--skip-types', help='Do not show members of types (comma separated)'), filter_name: typing.Optional[str] = typer.Option(None, '-fn', '--filter-name', help='Only show members with this name regex')) -> None
    :canonical: autodoc2.cli.list_items
 
-   Analyse a python module or package and stream the results to the console.
+   .. autodoc2-docstring:: autodoc2.cli.list_items
+      :renderer: rst
 
 .. py:function:: create_db(path: pathlib.Path = typer.Argument(..., exists=True, help='Path to analyse'), output: pathlib.Path = typer.Argument('autodoc.db.json', help='File to write to'), module: typing.Optional[str] = typer.Option(None, '-m', '--module', help='The name of the module, otherwise it will be guessed from the path')) -> None
    :canonical: autodoc2.cli.create_db
 
-   Create a database for a python module or package.
+   .. autodoc2-docstring:: autodoc2.cli.create_db
+      :renderer: rst
 
 .. py:function:: analyse_all(path: pathlib.Path = typer.Argument(..., exists=True, help='Path to a database file'), package: str = typer.Argument(..., help='The name of the package to resolve.')) -> None
    :canonical: autodoc2.cli.analyse_all
 
-   Analyse the __all__ of a module and find potential matches
+   .. autodoc2-docstring:: autodoc2.cli.analyse_all
+      :renderer: rst
 
 .. py:function:: write(path: pathlib.Path = typer.Argument(..., exists=True, help='Path to analyse'), module: typing.Optional[str] = typer.Option(None, '-m', '--module', help='The name of the module, otherwise it will be guessed from the path'), output: pathlib.Path = typer.Option('_autodoc', help='Folder to write to'), clean: bool = typer.Option(False, '-c', '--clean', help='Remove old files')) -> None
    :canonical: autodoc2.cli.write
 
-   Create sphinx files for a python module or package.
+   .. autodoc2-docstring:: autodoc2.cli.write
+      :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.config.rst
+++ b/docs/apidocs/autodoc2/autodoc2.config.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-The configuration for the extension.
+.. autodoc2-docstring:: autodoc2.config
+   :renderer: rst
+   :allowtitles:
 
 Module Contents
 ---------------
@@ -20,11 +22,17 @@ Classes
    :align: left
 
    * - :py:obj:`RenderConfig <autodoc2.config.RenderConfig>`
-     - The configuration for rendering.
+     - .. autodoc2-docstring:: autodoc2.config.RenderConfig
+          :renderer: rst
+          :summary:
    * - :py:obj:`PackageConfig <autodoc2.config.PackageConfig>`
-     - A package-level config item.
+     - .. autodoc2-docstring:: autodoc2.config.PackageConfig
+          :renderer: rst
+          :summary:
    * - :py:obj:`Config <autodoc2.config.Config>`
-     - The configuration for autoapi.
+     - .. autodoc2-docstring:: autodoc2.config.Config
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -34,19 +42,33 @@ Functions
    :align: left
 
    * - :py:obj:`_coerce_packages <autodoc2.config._coerce_packages>`
-     - Coerce the packages config option to a set.
+     - .. autodoc2-docstring:: autodoc2.config._coerce_packages
+          :renderer: rst
+          :summary:
    * - :py:obj:`_validate_string_list <autodoc2.config._validate_string_list>`
-     - Validate that an item is a string.
+     - .. autodoc2-docstring:: autodoc2.config._validate_string_list
+          :renderer: rst
+          :summary:
    * - :py:obj:`_validate_replace_list <autodoc2.config._validate_replace_list>`
-     - Validate that an item is a list of tuples.
+     - .. autodoc2-docstring:: autodoc2.config._validate_replace_list
+          :renderer: rst
+          :summary:
    * - :py:obj:`_validate_hidden_objects <autodoc2.config._validate_hidden_objects>`
-     - Validate that the hidden objects config option is a set.
+     - .. autodoc2-docstring:: autodoc2.config._validate_hidden_objects
+          :renderer: rst
+          :summary:
    * - :py:obj:`_validate_regex_list <autodoc2.config._validate_regex_list>`
-     - Validate that an item is a list of regexes.
+     - .. autodoc2-docstring:: autodoc2.config._validate_regex_list
+          :renderer: rst
+          :summary:
    * - :py:obj:`_load_renderer <autodoc2.config._load_renderer>`
-     - Load a renderer class.
+     - .. autodoc2-docstring:: autodoc2.config._load_renderer
+          :renderer: rst
+          :summary:
    * - :py:obj:`_load_regex_renderers <autodoc2.config._load_regex_renderers>`
-     - Load a list of (regex, renderer).
+     - .. autodoc2-docstring:: autodoc2.config._load_regex_renderers
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -56,7 +78,9 @@ Data
    :align: left
 
    * - :py:obj:`CONFIG_PREFIX <autodoc2.config.CONFIG_PREFIX>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.config.CONFIG_PREFIX
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -66,309 +90,479 @@ API
 
    Bases: :py:obj:`Exception`
 
-   An error validating a config value.
+   .. autodoc2-docstring:: autodoc2.config.ValidationError
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: autodoc2.config.ValidationError.__init__
+      :renderer: rst
 
 .. py:data:: CONFIG_PREFIX
    :canonical: autodoc2.config.CONFIG_PREFIX
    :value: 'autodoc2_'
 
+   .. autodoc2-docstring:: autodoc2.config.CONFIG_PREFIX
+      :renderer: rst
+
 .. py:class:: RenderConfig
    :canonical: autodoc2.config.RenderConfig
 
-   The configuration for rendering.
-
-   This uses the global, with package level overrides.
+   .. autodoc2-docstring:: autodoc2.config.RenderConfig
+      :renderer: rst
 
    .. py:attribute:: module_all_regexes
       :canonical: autodoc2.config.RenderConfig.module_all_regexes
       :type: list[typing.Pattern[str]]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.module_all_regexes
+         :renderer: rst
+
    .. py:attribute:: skip_module_regexes
       :canonical: autodoc2.config.RenderConfig.skip_module_regexes
       :type: list[typing.Pattern[str]]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.skip_module_regexes
+         :renderer: rst
 
    .. py:attribute:: hidden_objects
       :canonical: autodoc2.config.RenderConfig.hidden_objects
       :type: set[typing.Literal[undoc, dunder, private, inherited]]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.hidden_objects
+         :renderer: rst
+
    .. py:attribute:: hidden_regexes
       :canonical: autodoc2.config.RenderConfig.hidden_regexes
       :type: list[typing.Pattern[str]]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.hidden_regexes
+         :renderer: rst
 
    .. py:attribute:: deprecated_module_regexes
       :canonical: autodoc2.config.RenderConfig.deprecated_module_regexes
       :type: list[typing.Pattern[str]]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.deprecated_module_regexes
+         :renderer: rst
+
+   .. py:attribute:: no_index
+      :canonical: autodoc2.config.RenderConfig.no_index
+      :type: bool
+      :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.no_index
+         :renderer: rst
+
    .. py:attribute:: module_summary
       :canonical: autodoc2.config.RenderConfig.module_summary
       :type: bool
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.module_summary
+         :renderer: rst
 
    .. py:attribute:: class_docstring
       :canonical: autodoc2.config.RenderConfig.class_docstring
       :type: typing.Literal[merge, both]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.class_docstring
+         :renderer: rst
+
    .. py:attribute:: class_inheritance
       :canonical: autodoc2.config.RenderConfig.class_inheritance
       :type: bool
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.class_inheritance
+         :renderer: rst
 
    .. py:attribute:: annotations
       :canonical: autodoc2.config.RenderConfig.annotations
       :type: bool
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.annotations
+         :renderer: rst
+
    .. py:attribute:: sort_names
       :canonical: autodoc2.config.RenderConfig.sort_names
       :type: bool
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.sort_names
+         :renderer: rst
 
    .. py:attribute:: replace_annotations
       :canonical: autodoc2.config.RenderConfig.replace_annotations
       :type: list[tuple[str, str]]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.replace_annotations
+         :renderer: rst
+
    .. py:attribute:: replace_bases
       :canonical: autodoc2.config.RenderConfig.replace_bases
       :type: list[tuple[str, str]]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.RenderConfig.replace_bases
+         :renderer: rst
+
 .. py:class:: PackageConfig
    :canonical: autodoc2.config.PackageConfig
 
-   A package-level config item.
+   .. autodoc2-docstring:: autodoc2.config.PackageConfig
+      :renderer: rst
 
    .. py:attribute:: path
       :canonical: autodoc2.config.PackageConfig.path
       :type: str
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.path
+         :renderer: rst
+
    .. py:attribute:: from_git_clone
       :canonical: autodoc2.config.PackageConfig.from_git_clone
       :type: tuple[str, str] | None
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.from_git_clone
+         :renderer: rst
 
    .. py:attribute:: module
       :canonical: autodoc2.config.PackageConfig.module
       :type: str | None
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.module
+         :renderer: rst
+
    .. py:attribute:: exclude_dirs
       :canonical: autodoc2.config.PackageConfig.exclude_dirs
       :type: list[str] | None
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.exclude_dirs
+         :renderer: rst
 
    .. py:attribute:: exclude_files
       :canonical: autodoc2.config.PackageConfig.exclude_files
       :type: list[str] | None
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.exclude_files
+         :renderer: rst
+
    .. py:attribute:: module_all_regexes
       :canonical: autodoc2.config.PackageConfig.module_all_regexes
       :type: list[typing.Pattern[str]] | None
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.module_all_regexes
+         :renderer: rst
 
    .. py:attribute:: skip_module_regexes
       :canonical: autodoc2.config.PackageConfig.skip_module_regexes
       :type: list[typing.Pattern[str]] | None
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.skip_module_regexes
+         :renderer: rst
+
    .. py:attribute:: hidden_objects
       :canonical: autodoc2.config.PackageConfig.hidden_objects
       :type: set[typing.Literal[undoc, dunder, private, inherited]] | None
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.hidden_objects
+         :renderer: rst
 
    .. py:attribute:: hidden_regexes
       :canonical: autodoc2.config.PackageConfig.hidden_regexes
       :type: list[typing.Pattern[str]] | None
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.hidden_regexes
+         :renderer: rst
+
    .. py:attribute:: deprecated_module_regexes
       :canonical: autodoc2.config.PackageConfig.deprecated_module_regexes
       :type: list[typing.Pattern[str]] | None
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.deprecated_module_regexes
+         :renderer: rst
 
    .. py:attribute:: module_summary
       :canonical: autodoc2.config.PackageConfig.module_summary
       :type: bool | None
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.module_summary
+         :renderer: rst
+
    .. py:attribute:: class_inheritance
       :canonical: autodoc2.config.PackageConfig.class_inheritance
       :type: bool | None
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.class_inheritance
+         :renderer: rst
 
    .. py:attribute:: class_docstring
       :canonical: autodoc2.config.PackageConfig.class_docstring
       :type: typing.Literal[merge, both] | None
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.class_docstring
+         :renderer: rst
+
    .. py:attribute:: annotations
       :canonical: autodoc2.config.PackageConfig.annotations
       :type: bool | None
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.annotations
+         :renderer: rst
 
    .. py:attribute:: sort_names
       :canonical: autodoc2.config.PackageConfig.sort_names
       :type: bool | None
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.sort_names
+         :renderer: rst
+
    .. py:method:: as_triple() -> typing.Iterable[tuple[str, typing.Any, dataclasses.Field]]
       :canonical: autodoc2.config.PackageConfig.as_triple
 
-      Yield triples of (name, value, field).
+      .. autodoc2-docstring:: autodoc2.config.PackageConfig.as_triple
+         :renderer: rst
 
 .. py:function:: _coerce_packages(name: str, item: typing.Any) -> list[autodoc2.config.PackageConfig]
    :canonical: autodoc2.config._coerce_packages
 
-   Coerce the packages config option to a set.
+   .. autodoc2-docstring:: autodoc2.config._coerce_packages
+      :renderer: rst
 
 .. py:function:: _validate_string_list(name: str, item: typing.Any) -> list[str]
    :canonical: autodoc2.config._validate_string_list
 
-   Validate that an item is a string.
+   .. autodoc2-docstring:: autodoc2.config._validate_string_list
+      :renderer: rst
 
 .. py:function:: _validate_replace_list(name: str, item: typing.Any) -> list[typing.Tuple[str, str]]
    :canonical: autodoc2.config._validate_replace_list
 
-   Validate that an item is a list of tuples.
+   .. autodoc2-docstring:: autodoc2.config._validate_replace_list
+      :renderer: rst
 
 .. py:function:: _validate_hidden_objects(name: str, item: typing.Any) -> set[str]
    :canonical: autodoc2.config._validate_hidden_objects
 
-   Validate that the hidden objects config option is a set.
+   .. autodoc2-docstring:: autodoc2.config._validate_hidden_objects
+      :renderer: rst
 
 .. py:function:: _validate_regex_list(name: str, item: typing.Any) -> list[typing.Pattern[str]]
    :canonical: autodoc2.config._validate_regex_list
 
-   Validate that an item is a list of regexes.
+   .. autodoc2-docstring:: autodoc2.config._validate_regex_list
+      :renderer: rst
 
 .. py:function:: _load_renderer(name: str, item: typing.Any) -> type[autodoc2.render.base.RendererBase]
    :canonical: autodoc2.config._load_renderer
 
-   Load a renderer class.
+   .. autodoc2-docstring:: autodoc2.config._load_renderer
+      :renderer: rst
 
 .. py:function:: _load_regex_renderers(name: str, item: typing.Any) -> list[tuple[typing.Pattern[str], type[autodoc2.render.base.RendererBase]]]
    :canonical: autodoc2.config._load_regex_renderers
 
-   Load a list of (regex, renderer).
+   .. autodoc2-docstring:: autodoc2.config._load_regex_renderers
+      :renderer: rst
 
 .. py:class:: Config
    :canonical: autodoc2.config.Config
 
-   The configuration for autoapi.
+   .. autodoc2-docstring:: autodoc2.config.Config
+      :renderer: rst
 
    .. py:attribute:: packages
       :canonical: autodoc2.config.Config.packages
       :type: list[autodoc2.config.PackageConfig]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.packages
+         :renderer: rst
+
    .. py:attribute:: output_dir
       :canonical: autodoc2.config.Config.output_dir
       :type: str
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.output_dir
+         :renderer: rst
 
    .. py:attribute:: exclude_dirs
       :canonical: autodoc2.config.Config.exclude_dirs
       :type: list[str]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.exclude_dirs
+         :renderer: rst
+
    .. py:attribute:: exclude_files
       :canonical: autodoc2.config.Config.exclude_files
       :type: list[str]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.exclude_files
+         :renderer: rst
 
    .. py:attribute:: render_plugin
       :canonical: autodoc2.config.Config.render_plugin
       :type: type[autodoc2.render.base.RendererBase]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.render_plugin
+         :renderer: rst
+
    .. py:attribute:: render_plugin_regexes
       :canonical: autodoc2.config.Config.render_plugin_regexes
       :type: list[tuple[typing.Pattern[str], type[autodoc2.render.base.RendererBase]]]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.render_plugin_regexes
+         :renderer: rst
 
    .. py:attribute:: module_all_regexes
       :canonical: autodoc2.config.Config.module_all_regexes
       :type: list[typing.Pattern[str]]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.module_all_regexes
+         :renderer: rst
+
    .. py:attribute:: skip_module_regexes
       :canonical: autodoc2.config.Config.skip_module_regexes
       :type: list[typing.Pattern[str]]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.skip_module_regexes
+         :renderer: rst
 
    .. py:attribute:: hidden_objects
       :canonical: autodoc2.config.Config.hidden_objects
       :type: set[typing.Literal[undoc, dunder, private, inherited]]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.hidden_objects
+         :renderer: rst
+
    .. py:attribute:: hidden_regexes
       :canonical: autodoc2.config.Config.hidden_regexes
       :type: list[typing.Pattern[str]]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.hidden_regexes
+         :renderer: rst
+
+   .. py:attribute:: no_index
+      :canonical: autodoc2.config.Config.no_index
+      :type: bool
+      :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.no_index
+         :renderer: rst
 
    .. py:attribute:: deprecated_module_regexes
       :canonical: autodoc2.config.Config.deprecated_module_regexes
       :type: list[typing.Pattern[str]]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.deprecated_module_regexes
+         :renderer: rst
+
    .. py:attribute:: module_summary
       :canonical: autodoc2.config.Config.module_summary
       :type: bool
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.module_summary
+         :renderer: rst
 
    .. py:attribute:: class_docstring
       :canonical: autodoc2.config.Config.class_docstring
       :type: typing.Literal[merge, both]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.class_docstring
+         :renderer: rst
+
    .. py:attribute:: class_inheritance
       :canonical: autodoc2.config.Config.class_inheritance
       :type: bool
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.class_inheritance
+         :renderer: rst
 
    .. py:attribute:: annotations
       :canonical: autodoc2.config.Config.annotations
       :type: bool
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.annotations
+         :renderer: rst
+
    .. py:attribute:: sort_names
       :canonical: autodoc2.config.Config.sort_names
       :type: bool
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.sort_names
+         :renderer: rst
 
    .. py:attribute:: replace_annotations
       :canonical: autodoc2.config.Config.replace_annotations
       :type: list[tuple[str, str]]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.replace_annotations
+         :renderer: rst
+
    .. py:attribute:: replace_bases
       :canonical: autodoc2.config.Config.replace_bases
       :type: list[tuple[str, str]]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.config.Config.replace_bases
+         :renderer: rst
 
    .. py:attribute:: index_template
       :canonical: autodoc2.config.Config.index_template
       :type: str | None
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.config.Config.index_template
+         :renderer: rst
+
    .. py:method:: as_triple() -> typing.Iterable[tuple[str, typing.Any, dataclasses.Field]]
       :canonical: autodoc2.config.Config.as_triple
 
-      Yield triples of (name, value, field).
+      .. autodoc2-docstring:: autodoc2.config.Config.as_triple
+         :renderer: rst
 
    .. py:method:: to_render_config(pkg_index: int | None) -> autodoc2.config.RenderConfig
       :canonical: autodoc2.config.Config.to_render_config
 
-      Convert a module level render config.
+      .. autodoc2-docstring:: autodoc2.config.Config.to_render_config
+         :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.db.md
+++ b/docs/apidocs/autodoc2/autodoc2.db.md
@@ -5,31 +5,43 @@
 
 ## Description
 
-A database interface for storing and querying the analysis items.
+```{autodoc2-docstring} autodoc2.db
+:renderer: myst
+   :allowtitles:
+```
 
 ## Module Contents
 
 ### Classes
 
-```{list-table}
+````{list-table}
 :class: autosummary longtable
 :align: left
 
 * - {py:obj}`Database <autodoc2.db.Database>`
-  - A simple interface for storing and querying the analysis items, from a single package.
+  - ```{autodoc2-docstring} autodoc2.db.Database
+    :renderer: myst
+    :summary:
+    ```
 * - {py:obj}`InMemoryDb <autodoc2.db.InMemoryDb>`
-  - A simple in-memory database for storing and querying the analysis items.
-```
+  - ```{autodoc2-docstring} autodoc2.db.InMemoryDb
+    :renderer: myst
+    :summary:
+    ```
+````
 
 ### Data
 
-```{list-table}
+````{list-table}
 :class: autosummary longtable
 :align: left
 
 * - {py:obj}`_LIKE_REGEX <autodoc2.db._LIKE_REGEX>`
-  - 
-```
+  - ```{autodoc2-docstring} autodoc2.db._LIKE_REGEX
+    :renderer: myst
+    :summary:
+    ```
+````
 
 ### API
 
@@ -38,205 +50,236 @@ A database interface for storing and querying the analysis items.
 
 Bases: {py:obj}`KeyError`
 
-An error raised when a unique constraint is violated.
+```{autodoc2-docstring} autodoc2.db.UniqueError
+:renderer: myst
+```
 
 ```{rubric} Initialization
 ```
 
-Initialize self.  See help(type(self)) for accurate signature.
+```{autodoc2-docstring} autodoc2.db.UniqueError
+:renderer: myst
+```
 
 ````
 
-````{py:class} Database
+`````{py:class} Database
 :canonical: autodoc2.db.Database
 
 Bases: {py:obj}`typing.Protocol`
 
-A simple interface for storing and querying the analysis items, from a single package.
+```{autodoc2-docstring} autodoc2.db.Database
+:renderer: myst
+```
 
-This allows for potential extensibility in the future,
-e.g. using a persistent sqlite database.
-
-```{py:method} add(item: autodoc2.utils.ItemData) -> None
+````{py:method} add(item: autodoc2.utils.ItemData) -> None
 :canonical: autodoc2.db.Database.add
 
-Add an item to the database.
-
-```
-
-```{py:method} __contains__(full_name: str) -> bool
-:canonical: autodoc2.db.Database.__contains__
-
-Check if an item is in the database, by full_name.
-
-```
-
-```{py:method} get_item(full_name: str) -> typing.Optional[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.Database.get_item
-
-Get an item from the database, by full_name.
-
-```
-
-```{py:method} get_items_like(full_name: str) -> typing.Iterable[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.Database.get_items_like
-
-Get an item from the database, matching the wildcards `*` and `?`.
-
-`*` matches any number of characters, and `?` matches any single character.
-
-```
-
-```{py:method} get_type(full_name: str) -> None | str
-:canonical: autodoc2.db.Database.get_type
-
-Get the type of an item from the database, by full_name.
-
-```
-
-```{py:method} get_by_type(type_: str) -> typing.Iterable[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.Database.get_by_type
-
-Get all items from the database, by type.
-
-```
-
-```{py:method} get_overloads(full_name: str) -> typing.Iterable[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.Database.get_overloads
-
-Get all function overloads for this name.
-
-```
-
-```{py:method} get_children(full_name: str, types: None | set[str] = None, *, sort_name: bool = False) -> typing.Iterable[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.Database.get_children
-
-Get all items that are direct children of this name, i.e. `{full_name}.{name}`.
-
-:param full_name: The full name of the item.
-:param types: If given, only return items of these types.
-:param sort_name: If True, sort the names alphabetically.
-
-```
-
-```{py:method} get_children_names(full_name: str, types: None | set[str] = None, *, sort_name: bool = False) -> typing.Iterable[str]
-:canonical: autodoc2.db.Database.get_children_names
-
-Get all names of direct children of this name, i.e. `{full_name}.{name}`.
-
-:param full_name: The full name of the item.
-:param types: If given, only return items of these types.
-:param sort_name: If True, sort the names alphabetically.
-
+```{autodoc2-docstring} autodoc2.db.Database.add
+:renderer: myst
 ```
 
 ````
 
-```{py:data} _LIKE_REGEX
+````{py:method} __contains__(full_name: str) -> bool
+:canonical: autodoc2.db.Database.__contains__
+
+```{autodoc2-docstring} autodoc2.db.Database.__contains__
+:renderer: myst
+```
+
+````
+
+````{py:method} get_item(full_name: str) -> typing.Optional[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.Database.get_item
+
+```{autodoc2-docstring} autodoc2.db.Database.get_item
+:renderer: myst
+```
+
+````
+
+````{py:method} get_items_like(full_name: str) -> typing.Iterable[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.Database.get_items_like
+
+```{autodoc2-docstring} autodoc2.db.Database.get_items_like
+:renderer: myst
+```
+
+````
+
+````{py:method} get_type(full_name: str) -> None | str
+:canonical: autodoc2.db.Database.get_type
+
+```{autodoc2-docstring} autodoc2.db.Database.get_type
+:renderer: myst
+```
+
+````
+
+````{py:method} get_by_type(type_: str) -> typing.Iterable[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.Database.get_by_type
+
+```{autodoc2-docstring} autodoc2.db.Database.get_by_type
+:renderer: myst
+```
+
+````
+
+````{py:method} get_overloads(full_name: str) -> typing.Iterable[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.Database.get_overloads
+
+```{autodoc2-docstring} autodoc2.db.Database.get_overloads
+:renderer: myst
+```
+
+````
+
+````{py:method} get_children(full_name: str, types: None | set[str] = None, *, sort_name: bool = False) -> typing.Iterable[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.Database.get_children
+
+```{autodoc2-docstring} autodoc2.db.Database.get_children
+:renderer: myst
+```
+
+````
+
+````{py:method} get_children_names(full_name: str, types: None | set[str] = None, *, sort_name: bool = False) -> typing.Iterable[str]
+:canonical: autodoc2.db.Database.get_children_names
+
+```{autodoc2-docstring} autodoc2.db.Database.get_children_names
+:renderer: myst
+```
+
+````
+
+`````
+
+````{py:data} _LIKE_REGEX
 :canonical: autodoc2.db._LIKE_REGEX
 :value: >
    None
 
+```{autodoc2-docstring} autodoc2.db._LIKE_REGEX
+:renderer: myst
 ```
 
-````{py:class} InMemoryDb()
+````
+
+`````{py:class} InMemoryDb()
 :canonical: autodoc2.db.InMemoryDb
 
 Bases: {py:obj}`autodoc2.db.Database`
 
-A simple in-memory database for storing and querying the analysis items.
+```{autodoc2-docstring} autodoc2.db.InMemoryDb
+:renderer: myst
+```
 
 ```{rubric} Initialization
 ```
 
-Create the database.
+```{autodoc2-docstring} autodoc2.db.InMemoryDb
+:renderer: myst
+```
 
-```{py:method} add(item: autodoc2.utils.ItemData) -> None
+````{py:method} add(item: autodoc2.utils.ItemData) -> None
 :canonical: autodoc2.db.InMemoryDb.add
 
-Add an item to the database.
-
-```
-
-```{py:method} __contains__(full_name: str) -> bool
-:canonical: autodoc2.db.InMemoryDb.__contains__
-
-Check if an item is in the database, by full_name.
-
-```
-
-```{py:method} get_item(full_name: str) -> typing.Optional[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.InMemoryDb.get_item
-
-Get an item from the database, by full_name.
-
-```
-
-```{py:method} get_items_like(full_name: str) -> typing.Iterable[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.InMemoryDb.get_items_like
-
-Get an item from the database, matching the wildcards `*` and `?`.
-
-`*` matches any number of characters, and `?` matches any single character.
-
-```
-
-```{py:method} get_type(full_name: str) -> None | str
-:canonical: autodoc2.db.InMemoryDb.get_type
-
-Get the type of an item from the database, by full_name.
-
-```
-
-```{py:method} get_by_type(type_: str) -> typing.Iterable[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.InMemoryDb.get_by_type
-
-Get all items from the database, by type.
-
-```
-
-```{py:method} get_overloads(full_name: str) -> typing.Iterable[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.InMemoryDb.get_overloads
-
-Get all function overloads for this name.
-
-```
-
-```{py:method} get_children(full_name: str, types: None | set[str] = None, *, sort_name: bool = False) -> typing.Iterable[autodoc2.utils.ItemData]
-:canonical: autodoc2.db.InMemoryDb.get_children
-
-Get all items that are direct children of this name, i.e. `{full_name}.{name}`.
-
-:param full_name: The full name of the item.
-:param types: If given, only return items of these types.
-:param sort_name: If True, sort the names alphabetically.
-
-```
-
-```{py:method} get_children_names(full_name: str, types: None | set[str] = None, *, sort_name: bool = False) -> typing.Iterable[str]
-:canonical: autodoc2.db.InMemoryDb.get_children_names
-
-Get all names of direct children of this name, i.e. `{full_name}.{name}`.
-
-:param full_name: The full name of the item.
-:param types: If given, only return items of these types.
-:param sort_name: If True, sort the names alphabetically.
-
-```
-
-```{py:method} write(stream: typing.TextIO) -> None
-:canonical: autodoc2.db.InMemoryDb.write
-
-Write the database to a file.
-
-```
-
-```{py:method} read(stream: typing.TextIO) -> autodoc2.db.InMemoryDb
-:canonical: autodoc2.db.InMemoryDb.read
-:classmethod:
-
-Read the database from a file.
-
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.add
+:renderer: myst
 ```
 
 ````
+
+````{py:method} __contains__(full_name: str) -> bool
+:canonical: autodoc2.db.InMemoryDb.__contains__
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.__contains__
+:renderer: myst
+```
+
+````
+
+````{py:method} get_item(full_name: str) -> typing.Optional[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.InMemoryDb.get_item
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.get_item
+:renderer: myst
+```
+
+````
+
+````{py:method} get_items_like(full_name: str) -> typing.Iterable[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.InMemoryDb.get_items_like
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.get_items_like
+:renderer: myst
+```
+
+````
+
+````{py:method} get_type(full_name: str) -> None | str
+:canonical: autodoc2.db.InMemoryDb.get_type
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.get_type
+:renderer: myst
+```
+
+````
+
+````{py:method} get_by_type(type_: str) -> typing.Iterable[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.InMemoryDb.get_by_type
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.get_by_type
+:renderer: myst
+```
+
+````
+
+````{py:method} get_overloads(full_name: str) -> typing.Iterable[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.InMemoryDb.get_overloads
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.get_overloads
+:renderer: myst
+```
+
+````
+
+````{py:method} get_children(full_name: str, types: None | set[str] = None, *, sort_name: bool = False) -> typing.Iterable[autodoc2.utils.ItemData]
+:canonical: autodoc2.db.InMemoryDb.get_children
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.get_children
+:renderer: myst
+```
+
+````
+
+````{py:method} get_children_names(full_name: str, types: None | set[str] = None, *, sort_name: bool = False) -> typing.Iterable[str]
+:canonical: autodoc2.db.InMemoryDb.get_children_names
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.get_children_names
+:renderer: myst
+```
+
+````
+
+````{py:method} write(stream: typing.TextIO) -> None
+:canonical: autodoc2.db.InMemoryDb.write
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.write
+:renderer: myst
+```
+
+````
+
+````{py:method} read(stream: typing.TextIO) -> autodoc2.db.InMemoryDb
+:canonical: autodoc2.db.InMemoryDb.read
+:classmethod:
+
+```{autodoc2-docstring} autodoc2.db.InMemoryDb.read
+:renderer: myst
+```
+
+````
+
+`````

--- a/docs/apidocs/autodoc2/autodoc2.extension.rst
+++ b/docs/apidocs/autodoc2/autodoc2.extension.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-The sphinx extension for the package.
+.. autodoc2-docstring:: autodoc2.extension
+   :renderer: rst
+   :allowtitles:
 
 Module Contents
 ---------------
@@ -20,7 +22,13 @@ Classes
    :align: left
 
    * - :py:obj:`EnvCache <autodoc2.extension.EnvCache>`
-     - Cache for the environment.
+     - .. autodoc2-docstring:: autodoc2.extension.EnvCache
+          :renderer: rst
+          :summary:
+   * - :py:obj:`DocstringRenderer <autodoc2.extension.DocstringRenderer>`
+     - .. autodoc2-docstring:: autodoc2.extension.DocstringRenderer
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -30,15 +38,25 @@ Functions
    :align: left
 
    * - :py:obj:`warn <autodoc2.extension.warn>`
-     - Log a warning.
+     - .. autodoc2-docstring:: autodoc2.extension.warn
+          :renderer: rst
+          :summary:
    * - :py:obj:`setup <autodoc2.extension.setup>`
-     - Entry point for sphinx.
+     - .. autodoc2-docstring:: autodoc2.extension.setup
+          :renderer: rst
+          :summary:
    * - :py:obj:`run_autodoc <autodoc2.extension.run_autodoc>`
-     - The primary sphinx call back event for sphinx.
+     - .. autodoc2-docstring:: autodoc2.extension.run_autodoc
+          :renderer: rst
+          :summary:
    * - :py:obj:`run_autodoc_package <autodoc2.extension.run_autodoc_package>`
-     - Run autodoc for a single package.
+     - .. autodoc2-docstring:: autodoc2.extension.run_autodoc_package
+          :renderer: rst
+          :summary:
    * - :py:obj:`get_git_clone <autodoc2.extension.get_git_clone>`
-     - Download a git repository to the given folder.
+     - .. autodoc2-docstring:: autodoc2.extension.get_git_clone
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -48,7 +66,9 @@ Data
    :align: left
 
    * - :py:obj:`LOGGER <autodoc2.extension.LOGGER>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.extension.LOGGER
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -57,50 +77,118 @@ API
    :canonical: autodoc2.extension.LOGGER
    :value: None
 
+   .. autodoc2-docstring:: autodoc2.extension.LOGGER
+      :renderer: rst
+
 .. py:function:: warn(msg: str, subtype: autodoc2.utils.WarningSubtypes) -> None
    :canonical: autodoc2.extension.warn
 
-   Log a warning.
+   .. autodoc2-docstring:: autodoc2.extension.warn
+      :renderer: rst
 
 .. py:function:: setup(app: sphinx.application.Sphinx) -> dict[str, str | bool]
    :canonical: autodoc2.extension.setup
 
-   Entry point for sphinx.
+   .. autodoc2-docstring:: autodoc2.extension.setup
+      :renderer: rst
 
 .. py:function:: run_autodoc(app: sphinx.application.Sphinx) -> None
    :canonical: autodoc2.extension.run_autodoc
 
-   The primary sphinx call back event for sphinx.
+   .. autodoc2-docstring:: autodoc2.extension.run_autodoc
+      :renderer: rst
 
 .. py:function:: run_autodoc_package(app: sphinx.application.Sphinx, config: autodoc2.config.Config, pkg_index: int) -> str | None
    :canonical: autodoc2.extension.run_autodoc_package
 
-   Run autodoc for a single package.
-
-   :return: The top level module name, relative to the api directory.
+   .. autodoc2-docstring:: autodoc2.extension.run_autodoc_package
+      :renderer: rst
 
 .. py:function:: get_git_clone(app: sphinx.application.Sphinx, url: str, branch_tag: str, config: autodoc2.config.Config) -> None | pathlib.Path
    :canonical: autodoc2.extension.get_git_clone
 
-   Download a git repository to the given folder.
+   .. autodoc2-docstring:: autodoc2.extension.get_git_clone
+      :renderer: rst
 
 .. py:class:: EnvCache()
    :canonical: autodoc2.extension.EnvCache
 
    Bases: :py:obj:`typing.TypedDict`
 
-   Cache for the environment.
+   .. autodoc2-docstring:: autodoc2.extension.EnvCache
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: autodoc2.extension.EnvCache.__init__
+      :renderer: rst
 
    .. py:attribute:: hash
       :canonical: autodoc2.extension.EnvCache.hash
       :type: str
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.extension.EnvCache.hash
+         :renderer: rst
+
    .. py:attribute:: db
       :canonical: autodoc2.extension.EnvCache.db
       :type: autodoc2.db.InMemoryDb
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.extension.EnvCache.db
+         :renderer: rst
+
+.. py:class:: DocstringRenderer(name, arguments, options, content, lineno, content_offset, block_text, state, state_machine)
+   :canonical: autodoc2.extension.DocstringRenderer
+
+   Bases: :py:obj:`sphinx.util.docutils.SphinxDirective`
+
+   .. autodoc2-docstring:: autodoc2.extension.DocstringRenderer
+      :renderer: rst
+
+   .. rubric:: Initialization
+
+   .. autodoc2-docstring:: autodoc2.extension.DocstringRenderer.__init__
+      :renderer: rst
+
+   .. py:attribute:: has_content
+      :canonical: autodoc2.extension.DocstringRenderer.has_content
+      :value: False
+
+      .. autodoc2-docstring:: autodoc2.extension.DocstringRenderer.has_content
+         :renderer: rst
+
+   .. py:attribute:: required_arguments
+      :canonical: autodoc2.extension.DocstringRenderer.required_arguments
+      :value: 1
+
+      .. autodoc2-docstring:: autodoc2.extension.DocstringRenderer.required_arguments
+         :renderer: rst
+
+   .. py:attribute:: optional_arguments
+      :canonical: autodoc2.extension.DocstringRenderer.optional_arguments
+      :value: 0
+
+      .. autodoc2-docstring:: autodoc2.extension.DocstringRenderer.optional_arguments
+         :renderer: rst
+
+   .. py:attribute:: final_argument_whitespace
+      :canonical: autodoc2.extension.DocstringRenderer.final_argument_whitespace
+      :value: True
+
+      .. autodoc2-docstring:: autodoc2.extension.DocstringRenderer.final_argument_whitespace
+         :renderer: rst
+
+   .. py:attribute:: option_spec
+      :canonical: autodoc2.extension.DocstringRenderer.option_spec
+      :value: None
+
+      .. autodoc2-docstring:: autodoc2.extension.DocstringRenderer.option_spec
+         :renderer: rst
+
+   .. py:method:: run() -> list[docutils.nodes.Node]
+      :canonical: autodoc2.extension.DocstringRenderer.run
+
+      .. autodoc2-docstring:: autodoc2.extension.DocstringRenderer.run
+         :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.render.base.rst
+++ b/docs/apidocs/autodoc2/autodoc2.render.base.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Convert the database items into documentation.
+.. autodoc2-docstring:: autodoc2.render.base
+   :renderer: rst
+   :allowtitles:
 
 Module Contents
 ---------------
@@ -20,7 +22,9 @@ Classes
    :align: left
 
    * - :py:obj:`RendererBase <autodoc2.render.base.RendererBase>`
-     - The base renderer.
+     - .. autodoc2-docstring:: autodoc2.render.base.RendererBase
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -30,111 +34,128 @@ API
 
    Bases: :py:obj:`abc.ABC`
 
-   The base renderer.
+   .. autodoc2-docstring:: autodoc2.render.base.RendererBase
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialise the renderer.
+   .. autodoc2-docstring:: autodoc2.render.base.RendererBase.__init__
+      :renderer: rst
+
+   .. py:attribute:: NAME
+      :canonical: autodoc2.render.base.RendererBase.NAME
+      :type: typing.ClassVar[str]
+      :value: 'base'
+
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.NAME
+         :renderer: rst
 
    .. py:attribute:: EXTENSION
       :canonical: autodoc2.render.base.RendererBase.EXTENSION
       :type: typing.ClassVar[str]
       :value: '.txt'
 
-      The extension for the output files.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.EXTENSION
+         :renderer: rst
 
    .. py:attribute:: _resolve_all_warned
       :canonical: autodoc2.render.base.RendererBase._resolve_all_warned
       :type: set[str]
       :value: None
 
-      The full_names of modules that have already been warned about, regarding __all__ resolution
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase._resolve_all_warned
+         :renderer: rst
 
    .. py:attribute:: _is_hidden_cache
       :canonical: autodoc2.render.base.RendererBase._is_hidden_cache
       :type: collections.OrderedDict[str, bool]
       :value: None
 
-      Cache for the is_hidden function: full_name -> bool.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase._is_hidden_cache
+         :renderer: rst
 
    .. py:property:: config
       :canonical: autodoc2.render.base.RendererBase.config
       :type: autodoc2.config.RenderConfig
 
-      The configuration.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.config
+         :renderer: rst
 
    .. py:method:: warn(msg: str, type_: autodoc2.utils.WarningSubtypes = WarningSubtypes.RENDER_ERROR) -> None
       :canonical: autodoc2.render.base.RendererBase.warn
 
-      Warn the user.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.warn
+         :renderer: rst
 
    .. py:method:: get_item(full_name: str) -> typing.Optional[autodoc2.utils.ItemData]
       :canonical: autodoc2.render.base.RendererBase.get_item
 
-      Get an item from the database, by full_name.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.get_item
+         :renderer: rst
 
    .. py:method:: get_children(item: autodoc2.utils.ItemData, types: None | set[str] = None, *, omit_hidden: bool = True) -> typing.Iterable[autodoc2.utils.ItemData]
       :canonical: autodoc2.render.base.RendererBase.get_children
 
-      Get the children of this item, sorted according to the config.
-
-      If module and full_name in module_all_regexes,
-      it will use the __all__ list instead of the children.
-
-      :param item: The item to get the children of.
-      :param types: If given, only return items of these types.
-      :param omit_hidden: If True, omit hidden items.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.get_children
+         :renderer: rst
 
    .. py:method:: is_hidden(item: autodoc2.utils.ItemData) -> bool
       :canonical: autodoc2.render.base.RendererBase.is_hidden
 
-      Whether this object should be displayed in documentation.
-
-      Based on configuration regarding:
-
-      - does i match a hidden regex pattern
-      - does it have documentation
-      - is it a dunder, i.e. __name__
-      - is it a private member, i.e. starts with _, but not a dunder
-      - is it an inherited member of a class
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.is_hidden
+         :renderer: rst
 
    .. py:method:: is_module_deprecated(item: autodoc2.utils.ItemData) -> bool
       :canonical: autodoc2.render.base.RendererBase.is_module_deprecated
 
-      Whether this module is deprecated.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.is_module_deprecated
+         :renderer: rst
+
+   .. py:method:: no_index(item: autodoc2.utils.ItemData) -> bool
+      :canonical: autodoc2.render.base.RendererBase.no_index
+
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.no_index
+         :renderer: rst
 
    .. py:method:: show_module_summary(item: autodoc2.utils.ItemData) -> bool
       :canonical: autodoc2.render.base.RendererBase.show_module_summary
 
-      Whether to show a summary for this module/package.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.show_module_summary
+         :renderer: rst
 
    .. py:method:: show_class_inheritance(item: autodoc2.utils.ItemData) -> bool
       :canonical: autodoc2.render.base.RendererBase.show_class_inheritance
 
-      Whether to show the inheritance for this class.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.show_class_inheritance
+         :renderer: rst
 
    .. py:method:: show_annotations(item: autodoc2.utils.ItemData) -> bool
       :canonical: autodoc2.render.base.RendererBase.show_annotations
 
-      Whether to show type annotations.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.show_annotations
+         :renderer: rst
 
    .. py:method:: render_item(full_name: str) -> typing.Iterable[str]
       :canonical: autodoc2.render.base.RendererBase.render_item
       :abstractmethod:
 
-      Yield the content for a single item.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.render_item
+         :renderer: rst
 
    .. py:method:: format_args(args_info: autodoc2.utils.ARGS_TYPE, include_annotations: bool = True, ignore_self: None | str = None) -> str
       :canonical: autodoc2.render.base.RendererBase.format_args
 
-      Format the arguments of a function or method.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.format_args
+         :renderer: rst
 
    .. py:method:: format_annotation(annotation: None | str) -> str
       :canonical: autodoc2.render.base.RendererBase.format_annotation
 
-      Format a single type annotation.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.format_annotation
+         :renderer: rst
 
    .. py:method:: format_base(base: None | str) -> str
       :canonical: autodoc2.render.base.RendererBase.format_base
 
-      Format a single class base type.
+      .. autodoc2-docstring:: autodoc2.render.base.RendererBase.format_base
+         :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.render.myst_.rst
+++ b/docs/apidocs/autodoc2/autodoc2.render.myst_.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Renderer for MyST.
+.. autodoc2-docstring:: autodoc2.render.myst_
+   :renderer: rst
+   :allowtitles:
 
 Module Contents
 ---------------
@@ -20,7 +22,9 @@ Classes
    :align: left
 
    * - :py:obj:`MystRenderer <autodoc2.render.myst_.MystRenderer>`
-     - Render the documentation as MyST.
+     - .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -29,108 +33,123 @@ Data
    :class: autosummary longtable
    :align: left
 
-   * - :py:obj:`_MD_HEAD_RE <autodoc2.render.myst_._MD_HEAD_RE>`
-     - 
    * - :py:obj:`_RE_DELIMS <autodoc2.render.myst_._RE_DELIMS>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.render.myst_._RE_DELIMS
+          :renderer: rst
+          :summary:
 
 API
 ~~~
 
-.. py:data:: _MD_HEAD_RE
-   :canonical: autodoc2.render.myst_._MD_HEAD_RE
-   :value: None
-
 .. py:data:: _RE_DELIMS
    :canonical: autodoc2.render.myst_._RE_DELIMS
    :value: None
+
+   .. autodoc2-docstring:: autodoc2.render.myst_._RE_DELIMS
+      :renderer: rst
 
 .. py:class:: MystRenderer(db: autodoc2.db.Database, config: autodoc2.config.RenderConfig, warn: typing.Callable[[str, autodoc2.utils.WarningSubtypes], None] | None = None, resolved_all: dict[str, autodoc2.utils.ResolvedDict] | None = None)
    :canonical: autodoc2.render.myst_.MystRenderer
 
    Bases: :py:obj:`autodoc2.render.base.RendererBase`
 
-   Render the documentation as MyST.
+   .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialise the renderer.
+   .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.__init__
+      :renderer: rst
+
+   .. py:attribute:: NAME
+      :canonical: autodoc2.render.myst_.MystRenderer.NAME
+      :value: 'myst'
+
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.NAME
+         :renderer: rst
 
    .. py:attribute:: EXTENSION
       :canonical: autodoc2.render.myst_.MystRenderer.EXTENSION
       :value: '.md'
 
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.EXTENSION
+         :renderer: rst
+
    .. py:method:: render_item(full_name: str) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_item
 
-      Yield the content for a single item.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_item
+         :renderer: rst
 
    .. py:method:: generate_summary(items: list[autodoc2.utils.ItemData]) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.generate_summary
 
-      Generate a summary of the items.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.generate_summary
+         :renderer: rst
 
    .. py:method:: enclosing_backticks(text: str) -> str
       :canonical: autodoc2.render.myst_.MystRenderer.enclosing_backticks
       :staticmethod:
 
-      Ensure the enclosing backticks are more than any inner ones.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.enclosing_backticks
+         :renderer: rst
 
    .. py:method:: render_package(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_package
 
-      Create the content for a package.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_package
+         :renderer: rst
 
    .. py:method:: render_module(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_module
 
-      Create the content for a module.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_module
+         :renderer: rst
 
    .. py:method:: render_function(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_function
 
-      Create the content for a function.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_function
+         :renderer: rst
 
    .. py:method:: render_exception(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_exception
 
-      Create the content for an exception.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_exception
+         :renderer: rst
 
    .. py:method:: render_class(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_class
 
-      Create the content for a class.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_class
+         :renderer: rst
 
    .. py:method:: render_property(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_property
 
-      Create the content for a property.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_property
+         :renderer: rst
 
    .. py:method:: render_method(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_method
 
-      Create the content for a method.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_method
+         :renderer: rst
 
    .. py:method:: render_attribute(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_attribute
 
-      Create the content for an attribute.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_attribute
+         :renderer: rst
 
    .. py:method:: render_data(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.myst_.MystRenderer.render_data
 
-      Create the content for a data item.
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer.render_data
+         :renderer: rst
 
    .. py:method:: _reformat_cls_base_myst(value: str) -> str
       :canonical: autodoc2.render.myst_.MystRenderer._reformat_cls_base_myst
 
-      Reformat the base of a class for RST.
-
-      Base annotations can come in the form::
-
-          A[B, C, D]
-
-      which we want to reformat as::
-
-          {py:obj}`A`\[{py:obj}`B`, {py:obj}`C`, {py:obj}`D`\]
-
+      .. autodoc2-docstring:: autodoc2.render.myst_.MystRenderer._reformat_cls_base_myst
+         :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.render.rst
+++ b/docs/apidocs/autodoc2/autodoc2.render.rst
@@ -4,6 +4,13 @@
 .. py:module:: autodoc2.render
 
 
+Description
+-----------
+
+.. autodoc2-docstring:: autodoc2.render
+   :renderer: rst
+   :allowtitles:
+
 Submodules
 ----------
 

--- a/docs/apidocs/autodoc2/autodoc2.render.rst_.rst
+++ b/docs/apidocs/autodoc2/autodoc2.render.rst_.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Renderer for reStructuredText.
+.. autodoc2-docstring:: autodoc2.render.rst_
+   :renderer: rst
+   :allowtitles:
 
 Module Contents
 ---------------
@@ -20,7 +22,9 @@ Classes
    :align: left
 
    * - :py:obj:`RstRenderer <autodoc2.render.rst_.RstRenderer>`
-     - Render the documentation as reStructuredText.
+     - .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -30,7 +34,9 @@ Data
    :align: left
 
    * - :py:obj:`_RE_DELIMS <autodoc2.render.rst_._RE_DELIMS>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.render.rst_._RE_DELIMS
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -39,88 +45,104 @@ API
    :canonical: autodoc2.render.rst_._RE_DELIMS
    :value: None
 
+   .. autodoc2-docstring:: autodoc2.render.rst_._RE_DELIMS
+      :renderer: rst
+
 .. py:class:: RstRenderer(db: autodoc2.db.Database, config: autodoc2.config.RenderConfig, warn: typing.Callable[[str, autodoc2.utils.WarningSubtypes], None] | None = None, resolved_all: dict[str, autodoc2.utils.ResolvedDict] | None = None)
    :canonical: autodoc2.render.rst_.RstRenderer
 
    Bases: :py:obj:`autodoc2.render.base.RendererBase`
 
-   Render the documentation as reStructuredText.
+   .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialise the renderer.
+   .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.__init__
+      :renderer: rst
+
+   .. py:attribute:: NAME
+      :canonical: autodoc2.render.rst_.RstRenderer.NAME
+      :value: 'rst'
+
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.NAME
+         :renderer: rst
 
    .. py:attribute:: EXTENSION
       :canonical: autodoc2.render.rst_.RstRenderer.EXTENSION
       :value: '.rst'
 
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.EXTENSION
+         :renderer: rst
+
    .. py:method:: render_item(full_name: str) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_item
 
-      Yield the content for a single item.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_item
+         :renderer: rst
 
    .. py:method:: generate_summary(items: list[autodoc2.utils.ItemData]) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.generate_summary
 
-      Generate a summary of the items.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.generate_summary
+         :renderer: rst
 
    .. py:method:: render_package(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_package
 
-      Create the content for a package.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_package
+         :renderer: rst
 
    .. py:method:: render_module(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_module
 
-      Create the content for a module.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_module
+         :renderer: rst
 
    .. py:method:: render_function(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_function
 
-      Create the content for a function.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_function
+         :renderer: rst
 
    .. py:method:: render_exception(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_exception
 
-      Create the content for an exception.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_exception
+         :renderer: rst
 
    .. py:method:: render_class(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_class
 
-      Create the content for a class.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_class
+         :renderer: rst
 
    .. py:method:: render_property(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_property
 
-      Create the content for a property.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_property
+         :renderer: rst
 
    .. py:method:: render_method(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_method
 
-      Create the content for a method.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_method
+         :renderer: rst
 
    .. py:method:: render_attribute(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_attribute
 
-      Create the content for an attribute.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_attribute
+         :renderer: rst
 
    .. py:method:: render_data(item: autodoc2.utils.ItemData) -> typing.Iterable[str]
       :canonical: autodoc2.render.rst_.RstRenderer.render_data
 
-      Create the content for a data item.
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer.render_data
+         :renderer: rst
 
    .. py:method:: _reformat_cls_base_rst(value: str) -> str
       :canonical: autodoc2.render.rst_.RstRenderer._reformat_cls_base_rst
 
-      Reformat the base of a class for RST.
-
-      Base annotations can come in the form::
-
-          A[B, C, D]
-
-      which we want to reformat as::
-
-          :py:obj:`A`\ [\ :py:obj:`B`\ , :py:obj:`C`\ , :py:obj:`D`\ ]
-
-      The backslash escapes are needed because of:
-      https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#character-level-inline-markup-1
+      .. autodoc2-docstring:: autodoc2.render.rst_.RstRenderer._reformat_cls_base_rst
+         :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.rst
+++ b/docs/apidocs/autodoc2/autodoc2.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Analyse a python project and create documentation for it.
+.. autodoc2-docstring:: autodoc2
+   :renderer: rst
+   :allowtitles:
 
 Subpackages
 -----------
@@ -44,7 +46,9 @@ Functions
    :align: left
 
    * - :py:obj:`setup <autodoc2.setup>`
-     - Entrypoint for sphinx.
+     - .. autodoc2-docstring:: autodoc2.setup
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -54,7 +58,9 @@ Data
    :align: left
 
    * - :py:obj:`__version__ <autodoc2.__version__>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.__version__
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -63,7 +69,11 @@ API
    :canonical: autodoc2.__version__
    :value: '0.3.0'
 
+   .. autodoc2-docstring:: autodoc2.__version__
+      :renderer: rst
+
 .. py:function:: setup(app)
    :canonical: autodoc2.setup
 
-   Entrypoint for sphinx.
+   .. autodoc2-docstring:: autodoc2.setup
+      :renderer: rst

--- a/docs/apidocs/autodoc2/autodoc2.utils.rst
+++ b/docs/apidocs/autodoc2/autodoc2.utils.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-Utility functions and types.
+.. autodoc2-docstring:: autodoc2.utils
+   :renderer: rst
+   :allowtitles:
 
 Module Contents
 ---------------
@@ -20,11 +22,17 @@ Classes
    :align: left
 
    * - :py:obj:`ItemData <autodoc2.utils.ItemData>`
-     - A data item, for the results of the analysis.
+     - .. autodoc2-docstring:: autodoc2.utils.ItemData
+          :renderer: rst
+          :summary:
    * - :py:obj:`WarningSubtypes <autodoc2.utils.WarningSubtypes>`
-     - The subtypes of warnings for the extension.
+     - .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes
+          :renderer: rst
+          :summary:
    * - :py:obj:`ResolvedDict <autodoc2.utils.ResolvedDict>`
-     - The outcome of resolving a packages's __all__ attributes.
+     - .. autodoc2-docstring:: autodoc2.utils.ResolvedDict
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -34,9 +42,13 @@ Functions
    :align: left
 
    * - :py:obj:`yield_modules <autodoc2.utils.yield_modules>`
-     - Walk the given folder and yield all required modules.
+     - .. autodoc2-docstring:: autodoc2.utils.yield_modules
+          :renderer: rst
+          :summary:
    * - :py:obj:`resolve_all <autodoc2.utils.resolve_all>`
-     - Give a module name, yield all names that would be imported by star.
+     - .. autodoc2-docstring:: autodoc2.utils.resolve_all
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -46,9 +58,13 @@ Data
    :align: left
 
    * - :py:obj:`PROPERTY_TYPE <autodoc2.utils.PROPERTY_TYPE>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.utils.PROPERTY_TYPE
+          :renderer: rst
+          :summary:
    * - :py:obj:`ARGS_TYPE <autodoc2.utils.ARGS_TYPE>`
-     - 
+     - .. autodoc2-docstring:: autodoc2.utils.ARGS_TYPE
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -57,209 +73,274 @@ API
    :canonical: autodoc2.utils.PROPERTY_TYPE
    :value: None
 
+   .. autodoc2-docstring:: autodoc2.utils.PROPERTY_TYPE
+      :renderer: rst
+
 .. py:data:: ARGS_TYPE
    :canonical: autodoc2.utils.ARGS_TYPE
    :value: None
+
+   .. autodoc2-docstring:: autodoc2.utils.ARGS_TYPE
+      :renderer: rst
 
 .. py:class:: ItemData()
    :canonical: autodoc2.utils.ItemData
 
    Bases: :py:obj:`typing.TypedDict`
 
-   A data item, for the results of the analysis.
+   .. autodoc2-docstring:: autodoc2.utils.ItemData
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: autodoc2.utils.ItemData.__init__
+      :renderer: rst
 
    .. py:attribute:: type
       :canonical: autodoc2.utils.ItemData.type
       :type: typing_extensions.Required[str]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.type
+         :renderer: rst
+
    .. py:attribute:: full_name
       :canonical: autodoc2.utils.ItemData.full_name
       :type: typing_extensions.Required[str]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.full_name
+         :renderer: rst
 
    .. py:attribute:: doc
       :canonical: autodoc2.utils.ItemData.doc
       :type: typing_extensions.Required[str]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.doc
+         :renderer: rst
+
    .. py:attribute:: range
       :canonical: autodoc2.utils.ItemData.range
       :type: tuple[int, int]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.range
+         :renderer: rst
 
    .. py:attribute:: file_path
       :canonical: autodoc2.utils.ItemData.file_path
       :type: None | str
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.file_path
+         :renderer: rst
+
    .. py:attribute:: encoding
       :canonical: autodoc2.utils.ItemData.encoding
       :type: str
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.encoding
+         :renderer: rst
 
    .. py:attribute:: all
       :canonical: autodoc2.utils.ItemData.all
       :type: None | list[str]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.all
+         :renderer: rst
+
    .. py:attribute:: imports
       :canonical: autodoc2.utils.ItemData.imports
       :type: list[tuple[str, str | None]]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.imports
+         :renderer: rst
 
    .. py:attribute:: value
       :canonical: autodoc2.utils.ItemData.value
       :type: None | str | typing.Any
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.value
+         :renderer: rst
+
    .. py:attribute:: annotation
       :canonical: autodoc2.utils.ItemData.annotation
       :type: None | str
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.annotation
+         :renderer: rst
 
    .. py:attribute:: properties
       :canonical: autodoc2.utils.ItemData.properties
       :type: list[autodoc2.utils.PROPERTY_TYPE]
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.properties
+         :renderer: rst
+
    .. py:attribute:: args
       :canonical: autodoc2.utils.ItemData.args
       :type: autodoc2.utils.ARGS_TYPE
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.args
+         :renderer: rst
 
    .. py:attribute:: return_annotation
       :canonical: autodoc2.utils.ItemData.return_annotation
       :type: None | str
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.return_annotation
+         :renderer: rst
+
    .. py:attribute:: bases
       :canonical: autodoc2.utils.ItemData.bases
       :type: list[str]
       :value: None
+
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.bases
+         :renderer: rst
 
    .. py:attribute:: inherited
       :canonical: autodoc2.utils.ItemData.inherited
       :type: bool
       :value: None
 
+      .. autodoc2-docstring:: autodoc2.utils.ItemData.inherited
+         :renderer: rst
+
 .. py:class:: WarningSubtypes
    :canonical: autodoc2.utils.WarningSubtypes
 
    Bases: :py:obj:`enum.Enum`
 
-   The subtypes of warnings for the extension.
+   .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes
+      :renderer: rst
 
    .. py:attribute:: CONFIG_ERROR
       :canonical: autodoc2.utils.WarningSubtypes.CONFIG_ERROR
       :value: 'config_error'
 
-      Issue with configuration validation.
+      .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes.CONFIG_ERROR
+         :renderer: rst
 
    .. py:attribute:: GIT_CLONE_FAILED
       :canonical: autodoc2.utils.WarningSubtypes.GIT_CLONE_FAILED
       :value: 'git_clone'
 
-      Failed to clone a git repository.
+      .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes.GIT_CLONE_FAILED
+         :renderer: rst
 
    .. py:attribute:: MISSING_MODULE
       :canonical: autodoc2.utils.WarningSubtypes.MISSING_MODULE
       :value: 'missing_module'
 
-      If the package file/folder does not exist.
+      .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes.MISSING_MODULE
+         :renderer: rst
 
    .. py:attribute:: DUPLICATE_ITEM
       :canonical: autodoc2.utils.WarningSubtypes.DUPLICATE_ITEM
       :value: 'dup_item'
 
-      Duplicate fully qualified name found during package analysis.
+      .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes.DUPLICATE_ITEM
+         :renderer: rst
 
    .. py:attribute:: RENDER_ERROR
       :canonical: autodoc2.utils.WarningSubtypes.RENDER_ERROR
       :value: 'render'
 
-      Generic rendering error.
+      .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes.RENDER_ERROR
+         :renderer: rst
 
    .. py:attribute:: ALL_MISSING
       :canonical: autodoc2.utils.WarningSubtypes.ALL_MISSING
       :value: 'all_missing'
 
-      __all__ attribute missing or empty in a module.
+      .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes.ALL_MISSING
+         :renderer: rst
 
    .. py:attribute:: ALL_RESOLUTION
       :canonical: autodoc2.utils.WarningSubtypes.ALL_RESOLUTION
       :value: 'all_resolve'
 
-      Issue with resolution of an item in a module's __all__ attribute.
+      .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes.ALL_RESOLUTION
+         :renderer: rst
+
+   .. py:attribute:: DOCSTRING_NOT_FOUND
+      :canonical: autodoc2.utils.WarningSubtypes.DOCSTRING_NOT_FOUND
+      :value: 'docstring'
+
+      .. autodoc2-docstring:: autodoc2.utils.WarningSubtypes.DOCSTRING_NOT_FOUND
+         :renderer: rst
 
 .. py:function:: yield_modules(folder: str | pathlib.Path, *, root_module: str | None = None, extensions: typing.Sequence[str] = ('.py', '.pyi'), exclude_dirs: typing.Sequence[str] = ('__pycache__', ), exclude_files: typing.Sequence[str] = ()) -> typing.Iterable[tuple[pathlib.Path, str]]
    :canonical: autodoc2.utils.yield_modules
 
-   Walk the given folder and yield all required modules.
-
-   :param folder: The path to walk.
-   :param root_module: The name of the root module,
-       otherwise the folder name is used.
-   :param extensions: The extensions to include.
-       If multiple files with the same stem,
-       only the first extension will be used.
-   :param exclude_dirs: Directory names to exclude (matched with fnmatch).
-   :param exclude_files: File names to exclude (matched with fnmatch).
+   .. autodoc2-docstring:: autodoc2.utils.yield_modules
+      :renderer: rst
 
 .. py:class:: ResolvedDict()
    :canonical: autodoc2.utils.ResolvedDict
 
    Bases: :py:obj:`typing.TypedDict`
 
-   The outcome of resolving a packages's __all__ attributes.
+   .. autodoc2-docstring:: autodoc2.utils.ResolvedDict
+      :renderer: rst
 
    .. rubric:: Initialization
 
-   Initialize self.  See help(type(self)) for accurate signature.
+   .. autodoc2-docstring:: autodoc2.utils.ResolvedDict.__init__
+      :renderer: rst
 
    .. py:attribute:: resolved
       :canonical: autodoc2.utils.ResolvedDict.resolved
       :type: dict[str, set[str]]
       :value: None
 
-      These are names in __all__ that we have successfully resolved,
-      to one or more items.
+      .. autodoc2-docstring:: autodoc2.utils.ResolvedDict.resolved
+         :renderer: rst
 
    .. py:attribute:: unresolved
       :canonical: autodoc2.utils.ResolvedDict.unresolved
       :type: set[str]
       :value: None
 
-      These are names in __all__ that we have not been able to resolve.
+      .. autodoc2-docstring:: autodoc2.utils.ResolvedDict.unresolved
+         :renderer: rst
 
    .. py:attribute:: stars_unresolved
       :canonical: autodoc2.utils.ResolvedDict.stars_unresolved
       :type: set[str]
       :value: None
 
-      These are star imports in the module, that we have not yet resolved.
+      .. autodoc2-docstring:: autodoc2.utils.ResolvedDict.stars_unresolved
+         :renderer: rst
 
    .. py:attribute:: stars_no_all
       :canonical: autodoc2.utils.ResolvedDict.stars_no_all
       :type: set[str]
       :value: None
 
-      These are star imports in the module, that have no recognised __all__.
-      At present we do not resolve them.
+      .. autodoc2-docstring:: autodoc2.utils.ResolvedDict.stars_no_all
+         :renderer: rst
 
    .. py:attribute:: stars_unknown
       :canonical: autodoc2.utils.ResolvedDict.stars_unknown
       :type: set[str]
       :value: None
 
-      These are star imports in the module, that we cannot resolve.
-      Because they point to a module that is not in the database.
+      .. autodoc2-docstring:: autodoc2.utils.ResolvedDict.stars_unknown
+         :renderer: rst
 
 .. py:function:: resolve_all(db: autodoc2.db.Database, package_name: str) -> dict[str, autodoc2.utils.ResolvedDict]
    :canonical: autodoc2.utils.resolve_all
 
-   Give a module name, yield all names that would be imported by star.
+   .. autodoc2-docstring:: autodoc2.utils.resolve_all
+      :renderer: rst

--- a/docs/apidocs/index.rst
+++ b/docs/apidocs/index.rst
@@ -9,4 +9,4 @@ This page contains auto-generated API reference documentation [#f1]_.
    autodoc2/autodoc2
    aiida/aiida
 
-.. [#f1] Created with `sphinx-autodoc2`
+.. [#f1] Created with `sphinx-autodoc2 <https://github.com/chrisjsewell/sphinx-autodoc2>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ autodoc2_replace_annotations = [
 nitpick_ignore_regex = [
     (r"py:.*", r"typing_extensions.*"),
     (r"py:.*", r"astroid.*"),
+    (r"py:.*", r"docutils.*"),
     # TODO for some reason in:
     # .. py:function:: format_args(args_info: autodoc2.utils.ARGS_TYPE ...
     # ARGS_TYPE is treated as a class rather than data

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,19 +171,21 @@ class CreateConfigPkgDirective(SphinxDirective):
 def type_to_string(type_: t.Any) -> str:
     """Convert a type to a string."""
     # TODO just keeping it simple for now but can we do this with astroid!?
-    if type_ is str or type_ is (str,):
+    if isinstance(type_, tuple):
+        return " or ".join(type_to_string(t) for t in type_)
+    if type_ is type(None):
+        return "``None``"
+    if type_ is str:
         return "``str``"
-    if type_ is int or type_ is (int,):
+    if type_ is int:
         return "``int``"
-    if type_ is bool or type_ is (bool,):
+    if type_ is bool:
         return "``bool``"
-    if type_ is float or type_ is (float,):
+    if type_ is float:
         return "``float``"
-    if type_ is list or type_ is (list,):
+    if type_ is list:
         return "``list``"
     type_string = str(type_)
-    if type_string == "typing.Optional[str]":
-        return "``str`` or ``None``"
     if "RstRender" in type_string:
         return '``"rst"``'
     return type_string

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 
 Static analysis of Python code
 : There is no need to install your package to generate the documentation, and `sphinx-autodoc2` will correctly handle `if TYPE_CHECKING` blocks and other typing only features.
+: Sphinx parse warnings correctly point to the source code line, and not the generated documentation.
 : You can even document packages from outside the project (via `git clone`)!
 
 Optimized for rebuilds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ testpaths = [
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = cli-py38
+envlist = py38
 
 [testenv]
 usedevelop = true

--- a/src/autodoc2/config.py
+++ b/src/autodoc2/config.py
@@ -272,7 +272,7 @@ class Config:
                 "or it can be a dictionary with more fine-grained control "
                 "(see {ref}`config:package`))."
             ),
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _coerce_packages,
             "category": "required",
         },
@@ -285,7 +285,7 @@ class Config:
                 "The root output directory for the documentation, "
                 "relative to the source directory (in POSIX format)."
             ),
-            "sphinx_type": (str,),
+            "sphinx_type": str,
             "category": "render",
         },
     )
@@ -294,7 +294,7 @@ class Config:
         default_factory=lambda: ["__pycache__"],
         metadata={
             "help": "Directories to exclude from module analysis (matched by fnmatch).",
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _validate_string_list,
             "category": "analysis",
         },
@@ -304,7 +304,7 @@ class Config:
         default_factory=list,
         metadata={
             "help": "Files to exclude from module gathering (matched by fnmatch).",
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _validate_string_list,
             "category": "analysis",
         },
@@ -320,7 +320,7 @@ class Config:
                 "or a string pointing to a class that inherits from `RendererBase`, "
                 "such as `mypackage.mymodule.MyRenderer`."
             ),
-            "sphinx_type": (str,),
+            "sphinx_type": str,
             "sphinx_default": "rst",
             "sphinx_validate": _load_renderer,
             "category": "render",
@@ -331,7 +331,7 @@ class Config:
         default_factory=list,
         metadata={
             "help": "A list of (regex, renderer) to use for specific modules",
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _load_regex_renderers,
             "category": "render",
         },
@@ -342,7 +342,7 @@ class Config:
         metadata={
             "help": "Whether to use the `__all__` in a module, "
             "to determine what children to document",
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _validate_regex_list,
             "category": "render",
         },
@@ -352,7 +352,7 @@ class Config:
         default_factory=list,
         metadata={
             "help": "Regexes which match against module/package names, to skip them",
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _validate_regex_list,
             "category": "render",
         },
@@ -371,7 +371,7 @@ class Config:
                 "- `private`: single-underscore methods, e.g. `_private`\n"
                 "- `inherited`: inherited class methods\n"
             ),
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _validate_hidden_objects,
             "category": "render",
         },
@@ -381,7 +381,7 @@ class Config:
         default_factory=list,
         metadata={
             "help": "Regexes which match against object names, to mark them as hidden",
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _validate_regex_list,
             "category": "render",
         },
@@ -391,7 +391,7 @@ class Config:
         default=False,
         metadata={
             "help": "Do not generate a cross-reference index.",
-            "sphinx_type": (bool,),
+            "sphinx_type": bool,
             "category": "render",
         },
     )
@@ -400,7 +400,7 @@ class Config:
         default_factory=list,
         metadata={
             "help": "Regexes which match against module names, to mark them as deprecated",
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _validate_regex_list,
             "category": "render",
         },
@@ -410,7 +410,7 @@ class Config:
         default=True,
         metadata={
             "help": "Whether to include a per-module summary.",
-            "sphinx_type": (bool,),
+            "sphinx_type": bool,
             "category": "render",
         },
     )
@@ -424,7 +424,7 @@ class Config:
                 "and the `__init__` method is omitted."
                 "If `both`, then the `__init__` method is included separately."
             ),
-            "sphinx_type": (str,),
+            "sphinx_type": str,
             "category": "render",
         },
     )
@@ -433,7 +433,7 @@ class Config:
         default=True,
         metadata={
             "help": "Whether to document class inheritance.",
-            "sphinx_type": (bool,),
+            "sphinx_type": bool,
             "category": "render",
         },
     )
@@ -442,7 +442,7 @@ class Config:
         default=True,
         metadata={
             "help": "Whether to include annotations.",
-            "sphinx_type": (bool,),
+            "sphinx_type": bool,
             "category": "render",
         },
     )
@@ -451,7 +451,7 @@ class Config:
         default=False,
         metadata={
             "help": "Whether to sort by name, when documenting, otherwise order by source",
-            "sphinx_type": (bool,),
+            "sphinx_type": bool,
             "category": "render",
         },
     )
@@ -460,7 +460,7 @@ class Config:
         default_factory=list,
         metadata={
             "help": "List of (from, to) for annotation replacements",
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _validate_replace_list,
             "category": "render",
         },
@@ -470,7 +470,7 @@ class Config:
         default_factory=list,
         metadata={
             "help": "List of (from, to) for class base replacements",
-            "sphinx_type": (list,),
+            "sphinx_type": list,
             "sphinx_validate": _validate_replace_list,
             "category": "render",
         },
@@ -499,7 +499,7 @@ class Config:
                 "The template will be passed a ``top_level`` variable, "
                 "which is a list of top-level package/module names."
             ),
-            "sphinx_type": t.Optional[str],
+            "sphinx_type": (str, type(None)),
             "category": "render",
         },
     )

--- a/src/autodoc2/config.py
+++ b/src/autodoc2/config.py
@@ -489,7 +489,7 @@ class Config:
             "   {{ package }}\n"
             "{%- endfor %}\n"
             "\n"
-            ".. [#f1] Created with `sphinx-autodoc2`\n"
+            ".. [#f1] Created with `sphinx-autodoc2 <https://github.com/chrisjsewell/sphinx-autodoc2>`_\n"
             "\n"
         ),
         metadata={

--- a/src/autodoc2/extension.py
+++ b/src/autodoc2/extension.py
@@ -47,14 +47,18 @@ def warn(msg: str, subtype: WarningSubtypes) -> None:
 
 def setup(app: Sphinx) -> dict[str, str | bool]:
     """Entry point for sphinx."""
-
     # create the configuration options
     for name, default, field in Config().as_triple():
+        sphinx_type = t.Any
+        if "sphinx_type" in field.metadata:
+            sphinx_type = field.metadata["sphinx_type"]
+            if sphinx_type in (str, int, float, bool):
+                sphinx_type = (sphinx_type,)
         app.add_config_value(
             f"{CONFIG_PREFIX}{name}",
             field.metadata.get("sphinx_default", default),
             "env",
-            types=field.metadata.get("sphinx_type", t.Any),
+            types=sphinx_type,
         )
 
     # create the main event

--- a/src/autodoc2/render/base.py
+++ b/src/autodoc2/render/base.py
@@ -18,6 +18,9 @@ if t.TYPE_CHECKING:
 class RendererBase(abc.ABC):
     """The base renderer."""
 
+    NAME: t.ClassVar[str] = "base"
+    """The name of the renderer."""
+
     EXTENSION: t.ClassVar[str] = ".txt"
     """The extension for the output files."""
 

--- a/src/autodoc2/utils.py
+++ b/src/autodoc2/utils.py
@@ -70,6 +70,7 @@ class WarningSubtypes(enum.Enum):
     """__all__ attribute missing or empty in a module."""
     ALL_RESOLUTION = "all_resolve"
     """Issue with resolution of an item in a module's __all__ attribute."""
+    DOCSTRING_NOT_FOUND = "docstring"
 
 
 def yield_modules(

--- a/tests/test_render/test_basic_myst_.md
+++ b/tests/test_render/test_basic_myst_.md
@@ -5,7 +5,10 @@
 
 ## Description
 
-This is a test package.
+```{autodoc2-docstring} package
+:renderer: myst
+   :allowtitles:
+```
 
 ## Subpackages
 
@@ -20,96 +23,125 @@ package.a
 
 ### Classes
 
-```{list-table}
+````{list-table}
 :class: autosummary longtable
 :align: left
 
 * - {py:obj}`Class <package.Class>`
-  - This is a class.
-```
+  - ```{autodoc2-docstring} package.Class
+    :renderer: myst
+    :summary:
+    ```
+````
 
 ### Functions
 
-```{list-table}
+````{list-table}
 :class: autosummary longtable
 :align: left
 
 * - {py:obj}`func <package.func>`
-  - This is a function.
-```
+  - ```{autodoc2-docstring} package.func
+    :renderer: myst
+    :summary:
+    ```
+````
 
 ### Data
 
-```{list-table}
+````{list-table}
 :class: autosummary longtable
 :align: left
 
 * - {py:obj}`__all__ <package.__all__>`
-  - 
+  - ```{autodoc2-docstring} package.__all__
+    :renderer: myst
+    :summary:
+    ```
 * - {py:obj}`p <package.p>`
-  - p can be documented here.
-```
+  - ```{autodoc2-docstring} package.p
+    :renderer: myst
+    :summary:
+    ```
+````
 
 ### API
 
-```{py:data} __all__
+````{py:data} __all__
 :canonical: package.__all__
 :value: >
    ['p', 'a1', 'alias']
 
+```{autodoc2-docstring} package.__all__
+:renderer: myst
 ```
 
-```{py:data} p
+````
+
+````{py:data} p
 :canonical: package.p
 :value: >
    1
 
-p can be documented here.
-
+```{autodoc2-docstring} package.p
+:renderer: myst
 ```
 
-```{py:function} func(a: str, b: int) -> package.a.c.ac1
+````
+
+````{py:function} func(a: str, b: int) -> package.a.c.ac1
 :canonical: package.func
 
-This is a function.
-
+```{autodoc2-docstring} package.func
+:renderer: myst
 ```
+````
 
-````{py:class} Class
+`````{py:class} Class
 :canonical: package.Class
 
-This is a class.
+```{autodoc2-docstring} package.Class
+:renderer: myst
+```
 
-```{py:attribute} x
+````{py:attribute} x
 :canonical: package.Class.x
 :type: int
 :value: >
    1
 
-x can be documented here.
-
-```
-
-```{py:method} method(a: str, b: int) -> ...
-:canonical: package.Class.method
-
-This is a method.
-
-```
-
-```{py:property} prop
-:canonical: package.Class.prop
-:type: package.a.c.ac1 | None
-
-This is a property.
-
-```
-
-```{py:class} Nested
-:canonical: package.Class.Nested
-
-This is a nested class.
-
+```{autodoc2-docstring} package.Class.x
+:renderer: myst
 ```
 
 ````
+
+````{py:method} method(a: str, b: int) -> ...
+:canonical: package.Class.method
+
+```{autodoc2-docstring} package.Class.method
+:renderer: myst
+```
+
+````
+
+````{py:property} prop
+:canonical: package.Class.prop
+:type: package.a.c.ac1 | None
+
+```{autodoc2-docstring} package.Class.prop
+:renderer: myst
+```
+
+````
+
+````{py:class} Nested
+:canonical: package.Class.Nested
+
+```{autodoc2-docstring} package.Class.Nested
+:renderer: myst
+```
+
+````
+
+`````

--- a/tests/test_render/test_basic_rst_.rst
+++ b/tests/test_render/test_basic_rst_.rst
@@ -7,7 +7,9 @@
 Description
 -----------
 
-This is a test package.
+.. autodoc2-docstring:: package
+   :renderer: rst
+   :allowtitles:
 
 Subpackages
 -----------
@@ -29,7 +31,9 @@ Classes
    :align: left
 
    * - :py:obj:`Class <package.Class>`
-     - This is a class.
+     - .. autodoc2-docstring:: package.Class
+          :renderer: rst
+          :summary:
 
 Functions
 ~~~~~~~~~
@@ -39,7 +43,9 @@ Functions
    :align: left
 
    * - :py:obj:`func <package.func>`
-     - This is a function.
+     - .. autodoc2-docstring:: package.func
+          :renderer: rst
+          :summary:
 
 Data
 ~~~~
@@ -49,9 +55,13 @@ Data
    :align: left
 
    * - :py:obj:`__all__ <package.__all__>`
-     - 
+     - .. autodoc2-docstring:: package.__all__
+          :renderer: rst
+          :summary:
    * - :py:obj:`p <package.p>`
-     - p can be documented here.
+     - .. autodoc2-docstring:: package.p
+          :renderer: rst
+          :summary:
 
 API
 ~~~
@@ -60,41 +70,51 @@ API
    :canonical: package.__all__
    :value: ['p', 'a1', 'alias']
 
+   .. autodoc2-docstring:: package.__all__
+      :renderer: rst
+
 .. py:data:: p
    :canonical: package.p
    :value: 1
 
-   p can be documented here.
+   .. autodoc2-docstring:: package.p
+      :renderer: rst
 
 .. py:function:: func(a: str, b: int) -> package.a.c.ac1
    :canonical: package.func
 
-   This is a function.
+   .. autodoc2-docstring:: package.func
+      :renderer: rst
 
 .. py:class:: Class
    :canonical: package.Class
 
-   This is a class.
+   .. autodoc2-docstring:: package.Class
+      :renderer: rst
 
    .. py:attribute:: x
       :canonical: package.Class.x
       :type: int
       :value: 1
 
-      x can be documented here.
+      .. autodoc2-docstring:: package.Class.x
+         :renderer: rst
 
    .. py:method:: method(a: str, b: int) -> ...
       :canonical: package.Class.method
 
-      This is a method.
+      .. autodoc2-docstring:: package.Class.method
+         :renderer: rst
 
    .. py:property:: prop
       :canonical: package.Class.prop
       :type: package.a.c.ac1 | None
 
-      This is a property.
+      .. autodoc2-docstring:: package.Class.prop
+         :renderer: rst
 
    .. py:class:: Nested
       :canonical: package.Class.Nested
 
-      This is a nested class.
+      .. autodoc2-docstring:: package.Class.Nested
+         :renderer: rst

--- a/tests/test_render/test_config_options_myst_.md
+++ b/tests/test_render/test_config_options_myst_.md
@@ -1,7 +1,8 @@
-```{py:function} func(a: str, b: int) -> package.a.c.ac1
+````{py:function} func(a: str, b: int) -> package.a.c.ac1
 :canonical: package.func
 :noindex:
 
-This is a function.
-
+```{autodoc2-docstring} package.func
+:renderer: myst
 ```
+````

--- a/tests/test_render/test_config_options_rst_.rst
+++ b/tests/test_render/test_config_options_rst_.rst
@@ -2,4 +2,5 @@
    :canonical: package.func
    :noindex:
 
-   This is a function.
+   .. autodoc2-docstring:: package.func
+      :renderer: rst


### PR DESCRIPTION
docstrings (and summaries) are now parsed with the correct source/line, i.e. warnings point to the correct location in the source file